### PR TITLE
gPhoto2 environment variables and Settings screen fix

### DIFF
--- a/.github/workflows/release-win-x64.yml
+++ b/.github/workflows/release-win-x64.yml
@@ -100,7 +100,7 @@ jobs:
         echo "distributor_version=${release_version/-/+}" >> $GITHUB_OUTPUT
 
     - name: Build Project
-      run: msys2 -c 'flutter build windows --release --dart-define SENTRY_DSN=${{ secrets.SENTRY_DSN }} --dart-define SENTRY_ENVIRONMENT=Production --dart-define SENTRY_RELEASE=${{ steps.extract_release_version.outputs.distributor_version }}'
+      run: msys2 -c 'flutter build windows --release --dart-define SENTRY_DSN=${{ secrets.SENTRY_DSN }} --dart-define SENTRY_ENVIRONMENT=Production --dart-define SENTRY_RELEASE=${{ steps.extract_release_version.outputs.distributor_version }}' --dart-define IOLIBS=libgphoto2_iolibs --dart-define CAMLIBS=libgphoto2_camlibs
     
     - name: Bundle DLL dependencies of the helper library
       run: curl https://raw.githubusercontent.com/h3x4d3c1m4l/mingw-bundledlls/master/mingw-bundledlls | python - --copy build\windows\runner\Release\momento_booth_native_helpers.dll

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,7 +1,9 @@
 import 'dart:async';
+import 'dart:io';
 import 'dart:ui';
 
 import 'package:collection/collection.dart';
+import 'package:ffi/ffi.dart';
 import 'package:fluent_ui/fluent_ui.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
@@ -36,10 +38,13 @@ import 'package:momento_booth/views/start_screen/start_screen.dart';
 import 'package:go_router/go_router.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:win32/win32.dart';
 
 part 'main.routes.dart';
 
 void main() async {
+  _ensureGPhoto2EnvironmentVariables();
+
   WidgetsFlutterBinding.ensureInitialized();
 
   // Logging
@@ -69,6 +74,21 @@ void main() async {
     },
     appRunner: () => runApp(const App()),
   );
