### PR TITLE
Basic gPhoto2 support

### DIFF
--- a/.github/workflows/release-win-x64.yml
+++ b/.github/workflows/release-win-x64.yml
@@ -105,6 +105,15 @@ jobs:
     - name: Bundle DLL dependencies of the helper library
       run: curl https://raw.githubusercontent.com/h3x4d3c1m4l/mingw-bundledlls/master/mingw-bundledlls | python - --copy build\windows\runner\Release\momento_booth_native_helpers.dll
 
+    - name: Bundle libgphoto2 additional libs
+      shell: pwsh
+      run: |
+        $Env:MSYS2_ROOT = msys2 -c 'cygpath -m /'
+        mkdir build\windows\runner\Release\libgphoto2_iolibs
+        cp $Env:MSYS2_ROOT\mingw64\lib\libgphoto2_port\*\*.dll build\windows\runner\Release\libgphoto2_iolibs
+        mkdir build\windows\runner\Release\libgphoto2_camlibs
+        cp $Env:MSYS2_ROOT\mingw64\lib\libgphoto2\*\*.dll build\windows\runner\Release\libgphoto2_camlibs
+
     # Pack
     - name: Archive Release
       uses: thedoctor0/zip-release@0.7.1

--- a/lib/hardware_control/gphoto2_camera.dart
+++ b/lib/hardware_control/gphoto2_camera.dart
@@ -64,6 +64,8 @@ class GPhoto2Camera extends LiveViewSource implements PhotoCaptureMethod {
   }
 
   @override
-  Duration get captureDelay => const Duration(milliseconds: 200);
+  Duration get captureDelay => Duration(milliseconds: SettingsManager.instance.settings.hardware.captureDelayGPhoto2);
+
+  Future<void> autoFocus() async => await rustLibraryApi.gphoto2AutoFocus(handleId: handleId);
 
 }

--- a/lib/hardware_control/gphoto2_camera.dart
+++ b/lib/hardware_control/gphoto2_camera.dart
@@ -47,10 +47,10 @@ class GPhoto2Camera extends LiveViewSource implements PhotoCaptureMethod {
   }
 
   @override
-  Future<RawImage?> getLastFrame() => rustLibraryApi.nokhwaGetLastFrame(handleId: handleId);
+  Future<RawImage?> getLastFrame() => rustLibraryApi.gphoto2GetLastFrame(handleId: handleId);
 
   @override
