### PR TITLE
Multiple printer and error handling support

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,11 +1,11 @@
 import 'dart:async';
 
+import 'package:collection/collection.dart';
 import 'package:fluent_ui/fluent_ui.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_loggy/flutter_loggy.dart';
 import 'package:loggy/loggy.dart';
 import 'package:momento_booth/extensions/build_context_extension.dart';
-import 'package:momento_booth/managers/live_view_manager.dart';
 import 'package:momento_booth/managers/notifications_manager.dart';
 import 'package:momento_booth/managers/settings_manager.dart';
 import 'package:momento_booth/managers/stats_manager.dart';
@@ -91,16 +91,18 @@ class _AppState extends State<App> with UiLoggy {
   void _statusCheck() async {
     bool hasError, paperOut;
     final printerNames = SettingsManagerBase.instance.settings.hardware.printerNames;
-    (hasError, paperOut) = await compute(checkPrinterStatus, printerNames);
-    const hasErrorNotification = InfoBar(title: Text("Printer error"), content: Text("One of the printers has an error."), severity: InfoBarSeverity.warning,);
-    const paperOutNotification = InfoBar(title: Text("Printer out of paper"), content: Text("One of the printers is out of paper."), severity: InfoBarSeverity.warning,);
+    final printersStatus = await compute(checkPrintersStatus, printerNames);
     NotificationsManagerBase.instance.notifications.clear();
-    if (hasError) {
-      NotificationsManagerBase.instance.notifications.add(hasErrorNotification);
-    }
-    if (paperOut) {
-      NotificationsManagerBase.instance.notifications.add(paperOutNotification);
-    }
+    printersStatus.forEachIndexed((index, element) {
+      final hasErrorNotification = InfoBar(title: Text("Printer error"), content: Text("Printer ${index+1} has an error."), severity: InfoBarSeverity.warning,);
+      final paperOutNotification = InfoBar(title: Text("Printer out of paper"), content: Text("Printer  ${index+1} is out of paper."), severity: InfoBarSeverity.warning,);
+      if (element.hasError) {
+        NotificationsManagerBase.instance.notifications.add(hasErrorNotification);
+      }
+      if (element.paperOut) {
+        NotificationsManagerBase.instance.notifications.add(paperOutNotification);
+      }
+    });
     // loggy.debug("Status check $hasError, $paperOut");
   }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,6 +5,8 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter_loggy/flutter_loggy.dart';
 import 'package:loggy/loggy.dart';
 import 'package:momento_booth/extensions/build_context_extension.dart';
+import 'package:momento_booth/managers/live_view_manager.dart';
+import 'package:momento_booth/managers/notifications_manager.dart';
 import 'package:momento_booth/managers/settings_manager.dart';
 import 'package:momento_booth/managers/stats_manager.dart';
 import 'package:momento_booth/rust_bridge/library_bridge.dart';
@@ -90,7 +92,16 @@ class _AppState extends State<App> with UiLoggy {
     bool hasError, paperOut;
     final printerNames = SettingsManagerBase.instance.settings.hardware.printerNames;
     (hasError, paperOut) = await compute(checkPrinterStatus, printerNames);
-    loggy.debug("Status check $hasError, $paperOut");
+    const hasErrorNotification = InfoBar(title: Text("Printer error"), content: Text("One of the printers has an error."), severity: InfoBarSeverity.warning,);
+    const paperOutNotification = InfoBar(title: Text("Printer out of paper"), content: Text("One of the printers is out of paper."), severity: InfoBarSeverity.warning,);
+    NotificationsManagerBase.instance.notifications.clear();
+    if (hasError) {
+      NotificationsManagerBase.instance.notifications.add(hasErrorNotification);
+    }
+    if (paperOut) {
+      NotificationsManagerBase.instance.notifications.add(paperOutNotification);
+    }
+    // loggy.debug("Status check $hasError, $paperOut");
   }
 
   void _toggleFullscreen() {

--- a/lib/managers/notifications_manager.dart
+++ b/lib/managers/notifications_manager.dart
@@ -1,0 +1,32 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:fluent_ui/fluent_ui.dart';
+import 'package:momento_booth/managers/settings_manager.dart';
+import 'package:mobx/mobx.dart';
+import 'package:momento_booth/utils/hardware.dart';
+import 'package:path/path.dart' show basename, join; // Without show mobx complains
+import 'package:path_provider/path_provider.dart';
+
+part 'notifications_manager.g.dart';
+
+class NotificationsManager = NotificationsManagerBase with _$NotificationsManager;
+
+class Notification {
+  String title;
+  String content;
+  InfoBarSeverity severity;
+  Notification(this.title, this.content, this.severity);
+}
+
+/// Class containing global state for photos in the app
+abstract class NotificationsManagerBase with Store {
+
+  static final NotificationsManagerBase instance = NotificationsManager._internal();
+
+  @observable
+  ObservableList<InfoBar> notifications = ObservableList<InfoBar>();
+
+  NotificationsManagerBase._internal();
+
+}

--- a/lib/managers/notifications_manager.dart
+++ b/lib/managers/notifications_manager.dart
@@ -1,12 +1,5 @@
-import 'dart:io';
-import 'dart:typed_data';
-
 import 'package:fluent_ui/fluent_ui.dart';
-import 'package:momento_booth/managers/settings_manager.dart';
 import 'package:mobx/mobx.dart';
-import 'package:momento_booth/utils/hardware.dart';
-import 'package:path/path.dart' show basename, join; // Without show mobx complains
-import 'package:path_provider/path_provider.dart';
 
 part 'notifications_manager.g.dart';
 

--- a/lib/models/settings.dart
+++ b/lib/models/settings.dart
@@ -67,7 +67,7 @@ class HardwareSettings with _$HardwareSettings implements TomlEncodableValue {
     @Default(CaptureMethod.liveViewSource) CaptureMethod captureMethod,
     @Default(200) int captureDelaySony,
     @Default("") String captureLocation,
-    @Default("") String printerName,
+    @Default([]) List<String> printerNames,
     @Default(148) double pageHeight,
     @Default(100) double pageWidth,
     @Default(true) bool usePrinterSettings,

--- a/lib/utils/hardware.dart
+++ b/lib/utils/hardware.dart
@@ -109,8 +109,7 @@ List<JobInfo> getJobList(Printer printer) {
   Pointer<Uint32> numJobs;
 
   // Allocate space for printer name and set the string.
-  printerNameHandle = calloc<Uint16>(printer.name.length) as Pointer<Utf16>;
-  printerNameHandle.setString(printer.name);
+  printerNameHandle = printer.name.toNativeUtf16();
   // Allocate other pointers
   handle = calloc<IntPtr>();
   const numBytes = 100000;
@@ -122,7 +121,7 @@ List<JobInfo> getJobList(Printer printer) {
   final bool openSuccess = OpenPrinter(printerNameHandle, handle, Pointer.fromAddress(0)) != 0 ? true : false;
   free(printerNameHandle);
   if (!openSuccess) throw "Error opening printer ${printer.name} to acquire print jobs";
-  
+
   final int printerHandleValue = handle.value;
   // Enumerate jobs for printer.
   const int returnType = 1; // JOB_INFO_1
@@ -151,7 +150,6 @@ List<JobInfo> getJobList(Printer printer) {
     // Save jobinfo to list
     jobList.add(JobInfo(status, time, statusVal));
   }
-  loggy.debug("Job list for printer ${printer.name} = $jobList");
 
   // Close printer again so we can actually print...
   final bool closeSuccess = ClosePrinter(printerHandleValue) != 0 ? true : false;
@@ -175,7 +173,8 @@ Future<bool> printPDF(Uint8List pdfData) async {
   loggy.debug("Printing with printer #${lastUsedPrinterIndex+1} (${printer.name})");
 
   try {
-    getJobList(printer);
+    final jobList = getJobList(printer);
+    loggy.debug("Job list for printer ${printer.name} = $jobList");
   } catch (e) {
     loggy.error(e);
   }

--- a/lib/utils/hardware.dart
+++ b/lib/utils/hardware.dart
@@ -100,10 +100,21 @@ class JobInfo {
   }
 }
 
-(bool, bool) checkPrinterStatus(List<String> printerNames) {
-  bool hasError = false;
-  bool paperOut = false;
+class PrinterStatus {
+  int jobs;
+  bool hasError;
+  bool paperOut;
+
+  PrinterStatus(this.jobs, this.hasError, this.paperOut);
+}
+
+/// Get the status of all printers.
+/// Returns list of statusses.
+List<PrinterStatus> checkPrintersStatus(List<String> printerNames) {
+  List<PrinterStatus> output = [];
   for (String printerName in printerNames) {
+    bool hasError = false;
+    bool paperOut = false;
     late final List<JobInfo> jobList;
     try {
       jobList = getJobList(printerName);
@@ -116,8 +127,9 @@ class JobInfo {
     // Check if there are prints that have errored
     hasError = hasError || jobList.fold(false, (previousValue, element) => previousValue || element.status.contains(JobStatus.error));
     paperOut = paperOut || jobList.fold(false, (previousValue, element) => previousValue || element.status.contains(JobStatus.paperout));
+    output.add(PrinterStatus(jobList.length, hasError, paperOut));
   }
-  return (hasError, paperOut);
+  return output;
 }
 
 List<JobInfo> getJobList(String printerName) {

--- a/lib/views/custom_widgets/wrappers/live_view_background.dart
+++ b/lib/views/custom_widgets/wrappers/live_view_background.dart
@@ -4,6 +4,7 @@ import 'package:auto_size_text/auto_size_text.dart';
 import 'package:fluent_ui/fluent_ui.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
 import 'package:momento_booth/managers/live_view_manager.dart';
+import 'package:momento_booth/managers/notifications_manager.dart';
 import 'package:momento_booth/managers/photos_manager.dart';
 import 'package:momento_booth/managers/settings_manager.dart';
 import 'package:momento_booth/models/settings.dart';
@@ -28,7 +29,24 @@ class LiveViewBackground extends StatelessWidgetBase {
       children: [
         _viewState,
         child,
+        _statusOverlay,
       ]
+    );
+  }
+  
+  Widget get _statusOverlay {
+    return Padding(
+      padding: const EdgeInsets.all(30),
+      child: Observer(
+        builder: (context) => Column(
+          mainAxisAlignment: MainAxisAlignment.start,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            for (InfoBar notification in NotificationsManagerBase.instance.notifications)
+              notification
+          ],
+        ),
+      ),
     );
   }
 

--- a/lib/views/custom_widgets/wrappers/live_view_background.dart
+++ b/lib/views/custom_widgets/wrappers/live_view_background.dart
@@ -42,8 +42,10 @@ class LiveViewBackground extends StatelessWidgetBase {
           mainAxisAlignment: MainAxisAlignment.start,
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            for (InfoBar notification in NotificationsManagerBase.instance.notifications)
-              notification
+            for (InfoBar notification in NotificationsManagerBase.instance.notifications) ...[
+              notification,
+              const SizedBox(height: 8),
+            ]
           ],
         ),
       ),

--- a/lib/views/settings_screen/settings_screen_controller.dart
+++ b/lib/views/settings_screen/settings_screen_controller.dart
@@ -1,9 +1,10 @@
 import 'package:fluent_ui/fluent_ui.dart';
+import 'package:loggy/loggy.dart';
 import 'package:momento_booth/models/settings.dart';
 import 'package:momento_booth/views/base/screen_controller_base.dart';
 import 'package:momento_booth/views/settings_screen/settings_screen_view_model.dart';
 
-class SettingsScreenController extends ScreenControllerBase<SettingsScreenViewModel> {
+class SettingsScreenController extends ScreenControllerBase<SettingsScreenViewModel> with UiLoggy {
 
   final comboboxKey = GlobalKey<ComboBoxState>(debugLabel: 'Combobox Key');
 
@@ -102,9 +103,21 @@ class SettingsScreenController extends ScreenControllerBase<SettingsScreenViewMo
     }
   }
 
-  void onPrinterChanged(String? printerName) {
-    if (printerName != null) {
-      viewModel.updateSettings((settings) => settings.copyWith.hardware(printerName: printerName));
+  void onPrinterChanged(String? printerName, int? printerIndex) {
+    if (printerName != null && printerIndex != null) {
+      List<String> currentList = List.from(viewModel.printersSetting);
+      
+      if (printerName == viewModel.unsedPrinterValue) {
+        currentList.length = printerIndex;
+      } else {
+        if (printerIndex >= currentList.length) {
+          currentList.add(printerName);
+        } else {
+          currentList[printerIndex] = printerName;
+        }
+      }
+      loggy.debug("Setting printerlist to $currentList");
+      viewModel.updateSettings((settings) => settings.copyWith.hardware(printerNames: currentList));
     }
   }
 

--- a/lib/views/settings_screen/settings_screen_view.hardware.dart
+++ b/lib/views/settings_screen/settings_screen_view.hardware.dart
@@ -61,7 +61,9 @@ Widget _getHardwareSettings(SettingsScreenViewModel viewModel, SettingsScreenCon
       FluentSettingsBlock(
         title: "Printing",
         settings: [
-          _printerCard(viewModel, controller),
+          for (int i = 0; i <= viewModel.printersSetting.length; i++) ...[
+            _printerCard(viewModel, controller, "Printer ${i+1}", i),
+          ],
           _getInput(
             icon: FluentIcons.page,
             title: "Page height",
@@ -176,11 +178,11 @@ FluentSettingCard _webcamCard(SettingsScreenViewModel viewModel, SettingsScreenC
   );
 }
 
-FluentSettingCard _printerCard(SettingsScreenViewModel viewModel, SettingsScreenController controller) {
+FluentSettingCard _printerCard(SettingsScreenViewModel viewModel, SettingsScreenController controller, String title, int index) {
   return FluentSettingCard(
     icon: FluentIcons.print,
-    title: "Printer",
-    subtitle: "Which printer to use for printing photos",
+    title: title,
+    subtitle: "Which printer(s) to use for printing photos",
     child: Row(
       children: [
         Button(
@@ -193,8 +195,8 @@ FluentSettingCard _printerCard(SettingsScreenViewModel viewModel, SettingsScreen
           child: Observer(builder: (_) {
             return ComboBox<String>(
               items: viewModel.printerOptions,
-              value: viewModel.printerSetting,
-              onChanged: controller.onPrinterChanged,
+              value: index < viewModel.printersSetting.length ? viewModel.printersSetting[index] : viewModel.unsedPrinterValue,
+              onChanged: (name) => controller.onPrinterChanged(name, index),
             );
           }),
         ),

--- a/lib/views/settings_screen/settings_screen_view.hardware.dart
+++ b/lib/views/settings_screen/settings_screen_view.hardware.dart
@@ -61,9 +61,15 @@ Widget _getHardwareSettings(SettingsScreenViewModel viewModel, SettingsScreenCon
       FluentSettingsBlock(
         title: "Printing",
         settings: [
-          for (int i = 0; i <= viewModel.printersSetting.length; i++) ...[
-            _printerCard(viewModel, controller, "Printer ${i+1}", i),
-          ],
+          Observer(builder: (context) =>
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                for (int i = 0; i <= viewModel.printersSetting.length; i++)
+                  _printerCard(viewModel, controller, "Printer ${i+1}", i),
+              ],
+            ),
+          ),
           _getInput(
             icon: FluentIcons.page,
             title: "Page height",

--- a/lib/views/settings_screen/settings_screen_view_model.dart
+++ b/lib/views/settings_screen/settings_screen_view_model.dart
@@ -30,9 +30,29 @@ abstract class SettingsScreenViewModelBase extends ScreenViewModelBase with Stor
   @observable
   List<ComboBoxItem<String>> webcams = ObservableList<ComboBoxItem<String>>();
 
+  RichText _printerCardText(String printerName, bool isAvailable, bool isDefault) {
+    final icon = isAvailable ? FluentIcons.plug_connected : FluentIcons.plug_disconnected;
+    return RichText(
+      text: TextSpan(
+        style: const TextStyle(color: Color(0xFF000000)),
+        children: [
+          TextSpan(text: "$printerName  "),
+          if (isDefault) ...[
+            const WidgetSpan(child: Icon(FluentIcons.default_settings)),
+            const TextSpan(text: "  "),
+          ],
+          WidgetSpan(child: Icon(icon)),
+        ],
+      ),
+    );
+  }
+
+  final String unsedPrinterValue = "UNUSED";
+
   void setPrinterList() async {
     final printers = await Printing.listPrinters();
     printerOptions.clear();
+    printerOptions.add(ComboBoxItem(value: unsedPrinterValue, child: _printerCardText("- Not used -", false, false)));
     for (var printer in printers) {
       final icon = printer.isAvailable ? FluentIcons.plug_connected : FluentIcons.plug_disconnected;
       final text = RichText(
@@ -51,8 +71,8 @@ abstract class SettingsScreenViewModelBase extends ScreenViewModelBase with Stor
       printerOptions.add(ComboBoxItem(value: printer.name, child: text));
       
       // If there is no setting yet, set it to the default printer.
-      if (printer.isDefault && printerSetting == "") {
-        updateSettings((settings) => settings.copyWith.hardware(printerName: printer.name));
+      if (printer.isDefault && printersSetting == [""]) {
+        updateSettings((settings) => settings.copyWith.hardware(printerNames: [printer.name]));
       }
     }
   }
@@ -73,7 +93,7 @@ abstract class SettingsScreenViewModelBase extends ScreenViewModelBase with Stor
   CaptureMethod get captureMethodSetting => SettingsManagerBase.instance.settings.hardware.captureMethod;
   int get captureDelaySonySetting => SettingsManagerBase.instance.settings.hardware.captureDelaySony;
   String get captureLocationSetting => SettingsManagerBase.instance.settings.hardware.captureLocation;
-  String get printerSetting => SettingsManagerBase.instance.settings.hardware.printerName;
+  List<String> get printersSetting => SettingsManagerBase.instance.settings.hardware.printerNames;
   double get pageHeightSetting => SettingsManagerBase.instance.settings.hardware.pageHeight;
   double get pageWidthSetting => SettingsManagerBase.instance.settings.hardware.pageWidth;
   bool get usePrinterSettingsSetting => SettingsManagerBase.instance.settings.hardware.usePrinterSettings;

--- a/lib/views/settings_screen/settings_screen_view_model.dart
+++ b/lib/views/settings_screen/settings_screen_view_model.dart
@@ -54,24 +54,10 @@ abstract class SettingsScreenViewModelBase extends ScreenViewModelBase with Stor
     printerOptions.clear();
     printerOptions.add(ComboBoxItem(value: unsedPrinterValue, child: _printerCardText("- Not used -", false, false)));
     for (var printer in printers) {
-      final icon = printer.isAvailable ? FluentIcons.plug_connected : FluentIcons.plug_disconnected;
-      final text = RichText(
-        text: TextSpan(
-          style: const TextStyle(color: Color(0xFF000000)),
-          children: [
-            TextSpan(text: "${printer.name}  "),
-            if (printer.isDefault) ...[
-              const WidgetSpan(child: Icon(FluentIcons.default_settings)),
-              const TextSpan(text: "  "),
-            ],
-            WidgetSpan(child: Icon(icon)),
-          ],
-        ),
-      );
-      printerOptions.add(ComboBoxItem(value: printer.name, child: text));
+      printerOptions.add(ComboBoxItem(value: printer.name, child: _printerCardText(printer.name, printer.isAvailable, printer.isDefault)));
       
       // If there is no setting yet, set it to the default printer.
-      if (printer.isDefault && printersSetting == [""]) {
+      if (printer.isDefault && printersSetting.isEmpty) {
         updateSettings((settings) => settings.copyWith.hardware(printerNames: [printer.name]));
       }
     }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1115,7 +1115,7 @@ packages:
     source: hosted
     version: "3.0.2"
   win32:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: win32
       sha256: "5a751eddf9db89b3e5f9d50c20ab8612296e4e8db69009788d6c8b060a84191c"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -58,6 +58,7 @@ dependencies:
   flutter_loggy: 2.0.2
   synchronized: 3.1.0
   collection: 1.17.1
+  win32: ^4.1.4
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Adds support for using multiple printers, which are used round-robin. This can speed up printing.
Additionally adds functionality to check the open jobs for a printer (Windows only). This also allows checking if the printer is in an error state.
A notification manager has been added that can display notifications. Notifications are shown per printer if it is in an error state and/or it is out of paper.