+}
+
+void _ensureGPhoto2EnvironmentVariables() {
+  if (!Platform.isWindows) return;
+
+  // Read from Dart defines
+  const String iolibsDefine = String.fromEnvironment("IOLIBS");
+  const String camlibsDefine = String.fromEnvironment("CAMLIBS");
+  if (iolibsDefine.isEmpty || camlibsDefine.isEmpty) return;
+
+  // Set to current process using win32 API
+  using((arena) {
+    SetEnvironmentVariable("IOLIBS".toNativeUtf16(allocator: arena), iolibsDefine.toNativeUtf16(allocator: arena));
+    SetEnvironmentVariable("CAMLIBS".toNativeUtf16(allocator: arena), camlibsDefine.toNativeUtf16(allocator: arena));
+  });
 }
 
 class App extends StatefulWidget {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -216,19 +216,21 @@ class _AppState extends State<App> with UiLoggy, WidgetsBindingObserver {
   }
 
   Widget get _settingsScreen {
-    return Container(
-      decoration: BoxDecoration(
-        borderRadius: BorderRadius.circular(16),
-        boxShadow: const [
-          BoxShadow(
-            blurRadius: 16,
-            spreadRadius: 0,
-          ),
-        ],
+    return FluentApp(
+      home: Container(
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(16),
+          boxShadow: const [
+            BoxShadow(
+              blurRadius: 16,
+              spreadRadius: 0,
+            ),
+          ],
+        ),
+        margin: const EdgeInsets.all(32),
+        clipBehavior: Clip.hardEdge,
+        child: const SettingsScreen(),
       ),
-      margin: const EdgeInsets.all(32),
-      clipBehavior: Clip.hardEdge,
-      child: const SettingsScreen(),
     );
   }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -217,6 +217,17 @@ class _AppState extends State<App> with UiLoggy, WidgetsBindingObserver {
 
   Widget get _settingsScreen {
     return FluentApp(
+      localizationsDelegates: const [
+        AppLocalizations.delegate,
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+        FluentLocalizations.delegate,
+      ],
+      supportedLocales: const [
+        Locale('en'), // English
+        Locale('nl'), // Dutch
+      ],
+      locale: SettingsManager.instance.settings.ui.language.toLocale(),
       home: Container(
         decoration: BoxDecoration(
           borderRadius: BorderRadius.circular(16),

--- a/lib/views/settings_screen/settings_screen_view.dart
+++ b/lib/views/settings_screen/settings_screen_view.dart
@@ -28,53 +28,50 @@ class SettingsScreenView extends ScreenViewBase<SettingsScreenViewModel, Setting
 
   @override
   Widget get body {
-    return PageStorage(
-      bucket: viewModel.pageStorageBucket,
-      child: Observer(
-        builder: (context) {
-          return NavigationView(
-            pane: NavigationPane(
-              selected: viewModel.paneIndex,
-              onChanged: controller.onNavigationPaneIndexChanged,
-              items: [
-                PaneItemSeparator(color: Colors.transparent),
-                PaneItem(
-                  icon: const Icon(FluentIcons.settings),
-                  title: const Text("General"),
-                  body: Builder(builder: (_) => _getGeneralSettings(viewModel, controller)),
-                ),
-                PaneItem(
-                  icon: const Icon(FluentIcons.devices4),
-                  title: const Text("Hardware"),
-                  body: Builder(builder: (_) => _getHardwareSettings(viewModel, controller)),
-                ),
-                PaneItem(
-                  icon: const Icon(FluentIcons.send),
-                  title: const Text("Output"),
-                  body: Builder(builder: (_) => _getOutputSettings(viewModel, controller)),
-                ),
-                PaneItem(
-                  icon: const Icon(FluentIcons.open_in_new_window),
-                  title: const Text("User interface"),
-                  body: Builder(builder: (_) => _getUiSettings(viewModel, controller)),
-                ),
-              ],
-              footerItems: [
-                PaneItem(
-                  icon: const Icon(FluentIcons.device_bug),
-                  title: const Text("Debug"),
-                  body: Builder(builder: (_) => _getDebugTab(viewModel, controller)),
-                ),
-                PaneItem(
-                  icon: const Icon(FluentIcons.data_flow),
-                  title: const Text("Log"),
-                  body: Builder(builder: (_) => _log),
-                ),
-              ],
-            ),
-          );
-        },
-      ),
+    return Observer(
+      builder: (context) {
+        return NavigationView(
+          pane: NavigationPane(
+            selected: viewModel.paneIndex,
+            onChanged: controller.onNavigationPaneIndexChanged,
+            items: [
+              PaneItemSeparator(color: Colors.transparent),
+              PaneItem(
+                icon: const Icon(FluentIcons.settings),
+                title: const Text("General"),
+                body: Builder(builder: (_) => _getGeneralSettings(viewModel, controller)),
+              ),
+              PaneItem(
+                icon: const Icon(FluentIcons.devices4),
+                title: const Text("Hardware"),
+                body: Builder(builder: (_) => _getHardwareSettings(viewModel, controller)),
+              ),
+              PaneItem(
+                icon: const Icon(FluentIcons.send),
+                title: const Text("Output"),
+                body: Builder(builder: (_) => _getOutputSettings(viewModel, controller)),
+              ),
+              PaneItem(
+                icon: const Icon(FluentIcons.open_in_new_window),
+                title: const Text("User interface"),
+                body: Builder(builder: (_) => _getUiSettings(viewModel, controller)),
+              ),
+            ],
+            footerItems: [
+              PaneItem(
+                icon: const Icon(FluentIcons.device_bug),
+                title: const Text("Debug"),
+                body: Builder(builder: (_) => _getDebugTab(viewModel, controller)),
+              ),
+              PaneItem(
+                icon: const Icon(FluentIcons.data_flow),
+                title: const Text("Log"),
+                body: Builder(builder: (_) => _log),
+              ),
+            ],
+          ),
+        );
+      },
     );
   }
 

--- a/lib/views/settings_screen/settings_screen_view_model.dart
+++ b/lib/views/settings_screen/settings_screen_view_model.dart
@@ -18,8 +18,6 @@ abstract class SettingsScreenViewModelBase extends ScreenViewModelBase with Stor
   @observable
   int paneIndex = 0;
 
-  PageStorageBucket pageStorageBucket = PageStorageBucket();
-
   // Option lists
 
   List<ComboBoxItem<LiveViewMethod>> get liveViewMethods => LiveViewMethod.asComboBoxItems();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -106,3 +106,4 @@ flutter:
       fonts:
         - asset: assets/fonts/brandon_grotesque/Brandon_light.otf
           weight: 300
+          


### PR DESCRIPTION
This PR:
- Undos the translations (not available) fix for the settings screen and adds a new fix that should not interfere with popups/overlays used by `fluent_ui` components in the Settings screen
- Adds default paths (as Dart defines) for the supporting libraries for libgphoto2, this should help the app find the right libraries in production independently from whatever environment variables are set globally

Still TODO: Actually bundle these supporting libraries...