-  Future<CameraState> getCameraState() => Future.value(const CameraState(isStreaming: true, validFrameCount: 0, errorFrameCount: 0, lastFrameWasValid: true));
+  Future<CameraState> getCameraState() => rustLibraryApi.gphoto2GetCameraStatus(handleId: handleId);
 
   @override
   Future<void> dispose() async {

--- a/lib/hardware_control/gphoto2_camera.dart
+++ b/lib/hardware_control/gphoto2_camera.dart
@@ -4,6 +4,7 @@ import 'dart:typed_data';
 import 'package:fluent_ui/fluent_ui.dart' show ComboBoxItem, Text;
 import 'package:momento_booth/hardware_control/live_view_streaming/live_view_source.dart';
 import 'package:momento_booth/hardware_control/photo_capturing/photo_capture_method.dart';
+import 'package:momento_booth/managers/settings_manager.dart';
 import 'package:momento_booth/rust_bridge/library_api.generated.dart';
 import 'package:momento_booth/rust_bridge/library_bridge.dart';
 
@@ -38,7 +39,7 @@ class GPhoto2Camera extends LiveViewSource implements PhotoCaptureMethod {
   @override
   Future<void> openStream({required int texturePtr}) async {
     var split = id.split("/");
-    handleId = await rustLibraryApi.gphoto2OpenCamera(model: split[1], port: split[0], specialHandling: GPhoto2CameraSpecialHandling.NikonDSLR);
+    handleId = await rustLibraryApi.gphoto2OpenCamera(model: split[1], port: split[0], specialHandling: SettingsManager.instance.settings.hardware.gPhoto2SpecialHandling.toHelperLibraryEnumValue());
     isOpened = true;
     await rustLibraryApi.gphoto2StartLiveview(handleId: handleId, operations: [
       const ImageOperation.cropToAspectRatio(3 / 2),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:ui';
 
 import 'package:collection/collection.dart';
 import 'package:fluent_ui/fluent_ui.dart';
@@ -7,6 +8,7 @@ import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_loggy/flutter_loggy.dart';
 import 'package:loggy/loggy.dart';
 import 'package:momento_booth/extensions/build_context_extension.dart';
+import 'package:momento_booth/managers/live_view_manager.dart';
 import 'package:momento_booth/managers/notifications_manager.dart';
 import 'package:momento_booth/managers/hotkey_manager.dart';
 import 'package:momento_booth/managers/settings_manager.dart';
@@ -78,7 +80,7 @@ class App extends StatefulWidget {
 
 }
 
-class _AppState extends State<App> with UiLoggy {
+class _AppState extends State<App> with UiLoggy, WidgetsBindingObserver {
 
   final GoRouter _router = GoRouter(
     routes: rootRoutes,
@@ -105,6 +107,7 @@ class _AppState extends State<App> with UiLoggy {
     _statusCheckTimer = Timer.periodic(statusCheckPeriod, (_) => _statusCheck());
     _router.routerDelegate.addListener(() => _onActivity(isTap: false));
     _hotkeyActionStreamSubscription = _hotkeyActionStream.listen(_runHotkeyAction);
+    WidgetsBinding.instance.addObserver(this);
     super.initState();
   }
 
@@ -217,6 +220,7 @@ class _AppState extends State<App> with UiLoggy {
     _statusCheckTimer.cancel();
     _hotkeyActionStreamSubscription.cancel();
     _router.dispose();
+    WidgetsBinding.instance.removeObserver(this);
     super.dispose();
   }
 
@@ -234,6 +238,12 @@ class _AppState extends State<App> with UiLoggy {
       case HotkeyAction.goToHomeScreen:
         _router.go(StartScreen.defaultRoute);
     }
+  }
+
+  @override
+  Future<AppExitResponse> didRequestAppExit() async {
+    await LiveViewManager.instance.gPhoto2Camera?.dispose();
+    return super.didRequestAppExit();
   }
 
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -103,7 +103,7 @@ class _AppState extends State<App> with UiLoggy {
   void initState() {
     _returnHomeTimer = Timer(returnHomeTimeout, _returnHome);
     _statusCheckTimer = Timer.periodic(statusCheckPeriod, (_) => _statusCheck());
-    _router.addListener(() => _onActivity(isTap: false));
+    _router.routerDelegate.addListener(() => _onActivity(isTap: false));
     _hotkeyActionStreamSubscription = _hotkeyActionStream.listen(_runHotkeyAction);
     super.initState();
   }
@@ -129,7 +129,7 @@ class _AppState extends State<App> with UiLoggy {
   }
 
   void _returnHome() {
-    if (_router.location == StartScreen.defaultRoute) return;
+    if (GoRouterState.of(context).location == StartScreen.defaultRoute) return;
     loggy.debug("No activity in $returnHomeTimeout, returning to homescreen");
     _router.go(StartScreen.defaultRoute);
   }
@@ -226,7 +226,7 @@ class _AppState extends State<App> with UiLoggy {
         setState(() => _settingsOpen = !_settingsOpen);
         loggy.debug("Settings ${_settingsOpen ? "opened" : "closed"}");
       case HotkeyAction.openManualCollageScreen:
-        if (_router.location == ManualCollageScreen.defaultRoute) {
+        if (GoRouterState.of(context).location == ManualCollageScreen.defaultRoute) {
           _router.go(StartScreen.defaultRoute);
         } else {
           _router.go(ManualCollageScreen.defaultRoute);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -56,7 +56,7 @@ void main() async {
   await WindowManager.instance.initialize();
 
   // Native library init
-  init();
+  await init();
 
   await SentryFlutter.init(
     (options) {

--- a/lib/managers/live_view_manager.dart
+++ b/lib/managers/live_view_manager.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:collection/collection.dart';
 import 'package:loggy/loggy.dart';
 import 'package:momento_booth/extensions/camera_state_extension.dart';
+import 'package:momento_booth/hardware_control/live_view_streaming/gphoto2_camera.dart';
 import 'package:momento_booth/hardware_control/live_view_streaming/live_view_source.dart';
 import 'package:momento_booth/hardware_control/live_view_streaming/noise_source.dart';
 import 'package:momento_booth/managers/settings_manager.dart';
@@ -98,6 +99,9 @@ abstract class _LiveViewManagerBase with Store, UiLoggy {
         case LiveViewMethod.webcam:
           List<NokhwaCamera> cameras = await NokhwaCamera.getAllCameras();
           _currentLiveViewSource = cameras.firstWhereOrNull((camera) => camera.friendlyName == webcamIdSetting);
+        case LiveViewMethod.gphoto2:
+          List<Gphoto2Camera> cameras = await Gphoto2Camera.getAllCameras();
+          _currentLiveViewSource = cameras.firstWhereOrNull((camera) => camera.id == webcamIdSetting);
         default:
           throw "Unknown live view method";
       }

--- a/lib/managers/live_view_manager.dart
+++ b/lib/managers/live_view_manager.dart
@@ -3,7 +3,7 @@ import 'dart:async';
 import 'package:collection/collection.dart';
 import 'package:loggy/loggy.dart';
 import 'package:momento_booth/extensions/camera_state_extension.dart';
-import 'package:momento_booth/hardware_control/live_view_streaming/gphoto2_camera.dart';
+import 'package:momento_booth/hardware_control/gphoto2_camera.dart';
 import 'package:momento_booth/hardware_control/live_view_streaming/live_view_source.dart';
 import 'package:momento_booth/hardware_control/live_view_streaming/noise_source.dart';
 import 'package:momento_booth/managers/settings_manager.dart';
@@ -29,6 +29,9 @@ abstract class _LiveViewManagerBase with Store, UiLoggy {
 
   @readonly
   bool _lastFrameWasInvalid = false;
+
+  @readonly
+  GPhoto2Camera? _gPhoto2Camera;
 
   // ////////////// //
   // Initialization //
@@ -70,6 +73,10 @@ abstract class _LiveViewManagerBase with Store, UiLoggy {
   LiveViewMethod? _currentLiveViewMethodSetting;
   String? _currentLiveViewWebcamId;
 
+  CaptureMethod? _currentCaptureMethodSetting;
+
+  String? _currentGPhoto2CameraId;
+
   @readonly
   LiveViewState _liveViewState = LiveViewState.initializing;
 
@@ -83,15 +90,27 @@ abstract class _LiveViewManagerBase with Store, UiLoggy {
 
   Future<void> _updateConfig() async {
     LiveViewMethod liveViewMethodSetting = SettingsManager.instance.settings.hardware.liveViewMethod;
+    CaptureMethod captureMethodSetting = SettingsManager.instance.settings.hardware.captureMethod;
+    String gPhoto2CameraId = SettingsManager.instance.settings.hardware.gPhoto2CameraId;
     String webcamIdSetting = SettingsManager.instance.settings.hardware.liveViewWebcamId;
 
-    if (_currentLiveViewMethodSetting == null || _currentLiveViewMethodSetting != liveViewMethodSetting || _currentLiveViewWebcamId != webcamIdSetting) {
+    if (_currentLiveViewMethodSetting == null || _currentLiveViewMethodSetting != liveViewMethodSetting || _currentLiveViewWebcamId != webcamIdSetting || _currentCaptureMethodSetting != captureMethodSetting || _currentGPhoto2CameraId != gPhoto2CameraId) {
       // Webcam was not initialized yet or webcam ID setting changed
       _liveViewState = LiveViewState.initializing;
       await _currentLiveViewSource?.dispose();
 
       _currentLiveViewMethodSetting = liveViewMethodSetting;
       _currentLiveViewWebcamId = webcamIdSetting;
+      _currentCaptureMethodSetting = captureMethodSetting;
+      _currentGPhoto2CameraId = gPhoto2CameraId;
+
+      // GPhoto2
+      if (_gPhoto2Camera != null) {
+        await _gPhoto2Camera!.dispose();
+      }
+      if (liveViewMethodSetting == LiveViewMethod.gphoto2 || captureMethodSetting == CaptureMethod.gPhoto2) {
+        _gPhoto2Camera = GPhoto2Camera(id: gPhoto2CameraId, friendlyName: gPhoto2CameraId);
+      }
 
       switch (liveViewMethodSetting) {
         case LiveViewMethod.debugNoise:
@@ -100,8 +119,7 @@ abstract class _LiveViewManagerBase with Store, UiLoggy {
           List<NokhwaCamera> cameras = await NokhwaCamera.getAllCameras();
           _currentLiveViewSource = cameras.firstWhereOrNull((camera) => camera.friendlyName == webcamIdSetting);
         case LiveViewMethod.gphoto2:
-          List<Gphoto2Camera> cameras = await Gphoto2Camera.getAllCameras();
-          _currentLiveViewSource = cameras.firstWhereOrNull((camera) => camera.id == webcamIdSetting);
+          _currentLiveViewSource = _gPhoto2Camera;
         default:
           throw "Unknown live view method";
       }

--- a/lib/managers/live_view_manager.dart
+++ b/lib/managers/live_view_manager.dart
@@ -108,7 +108,7 @@ abstract class _LiveViewManagerBase with Store, UiLoggy {
       if (_gPhoto2Camera != null) {
         await _gPhoto2Camera!.dispose();
       }
-      if (liveViewMethodSetting == LiveViewMethod.gphoto2 || captureMethodSetting == CaptureMethod.gPhoto2) {
+      if ((liveViewMethodSetting == LiveViewMethod.gphoto2 || captureMethodSetting == CaptureMethod.gPhoto2) && gPhoto2CameraId.isNotEmpty) {
         _gPhoto2Camera = GPhoto2Camera(id: gPhoto2CameraId, friendlyName: gPhoto2CameraId);
       }
 

--- a/lib/managers/live_view_manager.dart
+++ b/lib/managers/live_view_manager.dart
@@ -105,8 +105,9 @@ abstract class _LiveViewManagerBase with Store, UiLoggy {
       _currentGPhoto2CameraId = gPhoto2CameraId;
 
       // GPhoto2
-      if (_gPhoto2Camera != null) {
+      if (_gPhoto2Camera != null && _gPhoto2Camera!.isOpened) {
         await _gPhoto2Camera!.dispose();
+        _gPhoto2Camera = null;
       }
       if ((liveViewMethodSetting == LiveViewMethod.gphoto2 || captureMethodSetting == CaptureMethod.gPhoto2) && gPhoto2CameraId.isNotEmpty) {
         _gPhoto2Camera = GPhoto2Camera(id: gPhoto2CameraId, friendlyName: gPhoto2CameraId);

--- a/lib/models/settings.dart
+++ b/lib/models/settings.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:fluent_ui/fluent_ui.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:momento_booth/rust_bridge/library_api.generated.dart';
 import 'package:path/path.dart';
 import 'package:toml/toml.dart';
 import 'dart:ui' as ui;
@@ -71,6 +72,7 @@ class HardwareSettings with _$HardwareSettings implements TomlEncodableValue {
     @Default(Flip.horizontally) Flip liveViewFlipImage,
     @Default(CaptureMethod.liveViewSource) CaptureMethod captureMethod,
     @Default("") String gPhoto2CameraId,
+    @Default(GPhoto2SpecialHandling.none) GPhoto2SpecialHandling gPhoto2SpecialHandling,
     @Default(200) int captureDelaySony,
     @Default("") String captureLocation,
     @Default([]) List<String> printerNames,

--- a/lib/models/settings.dart
+++ b/lib/models/settings.dart
@@ -70,6 +70,7 @@ class HardwareSettings with _$HardwareSettings implements TomlEncodableValue {
     @Default("") String liveViewWebcamId,
     @Default(Flip.horizontally) Flip liveViewFlipImage,
     @Default(CaptureMethod.liveViewSource) CaptureMethod captureMethod,
+    @Default("") String gPhoto2CameraId,
     @Default(200) int captureDelaySony,
     @Default("") String captureLocation,
     @Default([]) List<String> printerNames,

--- a/lib/models/settings.dart
+++ b/lib/models/settings.dart
@@ -73,6 +73,7 @@ class HardwareSettings with _$HardwareSettings implements TomlEncodableValue {
     @Default(CaptureMethod.liveViewSource) CaptureMethod captureMethod,
     @Default("") String gPhoto2CameraId,
     @Default(GPhoto2SpecialHandling.none) GPhoto2SpecialHandling gPhoto2SpecialHandling,
+    @Default(100) int captureDelayGPhoto2,
     @Default(200) int captureDelaySony,
     @Default("") String captureLocation,
     @Default([]) List<String> printerNames,

--- a/lib/models/settings.enums.dart
+++ b/lib/models/settings.enums.dart
@@ -3,7 +3,8 @@ part of 'settings.dart';
 enum LiveViewMethod {
 
   debugNoise(0, "Debug - Static noise"),
-  webcam(1, "Webcam");
+  webcam(1, "Webcam"),
+  gphoto2(2, "gPhoto2");
 
   final int value;
   final String name;

--- a/lib/models/settings.enums.dart
+++ b/lib/models/settings.enums.dart
@@ -34,6 +34,28 @@ enum CaptureMethod {
 
 }
 
+enum GPhoto2SpecialHandling {
+
+  none("None"),
+  nikonDSLR("Nikon DSLR");
+
+  final String name;
+
+  const GPhoto2SpecialHandling(this.name);
+
+  ComboBoxItem<GPhoto2SpecialHandling> toComboBoxItem() => ComboBoxItem(value: this, child: Text(name));
+
+  static List<ComboBoxItem<GPhoto2SpecialHandling>> asComboBoxItems() => GPhoto2SpecialHandling.values.map((value) => value.toComboBoxItem()).toList();
+
+  GPhoto2CameraSpecialHandling toHelperLibraryEnumValue() {
+    return switch (this) {
+      GPhoto2SpecialHandling.none => GPhoto2CameraSpecialHandling.None,
+      GPhoto2SpecialHandling.nikonDSLR => GPhoto2CameraSpecialHandling.NikonDSLR,
+    };
+  }
+
+}
+
 enum ExportFormat {
 
   jpgFormat(0, "JPG"),

--- a/lib/models/settings.enums.dart
+++ b/lib/models/settings.enums.dart
@@ -20,7 +20,8 @@ enum LiveViewMethod {
 enum CaptureMethod {
 
   liveViewSource(0, "Live view source"),
-  sonyImagingEdgeDesktop(1, "Sony Imaging Edge Desktop automation");
+  sonyImagingEdgeDesktop(1, "Sony Imaging Edge Desktop automation"),
+  gPhoto2(2, "gPhoto2");
 
   final int value;
   final String name;

--- a/lib/rust_bridge/library_bridge.dart
+++ b/lib/rust_bridge/library_bridge.dart
@@ -13,7 +13,7 @@ final _dylib = Platform.isIOS || Platform.isMacOS
 
 final rustLibraryApi = MomentoBoothNativeHelpersImpl(_dylib);
 
-void init() {
+Future<void> init() async {
   // Initialize log
   Stream<LogEvent> logStream = rustLibraryApi.initializeLog();
   logStream.listen(processLogEvent);

--- a/lib/views/capture_screen/capture_screen_view.dart
+++ b/lib/views/capture_screen/capture_screen_view.dart
@@ -37,22 +37,31 @@ class CaptureScreenView extends ScreenViewBase<CaptureScreenViewModel, CaptureSc
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
             _getReadyText,
-            Flexible(child: Container(
-              padding: const EdgeInsets.all(40.0),
-              constraints: const BoxConstraints(maxWidth: 600, maxHeight: 600),
-              child: Observer(builder: (_) {
-                return AnimatedOpacity(
-                  duration: const Duration(milliseconds: 50),
-                  opacity: viewModel.showCounter ? 1.0 : 0.0,
-                  child: CaptureCounter(
-                    onCounterFinished: viewModel.onCounterFinished,
-                    counterStart: viewModel.counterStart,
-                  ),
-                );
-              })
-            )),
+            Flexible(
+              child: Container(
+                padding: const EdgeInsets.all(40.0),
+                constraints: const BoxConstraints(maxWidth: 600, maxHeight: 600),
+                child: Observer(builder: (_) {
+                  return AnimatedOpacity(
+                    duration: const Duration(milliseconds: 50),
+                    opacity: viewModel.showCounter ? 1.0 : 0.0,
+                    child: CaptureCounter(
+                      onCounterFinished: viewModel.onCounterFinished,
+                      counterStart: viewModel.counterStart,
+                    ),
+                  );
+                })
+              ),
+            ),
           ],
         ),
+        Observer(
+          builder: (_) {
+          if (viewModel.showSpinner) {
+            return const Center(child: ProgressRing());
+          }
+          return const SizedBox();
+        }),
         _flashAnimation,
       ],
     );

--- a/lib/views/capture_screen/capture_screen_view_model.dart
+++ b/lib/views/capture_screen/capture_screen_view_model.dart
@@ -6,6 +6,7 @@ import 'package:loggy/loggy.dart';
 import 'package:momento_booth/hardware_control/photo_capturing/live_view_stream_snapshot_capturer.dart';
 import 'package:momento_booth/hardware_control/photo_capturing/photo_capture_method.dart';
 import 'package:momento_booth/hardware_control/photo_capturing/sony_remote_photo_capture.dart';
+import 'package:momento_booth/managers/live_view_manager.dart';
 import 'package:momento_booth/managers/photos_manager.dart';
 import 'package:momento_booth/managers/settings_manager.dart';
 import 'package:momento_booth/managers/stats_manager.dart';
@@ -79,7 +80,8 @@ abstract class CaptureScreenViewModelBase extends ScreenViewModelBase with Store
   }) {
     capturer = switch (SettingsManager.instance.settings.hardware.captureMethod) {
       CaptureMethod.sonyImagingEdgeDesktop => SonyRemotePhotoCapture(SettingsManager.instance.settings.hardware.captureLocation),
-      CaptureMethod.liveViewSource => LiveViewStreamSnapshotCapturer()
+      CaptureMethod.liveViewSource => LiveViewStreamSnapshotCapturer(),
+      CaptureMethod.gPhoto2 => LiveViewManager.instance.gPhoto2Camera,
     } as PhotoCaptureMethod;
     Future.delayed(photoDelay).then((_) => captureAndGetPhoto());
   }

--- a/lib/views/capture_screen/capture_screen_view_model.dart
+++ b/lib/views/capture_screen/capture_screen_view_model.dart
@@ -43,6 +43,9 @@ abstract class CaptureScreenViewModelBase extends ScreenViewModelBase with Store
   @observable
   bool showFlash = false;
 
+  @observable
+  bool showSpinner = false;
+
   @computed
   double get opacity => showFlash ? 1.0 : 0.0;
 
@@ -93,6 +96,7 @@ abstract class CaptureScreenViewModelBase extends ScreenViewModelBase with Store
     showCounter = false;
     await Future.delayed(flashAnimationDuration);
     showFlash = false;
+    showSpinner = true;
     await Future.delayed(minimumContinueWait);
     flashComplete = true; // Flash is now not actually complete, but after this time we do not care about it anymore.
     navigateAfterCapture();

--- a/lib/views/multi_capture_screen/multi_capture_screen_view_model.dart
+++ b/lib/views/multi_capture_screen/multi_capture_screen_view_model.dart
@@ -5,6 +5,7 @@ import 'package:loggy/loggy.dart';
 import 'package:momento_booth/hardware_control/photo_capturing/live_view_stream_snapshot_capturer.dart';
 import 'package:momento_booth/hardware_control/photo_capturing/photo_capture_method.dart';
 import 'package:momento_booth/hardware_control/photo_capturing/sony_remote_photo_capture.dart';
+import 'package:momento_booth/managers/live_view_manager.dart';
 import 'package:momento_booth/managers/photos_manager.dart';
 import 'package:momento_booth/managers/settings_manager.dart';
 import 'package:momento_booth/managers/stats_manager.dart';
@@ -56,8 +57,9 @@ abstract class MultiCaptureScreenViewModelBase extends ScreenViewModelBase with 
     required super.contextAccessor,
   }) {
     capturer = switch (SettingsManager.instance.settings.hardware.captureMethod) {
-      CaptureMethod.sonyImagingEdgeDesktop => SonyRemotePhotoCapture(SettingsManager.instance.settings.hardware.captureLocation),
       CaptureMethod.liveViewSource => LiveViewStreamSnapshotCapturer(),
+      CaptureMethod.sonyImagingEdgeDesktop => SonyRemotePhotoCapture(SettingsManager.instance.settings.hardware.captureLocation),
+      CaptureMethod.gPhoto2 => LiveViewManager.instance.gPhoto2Camera,
     } as PhotoCaptureMethod;
     Future.delayed(photoDelay).then((_) => captureAndGetPhoto());
   }

--- a/lib/views/settings_screen/settings_screen_controller.dart
+++ b/lib/views/settings_screen/settings_screen_controller.dart
@@ -91,6 +91,12 @@ class SettingsScreenController extends ScreenControllerBase<SettingsScreenViewMo
     }
   }
 
+  void onGPhoto2SpecialHandlingChanged(GPhoto2SpecialHandling? gPhoto2SpecialHandling) {
+    if (gPhoto2SpecialHandling != null) {
+      viewModel.updateSettings((settings) => settings.copyWith.hardware(gPhoto2SpecialHandling: gPhoto2SpecialHandling));
+    }
+  }
+
   void onCaptureDelaySonyChanged(int? captureDelaySony) {
     if (captureDelaySony != null) {
       viewModel.updateSettings((settings) => settings.copyWith.hardware(captureDelaySony: captureDelaySony));

--- a/lib/views/settings_screen/settings_screen_controller.dart
+++ b/lib/views/settings_screen/settings_screen_controller.dart
@@ -85,6 +85,12 @@ class SettingsScreenController extends ScreenControllerBase<SettingsScreenViewMo
     }
   }
 
+  void onGPhoto2CameraIdChanged(String? gPhoto2CameraId) {
+    if (gPhoto2CameraId != null) {
+      viewModel.updateSettings((settings) => settings.copyWith.hardware(gPhoto2CameraId: gPhoto2CameraId));
+    }
+  }
+
   void onCaptureDelaySonyChanged(int? captureDelaySony) {
     if (captureDelaySony != null) {
       viewModel.updateSettings((settings) => settings.copyWith.hardware(captureDelaySony: captureDelaySony));

--- a/lib/views/settings_screen/settings_screen_controller.dart
+++ b/lib/views/settings_screen/settings_screen_controller.dart
@@ -96,6 +96,12 @@ class SettingsScreenController extends ScreenControllerBase<SettingsScreenViewMo
       viewModel.updateSettings((settings) => settings.copyWith.hardware(gPhoto2SpecialHandling: gPhoto2SpecialHandling));
     }
   }
+  
+  void onCaptureDelayGPhoto2Changed(int? captureDelayGPhoto2) {
+    if (captureDelayGPhoto2 != null) {
+      viewModel.updateSettings((settings) => settings.copyWith.hardware(captureDelayGPhoto2: captureDelayGPhoto2));
+    }
+  }
 
   void onCaptureDelaySonyChanged(int? captureDelaySony) {
     if (captureDelaySony != null) {

--- a/lib/views/settings_screen/settings_screen_view.hardware.dart
+++ b/lib/views/settings_screen/settings_screen_view.hardware.dart
@@ -49,7 +49,22 @@ Widget _getHardwareSettings(SettingsScreenViewModel viewModel, SettingsScreenCon
               onChanged: controller.onCaptureDelaySonyChanged,
             ),
           Observer(builder: (_) {
-            if (viewModel.captureMethodSetting == CaptureMethod.gPhoto2) return _gPhoto2CamerasCard(viewModel, controller);
+            if (viewModel.captureMethodSetting == CaptureMethod.gPhoto2 || viewModel.liveViewMethodSetting == LiveViewMethod.gphoto2) {
+                return _gPhoto2CamerasCard(viewModel, controller);
+            }
+            return const SizedBox();
+          }),
+          Observer(builder: (_) {
+            if (viewModel.captureMethodSetting == CaptureMethod.gPhoto2 || viewModel.liveViewMethodSetting == LiveViewMethod.gphoto2) {
+              return _getComboBoxCard(
+                icon: FluentIcons.camera,
+                title: "Use special handling for camera",
+                subtitle: "Kind of special handling used for the camera. Pick \"Nikon DSLR\" for cameras like the D-series. The \"None\" might work for most mirrorless camera as they are always in live view mode.",
+                items: viewModel.gPhoto2SpecialHandlingOptions,
+                value: () => viewModel.gPhoto2SpecialHandling,
+                onChanged: controller.onGPhoto2SpecialHandlingChanged,
+              );
+            }
             return const SizedBox();
           }),
           _getFolderPickerCard(

--- a/lib/views/settings_screen/settings_screen_view.hardware.dart
+++ b/lib/views/settings_screen/settings_screen_view.hardware.dart
@@ -40,14 +40,18 @@ Widget _getHardwareSettings(SettingsScreenViewModel viewModel, SettingsScreenCon
             value: () => viewModel.captureMethodSetting,
             onChanged: controller.onCaptureMethodChanged,
           ),
-          if (viewModel.captureMethodSetting == CaptureMethod.sonyImagingEdgeDesktop)
-            _getInput(
-              icon: FluentIcons.timer,
-              title: "Capture delay for Sony camera",
-              subtitle: "Delay in [ms]. Sensible values are between 165 (manual focus) and 500 ms.",
-              value: () => viewModel.captureDelaySonySetting,
-              onChanged: controller.onCaptureDelaySonyChanged,
-            ),
+          Observer(builder: (_) {
+            if (viewModel.captureMethodSetting == CaptureMethod.sonyImagingEdgeDesktop) {
+              return _getInput(
+                icon: FluentIcons.timer,
+                title: "Capture delay for Sony camera",
+                subtitle: "Delay in [ms]. Sensible values are between 165 (manual focus) and 500 ms.",
+                value: () => viewModel.captureDelaySonySetting,
+                onChanged: controller.onCaptureDelaySonyChanged,
+              );
+            }
+            return const SizedBox();
+          }),
           Observer(builder: (_) {
             if (viewModel.captureMethodSetting == CaptureMethod.gPhoto2 || viewModel.liveViewMethodSetting == LiveViewMethod.gphoto2) {
                 return _gPhoto2CamerasCard(viewModel, controller);
@@ -63,6 +67,18 @@ Widget _getHardwareSettings(SettingsScreenViewModel viewModel, SettingsScreenCon
                 items: viewModel.gPhoto2SpecialHandlingOptions,
                 value: () => viewModel.gPhoto2SpecialHandling,
                 onChanged: controller.onGPhoto2SpecialHandlingChanged,
+              );
+            }
+            return const SizedBox();
+          }),
+          Observer(builder: (_) {
+            if (viewModel.captureMethodSetting == CaptureMethod.gPhoto2) {
+              return _getInput(
+                icon: FluentIcons.timer,
+                title: "Capture delay for gPhoto2 camera",
+                subtitle: "Delay in [ms].",
+                value: () => viewModel.captureDelayGPhoto2Setting,
+                onChanged: controller.onCaptureDelayGPhoto2Changed,
               );
             }
             return const SizedBox();

--- a/lib/views/settings_screen/settings_screen_view.hardware.dart
+++ b/lib/views/settings_screen/settings_screen_view.hardware.dart
@@ -48,6 +48,10 @@ Widget _getHardwareSettings(SettingsScreenViewModel viewModel, SettingsScreenCon
               value: () => viewModel.captureDelaySonySetting,
               onChanged: controller.onCaptureDelaySonyChanged,
             ),
+          Observer(builder: (_) {
+            if (viewModel.captureMethodSetting == CaptureMethod.gPhoto2) return _gPhoto2CamerasCard(viewModel, controller);
+            return const SizedBox();
+          }),
           _getFolderPickerCard(
             icon: FluentIcons.folder,
             title: "Capture location",
@@ -183,6 +187,33 @@ FluentSettingCard _webcamCard(SettingsScreenViewModel viewModel, SettingsScreenC
               items: viewModel.webcams,
               value: viewModel.liveViewWebcamId,
               onChanged: controller.onLiveViewWebcamIdChanged,
+            );
+          }),
+        ),
+      ],
+    ),
+  );
+}
+
+FluentSettingCard _gPhoto2CamerasCard(SettingsScreenViewModel viewModel, SettingsScreenController controller) {
+  return FluentSettingCard(
+    icon: FluentIcons.camera,
+    title: "Camera",
+    subtitle: "Pick the camera to use for capturing still frames",
+    child: Row(
+      children: [
+        Button(
+          onPressed: viewModel.setCameraList,
+          child: const Text('Refresh'),
+        ),
+        const SizedBox(width: 10),
+        ConstrainedBox(
+          constraints: const BoxConstraints(minWidth: 150),
+          child: Observer(builder: (_) {
+            return ComboBox<String>(
+              items: viewModel.gPhoto2Cameras,
+              value: viewModel.gPhoto2CameraId,
+              onChanged: controller.onGPhoto2CameraIdChanged,
             );
           }),
         ),

--- a/lib/views/settings_screen/settings_screen_view_model.dart
+++ b/lib/views/settings_screen/settings_screen_view_model.dart
@@ -1,4 +1,5 @@
 import 'package:fluent_ui/fluent_ui.dart';
+import 'package:momento_booth/hardware_control/live_view_streaming/gphoto2_camera.dart';
 import 'package:momento_booth/managers/settings_manager.dart';
 import 'package:momento_booth/hardware_control/live_view_streaming/nokhwa_camera.dart';
 import 'package:momento_booth/models/settings.dart';
@@ -66,7 +67,10 @@ abstract class SettingsScreenViewModelBase extends ScreenViewModelBase with Stor
     }
   }
   
-  void setWebcamList() async => webcams = await NokhwaCamera.getCamerasAsComboBoxItems();
+  void setWebcamList() async => webcams = [
+    ...await NokhwaCamera.getCamerasAsComboBoxItems(),
+    ...await Gphoto2Camera.getCamerasAsComboBoxItems(),
+  ];
 
   // Current values
 

--- a/lib/views/settings_screen/settings_screen_view_model.dart
+++ b/lib/views/settings_screen/settings_screen_view_model.dart
@@ -1,5 +1,5 @@
 import 'package:fluent_ui/fluent_ui.dart';
-import 'package:momento_booth/hardware_control/live_view_streaming/gphoto2_camera.dart';
+import 'package:momento_booth/hardware_control/gphoto2_camera.dart';
 import 'package:momento_booth/managers/settings_manager.dart';
 import 'package:momento_booth/hardware_control/live_view_streaming/nokhwa_camera.dart';
 import 'package:momento_booth/models/settings.dart';
@@ -71,7 +71,7 @@ abstract class SettingsScreenViewModelBase extends ScreenViewModelBase with Stor
   }
   
   void setWebcamList() async => webcams = await NokhwaCamera.getCamerasAsComboBoxItems();
-  void setCameraList() async => gPhoto2Cameras = await Gphoto2Camera.getCamerasAsComboBoxItems();
+  void setCameraList() async => gPhoto2Cameras = await GPhoto2Camera.getCamerasAsComboBoxItems();
 
   // Current values
 

--- a/lib/views/settings_screen/settings_screen_view_model.dart
+++ b/lib/views/settings_screen/settings_screen_view_model.dart
@@ -27,6 +27,7 @@ abstract class SettingsScreenViewModelBase extends ScreenViewModelBase with Stor
   List<ComboBoxItem<Language>> get languages => Language.asComboBoxItems();
   List<ComboBoxItem<ScreenTransitionAnimation>> get screenTransitionAnimations => ScreenTransitionAnimation.asComboBoxItems();
   List<ComboBoxItem<FilterQuality>> get filterQualityOptions => FilterQuality.asComboBoxItems();
+  List<ComboBoxItem<GPhoto2SpecialHandling>> get gPhoto2SpecialHandlingOptions => GPhoto2SpecialHandling.asComboBoxItems();
   
   @observable
   ObservableList<ComboBoxItem<String>> printerOptions = ObservableList<ComboBoxItem<String>>();
@@ -85,6 +86,7 @@ abstract class SettingsScreenViewModelBase extends ScreenViewModelBase with Stor
   Flip get liveViewFlipImage => SettingsManager.instance.settings.hardware.liveViewFlipImage;
   CaptureMethod get captureMethodSetting => SettingsManager.instance.settings.hardware.captureMethod;
   String get gPhoto2CameraId => SettingsManager.instance.settings.hardware.gPhoto2CameraId;
+  GPhoto2SpecialHandling get gPhoto2SpecialHandling => SettingsManager.instance.settings.hardware.gPhoto2SpecialHandling;
   int get captureDelaySonySetting => SettingsManager.instance.settings.hardware.captureDelaySony;
   String get captureLocationSetting => SettingsManager.instance.settings.hardware.captureLocation;
   List<String> get printersSetting => SettingsManager.instance.settings.hardware.printerNames;

--- a/lib/views/settings_screen/settings_screen_view_model.dart
+++ b/lib/views/settings_screen/settings_screen_view_model.dart
@@ -34,6 +34,9 @@ abstract class SettingsScreenViewModelBase extends ScreenViewModelBase with Stor
   @observable
   List<ComboBoxItem<String>> webcams = ObservableList<ComboBoxItem<String>>();
 
+  @observable
+  List<ComboBoxItem<String>> gPhoto2Cameras = ObservableList<ComboBoxItem<String>>();
+
   RichText _printerCardText(String printerName, bool isAvailable, bool isDefault) {
     final icon = isAvailable ? FluentIcons.plug_connected : FluentIcons.plug_disconnected;
     return RichText(
@@ -67,10 +70,8 @@ abstract class SettingsScreenViewModelBase extends ScreenViewModelBase with Stor
     }
   }
   
-  void setWebcamList() async => webcams = [
-    ...await NokhwaCamera.getCamerasAsComboBoxItems(),
-    ...await Gphoto2Camera.getCamerasAsComboBoxItems(),
-  ];
+  void setWebcamList() async => webcams = await NokhwaCamera.getCamerasAsComboBoxItems();
+  void setCameraList() async => gPhoto2Cameras = await Gphoto2Camera.getCamerasAsComboBoxItems();
 
   // Current values
 
@@ -83,6 +84,7 @@ abstract class SettingsScreenViewModelBase extends ScreenViewModelBase with Stor
   String get liveViewWebcamId => SettingsManager.instance.settings.hardware.liveViewWebcamId;
   Flip get liveViewFlipImage => SettingsManager.instance.settings.hardware.liveViewFlipImage;
   CaptureMethod get captureMethodSetting => SettingsManager.instance.settings.hardware.captureMethod;
+  String get gPhoto2CameraId => SettingsManager.instance.settings.hardware.gPhoto2CameraId;
   int get captureDelaySonySetting => SettingsManager.instance.settings.hardware.captureDelaySony;
   String get captureLocationSetting => SettingsManager.instance.settings.hardware.captureLocation;
   List<String> get printersSetting => SettingsManager.instance.settings.hardware.printerNames;
@@ -117,6 +119,7 @@ abstract class SettingsScreenViewModelBase extends ScreenViewModelBase with Stor
   }) {
     setPrinterList();
     setWebcamList();
+    setCameraList();
   }
 
   // Methods

--- a/lib/views/settings_screen/settings_screen_view_model.dart
+++ b/lib/views/settings_screen/settings_screen_view_model.dart
@@ -87,6 +87,7 @@ abstract class SettingsScreenViewModelBase extends ScreenViewModelBase with Stor
   CaptureMethod get captureMethodSetting => SettingsManager.instance.settings.hardware.captureMethod;
   String get gPhoto2CameraId => SettingsManager.instance.settings.hardware.gPhoto2CameraId;
   GPhoto2SpecialHandling get gPhoto2SpecialHandling => SettingsManager.instance.settings.hardware.gPhoto2SpecialHandling;
+  int get captureDelayGPhoto2Setting => SettingsManager.instance.settings.hardware.captureDelayGPhoto2;
   int get captureDelaySonySetting => SettingsManager.instance.settings.hardware.captureDelaySony;
   String get captureLocationSetting => SettingsManager.instance.settings.hardware.captureLocation;
   List<String> get printersSetting => SettingsManager.instance.settings.hardware.printerNames;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -101,10 +101,10 @@ packages:
     dependency: transitive
     description:
       name: build
-      sha256: "43865b79fbb78532e4bff7c33087aa43b1d488c4fdef014eaef568af6d8016dc"
+      sha256: "80184af8b6cb3e5c1c4ec6d8544d27711700bc3e6d2efad04238c7b5290889f0"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.0"
+    version: "2.4.1"
   build_cli_annotations:
     dependency: transitive
     description:
@@ -133,10 +133,10 @@ packages:
     dependency: transitive
     description:
       name: build_resolvers
-      sha256: db49b8609ef8c81cca2b310618c3017c00f03a92af44c04d310b907b2d692d95
+      sha256: "6c4dd11d05d056e76320b828a1db0fc01ccd376922526f8e9d6c796a5adbac20"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.2.1"
   build_runner:
     dependency: "direct dev"
     description:
@@ -277,10 +277,10 @@ packages:
     dependency: transitive
     description:
       name: dart_style
-      sha256: f4f1f73ab3fd2afcbcca165ee601fe980d966af6a21b5970c6c9376955c528ad
+      sha256: "1efa911ca7086affd35f463ca2fc1799584fb6aa89883cf0af8e3664d6a02d55"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.1"
+    version: "2.3.2"
   fake_async:
     dependency: transitive
     description:
@@ -949,18 +949,18 @@ packages:
     dependency: transitive
     description:
       name: source_gen
-      sha256: "373f96cf5a8744bc9816c1ff41cf5391bbdbe3d7a96fe98c622b6738a8a7bd33"
+      sha256: fc0da689e5302edb6177fdd964efcb7f58912f43c28c2047a808f5bfff643d16
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.2"
+    version: "1.4.0"
   source_helper:
     dependency: transitive
     description:
       name: source_helper
-      sha256: "3b67aade1d52416149c633ba1bb36df44d97c6b51830c2198e934e3fca87ca1f"
+      sha256: "6adebc0006c37dd63fe05bca0a929b99f06402fc95aa35bf36d67f5c06de01fd"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.3"
+    version: "1.3.4"
   source_span:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -141,10 +141,10 @@ packages:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: "5e1929ad37d48bd382b124266cb8e521de5548d406a45a5ae6656c13dab73e37"
+      sha256: "10c6bcdbf9d049a0b666702cf1cee4ddfdc38f02a19d35ae392863b47519848b"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.5"
+    version: "2.4.6"
   build_runner_core:
     dependency: transitive
     description:
@@ -359,10 +359,10 @@ packages:
     dependency: "direct dev"
     description:
       name: flutter_lints
-      sha256: aeb0b80a8b3709709c9cc496cdc027c5b3216796bc0af0ce1007eaf24464fd4c
+      sha256: "2118df84ef0c3ca93f96123a616ae8540879991b8b57af2f81b76a7ada49b2a4"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "2.0.2"
   flutter_localizations:
     dependency: "direct main"
     description: flutter
@@ -467,10 +467,10 @@ packages:
     dependency: "direct main"
     description:
       name: go_router
-      sha256: "2cb236ba3f923043fdbe14a6a3a796b8c250e85658e28caee3e86c0c275847e5"
+      sha256: "1531542666c2d052c44bbf6e2b48011bf3771da0404b94c60eabec1228a62906"
       url: "https://pub.dev"
     source: hosted
-    version: "8.2.0"
+    version: "9.0.0"
   graphs:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -467,10 +467,10 @@ packages:
     dependency: "direct main"
     description:
       name: go_router
-      sha256: da08429b5c1026cc78bd60c60bfff34f0b273b29feddeab00d3f5b56fb6f35ed
+      sha256: "2cb236ba3f923043fdbe14a6a3a796b8c250e85658e28caee3e86c0c275847e5"
       url: "https://pub.dev"
     source: hosted
-    version: "8.0.5"
+    version: "8.2.0"
   graphs:
     dependency: transitive
     description:
@@ -1158,10 +1158,10 @@ packages:
     dependency: "direct main"
     description:
       name: win32
-      sha256: dd8f9344bc305ae2923e3d11a2a911d9a4e2c7dd6fe0ed10626d63211a69676e
+      sha256: "5a751eddf9db89b3e5f9d50c20ab8612296e4e8db69009788d6c8b060a84191c"
       url: "https://pub.dev"
     source: hosted
-    version: "4.1.3"
+    version: "4.1.4"
   window_manager:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   # UI
   auto_size_text: 3.0.0
   fluent_ui: 4.6.2
-  go_router: 8.0.5
+  go_router: 8.2.0
   flutter_svg: 2.0.7
   animated_text_kit: 4.2.2
   hotkey_manager: 0.1.8
@@ -67,7 +67,7 @@ dependencies:
   toml: 0.14.0
   synchronized: 3.1.0
   collection: 1.17.1
-  win32: 4.1.3
+  win32: 4.1.4
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   # UI
   auto_size_text: 3.0.0
   fluent_ui: 4.6.2
-  go_router: 8.2.0
+  go_router: 9.0.0
   flutter_svg: 2.0.7
   animated_text_kit: 4.2.2
   hotkey_manager: 0.1.8
@@ -79,7 +79,7 @@ dev_dependencies:
   mobx_codegen: 2.3.0
 
   # Code quality
-  flutter_lints: 2.0.1
+  flutter_lints: 2.0.2
   dart_code_metrics: 5.7.5
   dart_code_metrics_presets: 1.8.0
 
@@ -88,7 +88,7 @@ dev_dependencies:
   json_serializable: 6.7.0
 
   # Code generation
-  build_runner: 2.4.5
+  build_runner: 2.4.6
   ffigen: 8.0.2
 
 flutter:

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1614,7 +1614,6 @@ dependencies = [
  "noise",
  "nokhwa",
  "nokhwa-bindings-macos 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "once_cell",
  "pathsep",
  "serde_json",
  "static_init",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1638,6 +1638,7 @@ dependencies = [
  "pathsep",
  "serde_json",
  "static_init",
+ "tokio",
  "turborand",
  "zune-jpeg",
 ]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -143,12 +143,12 @@ dependencies = [
  "log 0.4.19",
  "peeking_take_while",
  "prettyplease",
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.63",
  "quote 1.0.28",
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.18",
+ "syn 2.0.22",
  "which",
 ]
 
@@ -568,7 +568,7 @@ checksum = "f0c960ae2da4de88a91b2d920c2a7233b400bc33cb28453a2987822d8392519b"
 dependencies = [
  "fnv",
  "ident_case",
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.63",
  "quote 1.0.28",
  "strsim",
  "syn 1.0.109",
@@ -615,7 +615,7 @@ checksum = "a2658621297f2cf68762a6f7dc0bb7e1ff2cfd6583daef8ee0fed6f7ec468ec0"
 dependencies = [
  "darling",
  "derive_builder_core",
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.63",
  "quote 1.0.28",
  "syn 1.0.109",
 ]
@@ -627,7 +627,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2791ea3e372c8495c0bc2033991d76b512cd799d07491fbd6890124db9458bef"
 dependencies = [
  "darling",
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.63",
  "quote 1.0.28",
  "syn 1.0.109",
 ]
@@ -639,7 +639,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
 dependencies = [
  "convert_case",
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.63",
  "quote 1.0.28",
  "rustc_version 0.4.0",
  "syn 1.0.109",
@@ -788,7 +788,7 @@ dependencies = [
  "chrono",
  "derive_builder",
  "hkdf",
- "hyper 0.14.26",
+ "hyper 0.14.27",
  "mime 0.3.17",
  "mime_guess",
  "regex",
@@ -1038,9 +1038,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.19"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d357c7ae988e7d2182f7d7871d0b963962420b0678b0997ce7de72001aeab782"
+checksum = "97ec8491ebaf99c8eaa73058b045fe58073cd6be7f596ac993ced0b0a0c01049"
 dependencies = [
  "bytes 1.4.0",
  "fnv",
@@ -1057,10 +1057,11 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "2.2.1"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b4af3693f1b705df946e9fe5631932443781d0aabb423b62fcd4d73f6d2fd0"
+checksum = "bc52e53916c08643f1b56ec082790d1e86a32e58dc5268f897f313fbae7b4872"
 dependencies = [
+ "cfg-if 1.0.0",
  "crunchy",
 ]
 
@@ -1160,9 +1161,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.14.26"
+version = "0.14.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab302d72a6f11a3b910431ff93aae7e773078c769f0a3ef15fb9ec692ed147d4"
+checksum = "ffb1cfd654a8219eaef89881fdb3bb3b1cdc5fa75ded05d6933b2b382e395468"
 dependencies = [
  "bytes 1.4.0",
  "futures-channel",
@@ -1189,7 +1190,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0646026eb1b3eea4cd9ba47912ea5ce9cc07713d105b1a14698f4e6433d348b7"
 dependencies = [
  "http",
- "hyper 0.14.26",
+ "hyper 0.14.27",
  "rustls",
  "tokio",
  "tokio-rustls",
@@ -1202,7 +1203,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
  "bytes 1.4.0",
- "hyper 0.14.26",
+ "hyper 0.14.27",
  "native-tls",
  "tokio",
  "tokio-native-tls",
@@ -1397,9 +1398,9 @@ checksum = "03087c2bad5e1034e8cace5926dec053fb3790248370865f5117a7d0213354c8"
 
 [[package]]
 name = "libc"
-version = "0.2.146"
+version = "0.2.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
+checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
 name = "libgphoto2_sys"
@@ -1878,9 +1879,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.54"
+version = "0.10.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69b3f656a17a6cbc115b5c7a40c616947d213ba182135b014d6051b73ab6f019"
+checksum = "345df152bc43501c5eb9e4654ff05f794effb78d4efe3d53abc158baddc0703d"
 dependencies = [
  "bitflags 1.3.2",
  "cfg-if 1.0.0",
@@ -1897,9 +1898,9 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.63",
  "quote 1.0.28",
- "syn 2.0.18",
+ "syn 2.0.22",
 ]
 
 [[package]]
@@ -1910,9 +1911,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.88"
+version = "0.9.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2ce0f250f34a308dcfdbb351f511359857d4ed2134ba715a4eadd46e1ffd617"
+checksum = "374533b0e45f3a7ced10fcaeccca020e66656bc03dac384f852e4e5a7a8104a6"
 dependencies = [
  "cc",
  "libc",
@@ -2039,9 +2040,9 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39407670928234ebc5e6e580247dd567ad73a3578460c5990f9503df207e8f07"
 dependencies = [
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.63",
  "quote 1.0.28",
- "syn 2.0.18",
+ "syn 2.0.22",
 ]
 
 [[package]]
@@ -2083,12 +2084,12 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "prettyplease"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b0377b720bde721213a46cda1289b2f34abf0a436907cad91578c20de0454d"
+checksum = "9825a04601d60621feed79c4e6b56d65db77cdca55cef43b46b0de1096d1c282"
 dependencies = [
- "proc-macro2 1.0.60",
- "syn 2.0.18",
+ "proc-macro2 1.0.63",
+ "syn 2.0.22",
 ]
 
 [[package]]
@@ -2108,9 +2109,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.60"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406"
+checksum = "7b368fba921b0dce7e60f5e04ec15e565b3303972b42bcfde1d0713b881959eb"
 dependencies = [
  "unicode-ident",
 ]
@@ -2139,7 +2140,7 @@ version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
 dependencies = [
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.63",
 ]
 
 [[package]]
@@ -2384,7 +2385,7 @@ dependencies = [
  "h2",
  "http",
  "http-body",
- "hyper 0.14.26",
+ "hyper 0.14.27",
  "hyper-rustls",
  "hyper-tls",
  "ipnet",
@@ -2601,16 +2602,16 @@ version = "1.0.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68"
 dependencies = [
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.63",
  "quote 1.0.28",
- "syn 2.0.18",
+ "syn 2.0.22",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.97"
+version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdf3bf93142acad5821c99197022e170842cdbc1c30482b98750c688c640842a"
+checksum = "46266871c240a00b8f503b877622fe33430b3c7d963bdc0f2adc511e54a1eae3"
 dependencies = [
  "itoa",
  "ryu",
@@ -2762,7 +2763,7 @@ checksum = "70a2595fc3aa78f2d0e45dd425b22282dd863273761cc77780914b2cf3003acf"
 dependencies = [
  "cfg_aliases",
  "memchr",
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.63",
  "quote 1.0.28",
  "syn 1.0.109",
 ]
@@ -2787,7 +2788,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c87a60a40fccc84bef0652345bbbbbe20a605bf5d0ce81719fc476f5c03b50ef"
 dependencies = [
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.63",
  "quote 1.0.28",
  "serde",
  "serde_derive",
@@ -2801,7 +2802,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58fa5ff6ad0d98d1ffa8cb115892b6e69d67799f6763e162a1c9db421dc22e11"
 dependencies = [
  "base-x",
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.63",
  "quote 1.0.28",
  "serde",
  "serde_derive",
@@ -2845,18 +2846,18 @@ version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.63",
  "quote 1.0.28",
  "unicode-ident",
 ]
 
 [[package]]
 name = "syn"
-version = "2.0.18"
+version = "2.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e"
+checksum = "2efbeae7acf4eabd6bcdcbd11c92f45231ddda7539edc7806bd1a04a03b24616"
 dependencies = [
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.63",
  "quote 1.0.28",
  "unicode-ident",
 ]
@@ -2890,9 +2891,9 @@ version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.63",
  "quote 1.0.28",
- "syn 2.0.18",
+ "syn 2.0.22",
 ]
 
 [[package]]
@@ -2958,7 +2959,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd3c141a1b43194f3f56a1411225df8646c55781d5f26db825b3d98507eb482f"
 dependencies = [
  "proc-macro-hack",
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.63",
  "quote 1.0.28",
  "standback",
  "syn 1.0.109",
@@ -3345,9 +3346,9 @@ dependencies = [
  "bumpalo",
  "log 0.4.19",
  "once_cell",
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.63",
  "quote 1.0.28",
- "syn 2.0.18",
+ "syn 2.0.22",
  "wasm-bindgen-shared",
 ]
 
@@ -3379,9 +3380,9 @@ version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.63",
  "quote 1.0.28",
- "syn 2.0.18",
+ "syn 2.0.22",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4fa78e18c64fce05e902adecd7a5eed15a5e0a3439f7b0e169f0252214865e3"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -93,6 +102,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "backtrace"
+version = "0.3.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4319208da049c43661739c5fade2ba182f09d1dc2299b32298d3a31692b17e12"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if 1.0.0",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
+
+[[package]]
 name = "base-x"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -144,7 +168,7 @@ dependencies = [
  "peeking_take_while",
  "prettyplease",
  "proc-macro2 1.0.63",
- "quote 1.0.28",
+ "quote 1.0.29",
  "regex",
  "rustc-hash",
  "shlex",
@@ -166,9 +190,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.3.2"
+version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dbe3c979c178231552ecba20214a8272df4e09f232a87aef4320cf06539aded"
+checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
 
 [[package]]
 name = "block"
@@ -569,7 +593,7 @@ dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2 1.0.63",
- "quote 1.0.28",
+ "quote 1.0.29",
  "strsim",
  "syn 1.0.109",
 ]
@@ -581,7 +605,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72"
 dependencies = [
  "darling_core",
- "quote 1.0.28",
+ "quote 1.0.29",
  "syn 1.0.109",
 ]
 
@@ -616,7 +640,7 @@ dependencies = [
  "darling",
  "derive_builder_core",
  "proc-macro2 1.0.63",
- "quote 1.0.28",
+ "quote 1.0.29",
  "syn 1.0.109",
 ]
 
@@ -628,7 +652,7 @@ checksum = "2791ea3e372c8495c0bc2033991d76b512cd799d07491fbd6890124db9458bef"
 dependencies = [
  "darling",
  "proc-macro2 1.0.63",
- "quote 1.0.28",
+ "quote 1.0.29",
  "syn 1.0.109",
 ]
 
@@ -640,7 +664,7 @@ checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
 dependencies = [
  "convert_case",
  "proc-macro2 1.0.63",
- "quote 1.0.28",
+ "quote 1.0.29",
  "rustc_version 0.4.0",
  "syn 1.0.109",
 ]
@@ -1019,6 +1043,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.27.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
+
+[[package]]
 name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1070,15 +1100,6 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-
-[[package]]
-name = "hermit-abi"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "hermit-abi"
@@ -1303,7 +1324,7 @@ version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
- "hermit-abi 0.3.1",
+ "hermit-abi",
  "libc",
  "windows-sys 0.48.0",
 ]
@@ -1319,9 +1340,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.7.2"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12b6ee2129af8d4fb011108c73d99a1b83a85977f23b82460c0ae2e25bb4b57f"
+checksum = "28b29a3cd74f0f4598934efe3aeba42bae0eb4680554128851ebbecb02af14e6"
 
 [[package]]
 name = "itoa"
@@ -1831,11 +1852,11 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.2.6",
+ "hermit-abi",
  "libc",
 ]
 
@@ -1856,6 +1877,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad970fb455818ad6cba4c122ad012fae53ae8b4795f86378bce65e4f6bab2ca4"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "object"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bda667d9f2b5051b8833f59f3bf748b28ef54f850f4fcb389a252aa383866d1"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1898,7 +1928,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2 1.0.63",
- "quote 1.0.28",
+ "quote 1.0.29",
  "syn 2.0.22",
 ]
 
@@ -2026,21 +2056,21 @@ checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "pin-project"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c95a7476719eab1e366eaf73d0260af3021184f18177925b07f54b30089ceead"
+checksum = "6e138fdd8263907a2b0e1b4e80b7e58c721126479b6e6eedfb1b402acea7b9bd"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39407670928234ebc5e6e580247dd567ad73a3578460c5990f9503df207e8f07"
+checksum = "d1fef411b303e3e12d534fb6e7852de82da56edd937d895125821fb7c09436c7"
 dependencies = [
  "proc-macro2 1.0.63",
- "quote 1.0.28",
+ "quote 1.0.29",
  "syn 2.0.22",
 ]
 
@@ -2135,9 +2165,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.28"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
+checksum = "573015e8ab27661678357f27dc26460738fd2b6c86e46f386fde94cb5d913105"
 dependencies = [
  "proc-macro2 1.0.63",
 ]
@@ -2437,6 +2467,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+
+[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2462,9 +2498,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.20"
+version = "0.37.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b96e891d04aa506a6d1f318d2771bcb1c7dfda84e126660ace067c9b474bb2c0"
+checksum = "62f25693a73057a1b4cb56179dd3c7ea21a7c6c5ee7d85781f5749b46f34b79c"
 dependencies = [
  "bitflags 1.3.2",
  "errno",
@@ -2488,9 +2524,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pemfile"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
+checksum = "2d3987094b1d07b653b7dfdc3f70ce9a1da9c51ac18c1b06b662e4f9a0e9f4b2"
 dependencies = [
  "base64 0.21.2",
 ]
@@ -2602,7 +2638,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68"
 dependencies = [
  "proc-macro2 1.0.63",
- "quote 1.0.28",
+ "quote 1.0.29",
  "syn 2.0.22",
 ]
 
@@ -2763,7 +2799,7 @@ dependencies = [
  "cfg_aliases",
  "memchr",
  "proc-macro2 1.0.63",
- "quote 1.0.28",
+ "quote 1.0.29",
  "syn 1.0.109",
 ]
 
@@ -2788,7 +2824,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c87a60a40fccc84bef0652345bbbbbe20a605bf5d0ce81719fc476f5c03b50ef"
 dependencies = [
  "proc-macro2 1.0.63",
- "quote 1.0.28",
+ "quote 1.0.29",
  "serde",
  "serde_derive",
  "syn 1.0.109",
@@ -2802,7 +2838,7 @@ checksum = "58fa5ff6ad0d98d1ffa8cb115892b6e69d67799f6763e162a1c9db421dc22e11"
 dependencies = [
  "base-x",
  "proc-macro2 1.0.63",
- "quote 1.0.28",
+ "quote 1.0.29",
  "serde",
  "serde_derive",
  "serde_json",
@@ -2846,7 +2882,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2 1.0.63",
- "quote 1.0.28",
+ "quote 1.0.29",
  "unicode-ident",
 ]
 
@@ -2857,7 +2893,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2efbeae7acf4eabd6bcdcbd11c92f45231ddda7539edc7806bd1a04a03b24616"
 dependencies = [
  "proc-macro2 1.0.63",
- "quote 1.0.28",
+ "quote 1.0.29",
  "unicode-ident",
 ]
 
@@ -2891,7 +2927,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2 1.0.63",
- "quote 1.0.28",
+ "quote 1.0.29",
  "syn 2.0.22",
 ]
 
@@ -2959,7 +2995,7 @@ checksum = "fd3c141a1b43194f3f56a1411225df8646c55781d5f26db825b3d98507eb482f"
 dependencies = [
  "proc-macro-hack",
  "proc-macro2 1.0.63",
- "quote 1.0.28",
+ "quote 1.0.29",
  "standback",
  "syn 1.0.109",
 ]
@@ -2981,11 +3017,12 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.28.2"
+version = "1.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94d7b1cfd2aa4011f2de74c2c4c63665e27a71006b0a192dcd2710272e73dfa2"
+checksum = "532826ff75199d5833b9d2c5fe410f29235e25704ee5f0ef599fb51c21f4a4da"
 dependencies = [
  "autocfg 1.1.0",
+ "backtrace",
  "bytes 1.4.0",
  "libc",
  "mio 0.8.8",
@@ -3346,7 +3383,7 @@ dependencies = [
  "log 0.4.19",
  "once_cell",
  "proc-macro2 1.0.63",
- "quote 1.0.28",
+ "quote 1.0.29",
  "syn 2.0.22",
  "wasm-bindgen-shared",
 ]
@@ -3369,7 +3406,7 @@ version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
 dependencies = [
- "quote 1.0.28",
+ "quote 1.0.29",
  "wasm-bindgen-macro-support",
 ]
 
@@ -3380,7 +3417,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2 1.0.63",
- "quote 1.0.28",
+ "quote 1.0.29",
  "syn 2.0.22",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
@@ -3563,9 +3600,9 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.48.0"
+version = "0.48.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+checksum = "05d4b17490f70499f20b9e791dcf6a299785ce8af4d709018206dc5b4953e95f"
 dependencies = [
  "windows_aarch64_gnullvm 0.48.0",
  "windows_aarch64_msvc 0.48.0",
@@ -3685,7 +3722,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29ca36c2e02af0d8d7ee977542bfe33ed1c516be73d3c1faa4420af46e96ceee"
 dependencies = [
- "bitflags 2.3.2",
+ "bitflags 2.3.3",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -9,7 +9,6 @@ crate-type = ["lib", "staticlib", "cdylib"]
 
 [dependencies]
 derive_more = "0.99.17"
-once_cell = "1.18.0"
 atom_table = "1.1.0"
 flutter_rust_bridge = "1.78.0"
 ffsend-api = "0.7.3"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -13,7 +13,7 @@ once_cell = "1.18.0"
 atom_table = "1.1.0"
 flutter_rust_bridge = "1.78.0"
 ffsend-api = "0.7.3"
-serde_json = "1.0.96"
+serde_json = "1.0.99"
 chrono = "0.4.26"
 image = "0.24.6"
 nokhwa-bindings-macos = "0.2.1"
@@ -28,7 +28,7 @@ dashmap = "5.4.0"
 turborand = "0.10.0"
 pathsep = "0.1.1"
 
-[target.'cfg(not(target_os = "macos"))'.dependencies]
+[target.'cfg(any(not(target_os = "macos"), debug_assertions))'.dependencies]
 gphoto2 = "3.2.1"
 
 [profile.dev]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -26,6 +26,7 @@ noise = "0.8.2"
 dashmap = "5.4.0"
 turborand = "0.10.0"
 pathsep = "0.1.1"
+tokio = "1.29.1"
 
 [target.'cfg(any(not(target_os = "macos"), debug_assertions))'.dependencies]
 gphoto2 = "3.2.1"

--- a/rust/src/dart_bridge/api.rs
+++ b/rust/src/dart_bridge/api.rs
@@ -242,7 +242,7 @@ pub fn gphoto2_start_liveview(handle_id: usize, operations: Vec<ImageOperation>,
                 Err(_) => todo!(),
             }
         }).await
-    }).expect("mad")
+    }).expect("Could not start live view")
 }
 
 pub fn gphoto2_stop_liveview(handle_id: usize) {

--- a/rust/src/dart_bridge/api.rs
+++ b/rust/src/dart_bridge/api.rs
@@ -8,7 +8,7 @@ use turborand::rng::Rng;
 
 use tokio::{sync::Mutex as AsyncMutex};
 
-use crate::{hardware_control::live_view::{nokhwa::{self, NokhwaCameraInfo}, white_noise::{self, WhiteNoiseGeneratorHandle}, gphoto2::{self, GPhoto2Camera, GPhoto2CameraSpecialHandling, GPhoto2CameraInfo}}, utils::{ffsend_client::{self, FfSendTransferProgress}, jpeg, image_processing::{self, ImageOperation}, flutter_texture::FlutterTexture}, LogEvent, HardwareInitializationFinishedEvent, log_debug, TOKIO_RUNTIME};
+use crate::{hardware_control::live_view::{nokhwa::{self, NokhwaCameraInfo}, white_noise::{self, WhiteNoiseGeneratorHandle}, gphoto2::{self, GPhoto2Camera, GPhoto2CameraSpecialHandling, GPhoto2CameraInfo, stop_liveview}}, utils::{ffsend_client::{self, FfSendTransferProgress}, jpeg, image_processing::{self, ImageOperation}, flutter_texture::FlutterTexture}, LogEvent, HardwareInitializationFinishedEvent, log_debug, TOKIO_RUNTIME};
 
 // ////////////// //
 // Initialization //
@@ -31,10 +31,19 @@ pub fn initialize_hardware(ready_sink: StreamSink<HardwareInitializationFinished
         for map_entry in NOKHWA_HANDLES.iter() {
             map_entry.value().lock().expect("Could not lock on handle").camera.set_callback(|_| {}).expect("Stream close error");
         }
+        log_debug("Possible Hot Reload: Closed nokhwa".to_string());
         NOKHWA_HANDLES.clear();
+        for map_entry in GPHOTO2_HANDLES.iter() {
+            TOKIO_RUNTIME.get().expect("Could not get tokio runtime").block_on(async{
+                gphoto2::stop_liveview(map_entry.value().lock().expect("Could not lock camera").camera.clone()).await
+            }).expect("Could not get result")
+        }
+        log_debug("Possible Hot Reload: Closed gphoto2".to_string());
+        GPHOTO2_HANDLES.clear();
         for map_entry in NOISE_HANDLES.iter() {
             noise_close(*map_entry.key())
         }
+        log_debug("Possible Hot Reload: Closed noise".to_string());
     }
 }
 

--- a/rust/src/dart_bridge/api.rs
+++ b/rust/src/dart_bridge/api.rs
@@ -210,10 +210,10 @@ pub fn gphoto2_start_liveview(handle_id: usize, operations: Vec<ImageOperation>,
     let renderer = FlutterTexture::new(texture_ptr, 0, 0);
     let renderer_mutex = Mutex::new(renderer);
 
-    let camera_ref = GPHOTO2_HANDLES.get(&handle_id).expect("Invalid gPhoto2 handle ID");
-    let mut camera = camera_ref.lock().expect("Could not get lock");
+    let camera_ref = GPHOTO2_HANDLES.get_mut(&handle_id).expect("Invalid gPhoto2 handle ID");
+    let camera = camera_ref.clone();
 
-    gphoto2::start_liveview(&mut camera, move |raw_frame| {
+    gphoto2::start_liveview(camera, move |raw_frame| {
         match raw_frame {
             Ok(raw_frame) => {
                 let processed_frame = image_processing::execute_operations(raw_frame, &operations);
@@ -227,10 +227,10 @@ pub fn gphoto2_start_liveview(handle_id: usize, operations: Vec<ImageOperation>,
 }
 
 pub fn gphoto2_stop_liveview(handle_id: usize) {
-    let camera_ref = GPHOTO2_HANDLES.get(&handle_id).expect("Invalid gPhoto2 handle ID");
-    let camera = camera_ref.lock().expect("Could not get lock");
+    let camera_ref = GPHOTO2_HANDLES.get_mut(&handle_id).expect("Invalid gPhoto2 handle ID");
+    let camera = camera_ref.clone();
 
-    gphoto2::stop_liveview(&camera).expect("Could not stop liveview");
+    gphoto2::stop_liveview(camera).expect("Could not stop liveview");
 }
 
 // /////// //

--- a/rust/src/hardware_control/live_view/gphoto2.rs
+++ b/rust/src/hardware_control/live_view/gphoto2.rs
@@ -1,53 +1,121 @@
-use std::thread;
+use std::{thread::{self, JoinHandle}, sync::{OnceLock, atomic::{AtomicBool, Ordering}}, any::Any, rc::Rc};
 
-use gphoto2::{Context, list::CameraDescriptor, widget::TextWidget};
+use gphoto2::{Context, list::CameraDescriptor, widget::TextWidget, Camera, Error};
 
 use crate::{utils::jpeg, dart_bridge::api::RawImage};
 
-pub fn get_cameras() -> Vec<Gphoto2CameraInfo> {
-  //env_logger::init();
+static CONTEXT: OnceLock<Context> = OnceLock::new();
 
-  let context = Context::new().expect("Could not create gphoto2 context");
+fn get_context() -> Result<&'static Context> {
+  CONTEXT.get().ok_or(Gphoto2Error::ContextNotInitialized)
+}
 
-  println!("Available cameras:");
-  let mut cameras: Vec<Gphoto2CameraInfo> = Vec::new();
-  for CameraDescriptor { model, port } in context.list_cameras().wait().expect("Could not list cameras") {
-    cameras.push(Gphoto2CameraInfo::from_camera_descriptor(CameraDescriptor { model, port }));
+pub fn initialize() -> Result<()> {
+  if CONTEXT.get().is_some() {
+    // Already initialized
+    return Ok(())
   }
 
-  cameras
+  let context = Context::new()?;
+  CONTEXT.get_or_init(|| context);
+
+  Ok(())
 }
 
-pub fn open_camera_liveview<F>(model: String, port: String, frame_callback: F) where F: Fn(Option<RawImage>) + Send + Sync + 'static {
-  let context = Context::new().expect("Could not create gphoto2 context");
+pub fn get_cameras() -> Result<Vec<GPhoto2CameraInfo>> {
+  let mut cameras: Vec<GPhoto2CameraInfo> = Vec::new();
+  for CameraDescriptor { model, port } in get_context()?.list_cameras().wait().expect("Could not list cameras") {
+    cameras.push(GPhoto2CameraInfo::from_camera_descriptor(CameraDescriptor { model, port }));
+  }
 
-  let camera = context.get_camera(&CameraDescriptor { model, port }).wait().expect("Could not open camera");
-  let opcode = camera.config_key::<TextWidget>("opcode").wait().expect("Could not get opcode");
+  Ok(cameras)
+}
 
-  println!("Starting live view");
-  opcode.set_value("0x9201").expect("Could not set opcode");
-  camera.set_config(&opcode).wait().expect("Could not set opcode");
+pub fn open_camera(model: String, port: String, special_handling: GPhoto2CameraSpecialHandling) -> Result<GPhoto2Camera> {
+  let camera = get_context()?.get_camera(&CameraDescriptor { model, port }).wait()?;
 
-  thread::spawn(move || {
+  Ok(GPhoto2Camera {
+    camera,
+    special_handling,
+    thread_join_handle: None,
+    thread_should_stop: AtomicBool::new(false),
+  })
+}
+
+pub fn start_liveview<F>(camera: &mut GPhoto2Camera, frame_callback: F) -> Result<()> where F: Fn(Result<RawImage>) + Send + Sync + 'static {
+  let opcode = camera.camera.config_key::<TextWidget>("opcode").wait().expect("Could not get opcode");
+
+  match camera.special_handling {
+    GPhoto2CameraSpecialHandling::None => {},
+    GPhoto2CameraSpecialHandling::NikonDSLR => {
+      opcode.set_value("0x9201")?;
+      camera.camera.set_config(&opcode).wait()?;
+    },
+  }
+  
+  let join_handle = thread::spawn(move || {
+    let context = get_context().expect("TODO: handle this");
+
     loop {
-      let preview = camera.capture_preview().wait().expect("Could not capture preview");
+      let preview = camera.camera.capture_preview().wait().expect("Could not capture preview");
       let data = preview.get_data(&context).wait().expect("Could not get preview data");
       let raw_image = jpeg::decode_jpeg_to_rgba(&data); // TODO: Handle errors (this should return Option<RawImage>)
-      frame_callback(Some(raw_image))
+      frame_callback(Ok(raw_image))
     }
   });
+
+  camera.thread_join_handle = Some(join_handle);
+
+  Ok(())
 }
 
-pub struct Gphoto2CameraInfo {
+pub fn stop_liveview(camera: &GPhoto2Camera) -> Result<()> {
+  camera.thread_should_stop.store(true, Ordering::SeqCst);
+  camera.thread_join_handle.map_or_else( ||Ok(()), |handle| handle.join().map_err(|error| Gphoto2Error::StopLiveViewThreadError(error)))
+}
+
+pub struct GPhoto2CameraInfo {
     pub port: String,
     pub model: String,
 }
 
-impl Gphoto2CameraInfo {
+impl GPhoto2CameraInfo {
     pub fn from_camera_descriptor (camera_descriptor: CameraDescriptor) -> Self {
         Self {
             port: camera_descriptor.port,
             model: camera_descriptor.model,
         }
     }
+}
+
+pub struct GPhoto2Camera {
+  pub camera: Camera,
+  pub special_handling: GPhoto2CameraSpecialHandling,
+  thread_join_handle: Option<JoinHandle<()>>,
+  thread_should_stop: AtomicBool,
+}
+
+pub enum GPhoto2CameraSpecialHandling {
+  None,
+  NikonDSLR,
+}
+
+// ////// //
+// Errors //
+// ////// //
+
+type Result<T> = std::result::Result<T, Gphoto2Error>;
+
+#[derive(Debug)]
+pub enum Gphoto2Error {
+  ContextNotInitialized,
+  FrameDecodeError,
+  StopLiveViewThreadError(Box<dyn Any + Send>),
+  Gphoto2LibraryError(Error),
+}
+
+impl From<Error> for Gphoto2Error {
+  fn from(err: Error) -> Gphoto2Error {
+    Gphoto2Error::Gphoto2LibraryError(err)
+  }
 }

--- a/rust/src/hardware_control/live_view/gphoto2.rs
+++ b/rust/src/hardware_control/live_view/gphoto2.rs
@@ -1,6 +1,9 @@
-use std::{thread::{self, JoinHandle}, sync::{OnceLock, atomic::{AtomicBool, Ordering}, Arc, Mutex, PoisonError, MutexGuard}, any::Any, cell::Cell, path::Path};
+use std::{sync::{OnceLock, atomic::{AtomicBool, Ordering}, Arc}, any::Any, cell::Cell};
 
 use gphoto2::{Context, list::CameraDescriptor, widget::TextWidget, Camera, Error};
+
+use tokio::{sync::Mutex as AsyncMutex};
+use tokio::task::JoinHandle as AsyncJoinHandle;
 
 use crate::{utils::jpeg, dart_bridge::api::RawImage};
 
@@ -31,8 +34,9 @@ pub fn get_cameras() -> Result<Vec<GPhoto2CameraInfo>> {
   Ok(cameras)
 }
 
-pub fn open_camera(model: String, port: String, special_handling: GPhoto2CameraSpecialHandling) -> Result<GPhoto2Camera> {
-  let camera = get_context()?.get_camera(&CameraDescriptor { model, port }).wait()?;
+pub async fn open_camera(model: String, port: String, special_handling: GPhoto2CameraSpecialHandling) -> Result<GPhoto2Camera> {
+  let camera_descriptor = get_context()?.list_cameras().await.expect("Could not enumerate cameras").into_iter().find(|camera| camera.model == model).expect("Could not find camera");
+  let camera = get_context()?.get_camera(&camera_descriptor).await?;
 
   Ok(GPhoto2Camera {
     camera,
@@ -42,31 +46,30 @@ pub fn open_camera(model: String, port: String, special_handling: GPhoto2CameraS
   })
 }
 
-pub fn start_liveview<F>(camera_ref: Arc<Mutex<GPhoto2Camera>>, frame_callback: F) -> Result<()> where F: Fn(Result<RawImage>) + Send + Sync + 'static {
-  let mut camera = camera_ref.lock().expect("Could not lock camera");
+pub async fn start_liveview<F>(camera_ref: Arc<AsyncMutex<GPhoto2Camera>>, frame_callback: F) -> Result<()> where F: Fn(Result<RawImage>) + Send + Sync + 'static {
+  let mut camera = camera_ref.lock().await;
 
   // TODO: check if join handle not already set
-
 
   match camera.special_handling {
     GPhoto2CameraSpecialHandling::None => {},
     GPhoto2CameraSpecialHandling::NikonDSLR => {
-      let opcode = camera.camera.config_key::<TextWidget>("opcode").wait()?;
+      let opcode = camera.camera.config_key::<TextWidget>("opcode").await?;
       opcode.set_value("0x9201")?;
-      camera.camera.set_config(&opcode).wait()?;
+      camera.camera.set_config(&opcode).await?;
     },
   }
   
   let camera_ref = camera_ref.clone();
-  let join_handle = thread::spawn(move || {
+  let join_handle = tokio::spawn(async move {
     let context = get_context().expect("TODO: handle this");
 
     loop {
-      let camera = camera_ref.lock().expect("Could not lock camera");
-      let preview = camera.camera.capture_preview().wait().expect("Could not capture preview");
+      let camera = camera_ref.lock().await;
+      let preview = camera.camera.capture_preview().await.expect("Could not capture preview");
       drop(camera);
 
-      let data = preview.get_data(&context).wait().expect("Could not get preview data");
+      let data = preview.get_data(&context).await.expect("Could not get preview data");
       let raw_image = jpeg::decode_jpeg_to_rgba(&data); // TODO: Handle errors (this should return Option<RawImage>)
       frame_callback(Ok(raw_image))
     }
@@ -77,29 +80,26 @@ pub fn start_liveview<F>(camera_ref: Arc<Mutex<GPhoto2Camera>>, frame_callback: 
   Ok(())
 }
 
-pub fn stop_liveview(camera_ref: Arc<Mutex<GPhoto2Camera>>) -> Result<()> {
-  let camera = camera_ref.lock().expect("Could not lock camera");
+pub async fn stop_liveview(camera_ref: Arc<AsyncMutex<GPhoto2Camera>>) -> Result<()> {
+  let camera = camera_ref.lock().await;
   camera.thread_should_stop.store(true, Ordering::SeqCst);
 
   let join_handle = camera.thread_join_handle.replace(None);
   match join_handle {
     Some(y) => {
-      y.join();
+      y.abort();
       Ok(())
     },
     None => Ok(()),
   }
 }
 
-pub fn capture_photo(camera_ref: Arc<Mutex<GPhoto2Camera>>) -> Result<Vec<u8>> {
-  let camera = camera_ref.lock().expect("Could not lock camera");
-  let capture = camera.camera.capture_image().wait()?;
+pub async fn capture_photo(camera_ref: Arc<AsyncMutex<GPhoto2Camera>>) -> Result<Vec<u8>> {
+  let camera = camera_ref.lock().await;
+  let capture = camera.camera.capture_image().await?;
   
-  let file = camera.camera
-    .fs()
-    .download(&capture.folder(), &capture.name())
-    .wait()?;
-  let data = file.get_data(get_context()?).wait()?;
+  let file = camera.camera.fs().download(&capture.folder(), &capture.name()).await?;
+  let data = file.get_data(get_context()?).await?;
 
   Ok(data.to_vec())
 }
@@ -121,7 +121,7 @@ impl GPhoto2CameraInfo {
 pub struct GPhoto2Camera {
   pub camera: Camera,
   pub special_handling: GPhoto2CameraSpecialHandling,
-  thread_join_handle: Cell<Option<JoinHandle<()>>>,
+  thread_join_handle: Cell<Option<AsyncJoinHandle<()>>>,
   thread_should_stop: AtomicBool,
 }
 

--- a/rust/src/hardware_control/live_view/gphoto2.rs
+++ b/rust/src/hardware_control/live_view/gphoto2.rs
@@ -1,6 +1,6 @@
 use std::{sync::{OnceLock, atomic::{AtomicBool, Ordering}, Arc}, any::Any, cell::Cell};
 
-use gphoto2::{Context, list::CameraDescriptor, widget::TextWidget, Camera, Error};
+use gphoto2::{Context, list::CameraDescriptor, widget::{TextWidget}, Camera, Error};
 
 use tokio::{sync::Mutex as AsyncMutex};
 use tokio::task::JoinHandle as AsyncJoinHandle;

--- a/rust/src/hardware_control/live_view/gphoto2.rs
+++ b/rust/src/hardware_control/live_view/gphoto2.rs
@@ -1,0 +1,53 @@
+use std::thread;
+
+use gphoto2::{Context, list::CameraDescriptor, widget::TextWidget};
+
+use crate::{utils::jpeg, dart_bridge::api::RawImage};
+
+pub fn get_cameras() -> Vec<Gphoto2CameraInfo> {
+  //env_logger::init();
+
+  let context = Context::new().expect("Could not create gphoto2 context");
+
+  println!("Available cameras:");
+  let mut cameras: Vec<Gphoto2CameraInfo> = Vec::new();
+  for CameraDescriptor { model, port } in context.list_cameras().wait().expect("Could not list cameras") {
+    cameras.push(Gphoto2CameraInfo::from_camera_descriptor(CameraDescriptor { model, port }));
+  }
+
+  cameras
+}
+
+pub fn open_camera_liveview<F>(model: String, port: String, frame_callback: F) where F: Fn(Option<RawImage>) + Send + Sync + 'static {
+  let context = Context::new().expect("Could not create gphoto2 context");
+
+  let camera = context.get_camera(&CameraDescriptor { model, port }).wait().expect("Could not open camera");
+  let opcode = camera.config_key::<TextWidget>("opcode").wait().expect("Could not get opcode");
+
+  println!("Starting live view");
+  opcode.set_value("0x9201").expect("Could not set opcode");
+  camera.set_config(&opcode).wait().expect("Could not set opcode");
+
+  thread::spawn(move || {
+    loop {
+      let preview = camera.capture_preview().wait().expect("Could not capture preview");
+      let data = preview.get_data(&context).wait().expect("Could not get preview data");
+      let raw_image = jpeg::decode_jpeg_to_rgba(&data); // TODO: Handle errors (this should return Option<RawImage>)
+      frame_callback(Some(raw_image))
+    }
+  });
+}
+
+pub struct Gphoto2CameraInfo {
+    pub port: String,
+    pub model: String,
+}
+
+impl Gphoto2CameraInfo {
+    pub fn from_camera_descriptor (camera_descriptor: CameraDescriptor) -> Self {
+        Self {
+            port: camera_descriptor.port,
+            model: camera_descriptor.model,
+        }
+    }
+}

--- a/rust/src/hardware_control/live_view/gphoto2.rs
+++ b/rust/src/hardware_control/live_view/gphoto2.rs
@@ -94,6 +94,21 @@ pub async fn stop_liveview(camera_ref: Arc<AsyncMutex<GPhoto2Camera>>) -> Result
   }
 }
 
+pub async fn auto_focus(camera_ref: Arc<AsyncMutex<GPhoto2Camera>>) -> Result<()> {
+  let camera = camera_ref.lock().await;
+  
+  match camera.special_handling {
+    GPhoto2CameraSpecialHandling::None => {},
+    GPhoto2CameraSpecialHandling::NikonDSLR => {
+      let opcode = camera.camera.config_key::<TextWidget>("opcode").await?;
+      opcode.set_value("0x90C1")?;
+      camera.camera.set_config(&opcode).await?;
+    },
+  }
+
+  Ok(())
+}
+
 pub async fn capture_photo(camera_ref: Arc<AsyncMutex<GPhoto2Camera>>) -> Result<Vec<u8>> {
   let camera = camera_ref.lock().await;
   let capture = camera.camera.capture_image().await?;

--- a/rust/src/hardware_control/live_view/mod.rs
+++ b/rust/src/hardware_control/live_view/mod.rs
@@ -1,3 +1,5 @@
 pub(crate) mod nokhwa;
 pub(crate) mod white_noise;
+
+#[cfg(any(not(target_os = "macos"), debug_assertions))]
 pub(crate) mod gphoto2;

--- a/rust/src/hardware_control/live_view/mod.rs
+++ b/rust/src/hardware_control/live_view/mod.rs
@@ -1,2 +1,3 @@
 pub(crate) mod nokhwa;
 pub(crate) mod white_noise;
+pub(crate) mod gphoto2;

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1,8 +1,9 @@
 use std::{sync::RwLock};
 
 use flutter_rust_bridge::StreamSink;
-use hardware_control::live_view::nokhwa;
+use hardware_control::live_view::{nokhwa};
 use pathsep::{path_separator, join_path};
+use crate::hardware_control::live_view::gphoto2;
 
 mod dart_bridge;
 mod hardware_control;
@@ -23,12 +24,12 @@ pub fn initialize_hardware(ready_sink: StreamSink<HardwareInitializationFinished
     log_debug("initialize_hardware() started".to_string());
 
     // gphoto2 initialize
-    #[cfg(any(target_os = "windows", target_os = "linux"))]
+    #[cfg(any(not(target_os = "macos"), debug_assertions))]
     {
-        let gphoto2_context = gphoto2::Context::new();
+        let initialize_result = gphoto2::initialize();
         ready_sink.add(HardwareInitializationFinishedEvent {
             step: HardwareInitializationStep::Gphoto2,
-            has_succeeded: gphoto2_context.is_ok(),
+            has_succeeded: initialize_result.is_ok(),
             message: String::new(),
         });
     }


### PR DESCRIPTION
This PR:
- Adds basic gPhoto2 support (atleast on Windows, Linux untested, macOS doesn't seem to compile at the moment)
- Adds support for specific Nikon DSLR commands (for live view enable, auto focus trigger)
- Add support for live view and HQ capture
- Adds a circular progress bar during capture photo load (only in single capture mode)
- Adds a step to the Windows build pipeline to bundle the necessary additional DLLs
- Updates some Dart and Rust packages