### PR TITLE
Enable more linter rules, upgrade Flutter, minor workaround for the Manual College screen

### DIFF
--- a/.fvm/fvm_config.json
+++ b/.fvm/fvm_config.json
@@ -1,4 +1,4 @@
 {
-  "flutterSdkVersion": "3.10.5",
+  "flutterSdkVersion": "3.10.6",
   "flavors": {}
 }

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -12,17 +12,49 @@ analyzer:
 linter:
   # More info: https://dart.dev/tools/linter-rules
   rules:
+    - always_declare_return_types
     - always_use_package_imports
+    - avoid_bool_literals_in_conditional_expressions
     - avoid_dynamic_calls
+    - avoid_field_initializers_in_const_classes 
+    - avoid_private_typedef_functions
     - avoid_slow_async_io
-    # - cascade_invocations # Yet to decide
+    - avoid_types_on_closure_parameters
+    - avoid_unused_constructor_parameters
+    - avoid_void_async
+    - cascade_invocations
+    - cast_nullable_to_non_nullable
     - close_sinks
+    - combinators_ordering
+    - directives_ordering
     # - discarded_futures # Enable ASAP
     - eol_at_end_of_file
+    - join_return_with_assignment
+    - missing_whitespace_between_adjacent_strings
+    - noop_primitive_operations
+    - only_throw_errors
+    - parameter_assignments
+    - prefer_asserts_in_initializer_lists
+    - prefer_asserts_with_message
+    # - prefer_expression_function_bodies # Yet to decide
+    - prefer_null_aware_method_calls
+    - sized_box_shrink_expand
+    - unawaited_futures
+    - unnecessary_breaks
+    - unnecessary_lambdas
+    - unnecessary_null_aware_operator_on_extension_on_nullable
+    - unnecessary_null_checks
+    - unnecessary_parenthesis
+    - unnecessary_raw_strings
+    - unnecessary_statements
     - unreachable_from_main
     - use_enums
     - use_is_even_rather_than_modulo
-    - unnecessary_statements
+    - use_late_for_private_fields_and_variables
+    - use_named_constants
+    - use_string_buffers
+    - use_super_parameters
+    - use_to_and_as_if_applicable
 
 dart_code_metrics:
   rules:

--- a/lib/exceptions/default_setting_restore_exception.dart
+++ b/lib/exceptions/default_setting_restore_exception.dart
@@ -1,0 +1,10 @@
+class DefaultSettingRestoreException implements Exception {
+
+  final String message;
+
+  DefaultSettingRestoreException(this.message);
+
+  @override
+  String toString() => message;
+  
+}

--- a/lib/exceptions/live_view_initialization_exception.dart
+++ b/lib/exceptions/live_view_initialization_exception.dart
@@ -1,0 +1,21 @@
+class LiveViewInitializationException implements Exception {
+
+  final String message;
+  final String? liveViewImplementationName;
+
+  LiveViewInitializationException(this.message, {this.liveViewImplementationName});
+
+  factory LiveViewInitializationException.fromImplementationRuntimeType(
+    String message, [
+    Object? liveViewImplementationInstance,
+  ]
+  ) =>
+      LiveViewInitializationException(
+        message,
+        liveViewImplementationName: liveViewImplementationInstance.runtimeType.toString(),
+      );
+
+  @override
+  String toString() => "$message (Implementation: $liveViewImplementationName)";
+
+}

--- a/lib/exceptions/photo_capture_exception.dart
+++ b/lib/exceptions/photo_capture_exception.dart
@@ -1,0 +1,20 @@
+class PhotoCaptureException implements Exception {
+
+  final String message;
+  final String captureImplementationName;
+
+  PhotoCaptureException(this.message, {required this.captureImplementationName});
+
+  factory PhotoCaptureException.fromImplementationRuntimeType(
+    String message,
+    Object photoCaptureImplementationInstance,
+  ) =>
+      PhotoCaptureException(
+        message,
+        captureImplementationName: photoCaptureImplementationInstance.runtimeType.toString(),
+      );
+
+  @override
+  String toString() => "$message (Implementation: $captureImplementationName)";
+
+}

--- a/lib/exceptions/win32_exception.dart
+++ b/lib/exceptions/win32_exception.dart
@@ -1,0 +1,15 @@
+import 'package:win32/win32.dart';
+
+class Win32Exception implements Exception {
+
+  final String message;
+  final int win32ErrorCode;
+
+  Win32Exception(this.message, {required this.win32ErrorCode});
+
+  factory Win32Exception.fromLastError(String message) => Win32Exception(message, win32ErrorCode: GetLastError());
+
+  @override
+  String toString() => "$message (Error code: 0x${win32ErrorCode.toRadixString(16).padLeft(8, '0')})";
+
+}

--- a/lib/extensions/build_context_extension.dart
+++ b/lib/extensions/build_context_extension.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/widgets.dart';
+import 'package:go_router/go_router.dart';
 import 'package:momento_booth/theme/momento_booth_theme.dart';
 import 'package:momento_booth/theme/momento_booth_theme_data.dart';
-import 'package:go_router/go_router.dart';
 
 extension BuildContextExtension on BuildContext {
 

--- a/lib/hardware_control/photo_capturing/sony_remote_photo_capture.dart
+++ b/lib/hardware_control/photo_capturing/sony_remote_photo_capture.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 
 import 'package:flutter/services.dart';
 import 'package:loggy/loggy.dart';
+import 'package:momento_booth/exceptions/photo_capture_exception.dart';
 import 'package:momento_booth/hardware_control/photo_capturing/photo_capture_method.dart';
 import 'package:momento_booth/managers/settings_manager.dart';
 import 'package:path_provider/path_provider.dart';
@@ -30,7 +31,7 @@ class SonyRemotePhotoCapture extends PhotoCaptureMethod with UiLoggy {
     var autoItScriptPath = await _ensureAutoItScriptIsExtracted();
 
     // Execute the AutoIt script using the AutoIt executable
-    Process.run('autoit3.exe', ['/AutoIt3ExecuteScript', autoItScriptPath]);
+    unawaited(Process.run('autoit3.exe', ['/AutoIt3ExecuteScript', autoItScriptPath]));
   }
 
   Future<Uint8List> _getPhoto() async {
@@ -40,7 +41,7 @@ class SonyRemotePhotoCapture extends PhotoCaptureMethod with UiLoggy {
       loggy.debug('Photo found: ${file.path}');
       return img;
     } on TimeoutException {
-      throw 'File not found within 5 seconds';
+      throw PhotoCaptureException.fromImplementationRuntimeType('File not found within 5 seconds', this);
     }
   }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -111,6 +111,7 @@ class _AppState extends State<App> with UiLoggy, WidgetsBindingObserver {
   );
 
   bool _settingsOpen = false;
+  bool _manualCollageScreenOpen = false;
 
   static const returnHomeTimeout = Duration(seconds: 45);
   late Timer _returnHomeTimer;
@@ -154,6 +155,7 @@ class _AppState extends State<App> with UiLoggy, WidgetsBindingObserver {
     if (GoRouterState.of(context).location == StartScreen.defaultRoute) return;
     loggy.debug("No activity in $returnHomeTimeout, returning to homescreen");
     _router.go(StartScreen.defaultRoute);
+    _manualCollageScreenOpen = false;
   }
 
   /// Method that is fired when a user does any kind of touch or the route changes.
@@ -258,11 +260,20 @@ class _AppState extends State<App> with UiLoggy, WidgetsBindingObserver {
         setState(() => _settingsOpen = !_settingsOpen);
         loggy.debug("Settings ${_settingsOpen ? "opened" : "closed"}");
       case HotkeyAction.openManualCollageScreen:
-        if (GoRouterState.of(context).location == ManualCollageScreen.defaultRoute) {
+        // This currently fails due to: https://github.com/flutter/flutter/issues/130213
+        // if (GoRouterState.of(context).location == ManualCollageScreen.defaultRoute) {
+        //   _router.go(StartScreen.defaultRoute);
+        // } else {
+        //   _router.go(ManualCollageScreen.defaultRoute);
+        // }
+
+        // Workaround
+        if (_manualCollageScreenOpen) {
           _router.go(StartScreen.defaultRoute);
         } else {
           _router.go(ManualCollageScreen.defaultRoute);
         }
+        _manualCollageScreenOpen = !_manualCollageScreenOpen;
       case HotkeyAction.goToHomeScreen:
         _router.go(StartScreen.defaultRoute);
     }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,13 +5,15 @@ import 'dart:ui';
 import 'package:collection/collection.dart';
 import 'package:fluent_ui/fluent_ui.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_loggy/flutter_loggy.dart';
+import 'package:go_router/go_router.dart';
 import 'package:loggy/loggy.dart';
 import 'package:momento_booth/extensions/build_context_extension.dart';
+import 'package:momento_booth/managers/hotkey_manager.dart';
 import 'package:momento_booth/managers/live_view_manager.dart';
 import 'package:momento_booth/managers/notifications_manager.dart';
-import 'package:momento_booth/managers/hotkey_manager.dart';
 import 'package:momento_booth/managers/settings_manager.dart';
 import 'package:momento_booth/managers/stats_manager.dart';
 import 'package:momento_booth/managers/window_manager.dart';
@@ -32,12 +34,10 @@ import 'package:momento_booth/views/gallery_screen/gallery_screen.dart';
 import 'package:momento_booth/views/manual_collage_screen/manual_collage_screen.dart';
 import 'package:momento_booth/views/multi_capture_screen/multi_capture_screen.dart';
 import 'package:momento_booth/views/photo_details_screen/photo_details_screen.dart';
-import 'package:momento_booth/views/share_screen/share_screen.dart';
 import 'package:momento_booth/views/settings_screen/settings_screen.dart';
+import 'package:momento_booth/views/share_screen/share_screen.dart';
 import 'package:momento_booth/views/start_screen/start_screen.dart';
-import 'package:go_router/go_router.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 part 'main.routes.dart';
 
@@ -66,10 +66,11 @@ void main() async {
 
   await SentryFlutter.init(
     (options) {
-      options.tracesSampleRate = 1.0;
-      options.dsn = const String.fromEnvironment("SENTRY_DSN", defaultValue: "");
-      options.environment = const String.fromEnvironment("SENTRY_ENVIRONMENT", defaultValue: 'Development');
-      options.release = const String.fromEnvironment("SENTRY_RELEASE", defaultValue: 'Development');
+      options
+        ..tracesSampleRate = 1.0
+        ..dsn = const String.fromEnvironment("SENTRY_DSN", defaultValue: "")
+        ..environment = const String.fromEnvironment("SENTRY_ENVIRONMENT", defaultValue: 'Development')
+        ..release = const String.fromEnvironment("SENTRY_RELEASE", defaultValue: 'Development');
     },
     appRunner: () => runApp(const App()),
   );
@@ -91,7 +92,7 @@ void _ensureGPhoto2EnvironmentVariables() {
 
 class App extends StatefulWidget {
 
-  const App({Key? key}) : super(key: key);
+  const App({super.key});
 
   @override
   State<App> createState() => _AppState();
@@ -104,7 +105,7 @@ class _AppState extends State<App> with UiLoggy, WidgetsBindingObserver {
     routes: rootRoutes,
     observers: [
       GoRouterObserver(),
-      HeroController(createRectTween: (begin, end) => CustomRectTween(begin: begin!, end: end!)),
+      HeroController(createRectTween: (begin, end) => CustomRectTween(begin: begin, end: end)),
     ],
     initialLocation: StartScreen.defaultRoute,
   );
@@ -129,7 +130,7 @@ class _AppState extends State<App> with UiLoggy, WidgetsBindingObserver {
     super.initState();
   }
 
-  void _statusCheck() async {
+  Future<void> _statusCheck() async {
     final printerNames = SettingsManager.instance.settings.hardware.printerNames;
     final printersStatus = await compute(checkPrintersStatus, printerNames);
     NotificationsManager.instance.notifications.clear();
@@ -168,9 +169,7 @@ class _AppState extends State<App> with UiLoggy, WidgetsBindingObserver {
     return MomentoBoothTheme(
       data: MomentoBoothThemeData.defaults(),
       child: Builder(
-        builder: (BuildContext context) {
-          return _getWidgetsApp(context);
-        },
+        builder: _getWidgetsApp,
       ),
     );
   }
@@ -201,7 +200,7 @@ class _AppState extends State<App> with UiLoggy, WidgetsBindingObserver {
                   Listener(
                     behavior: HitTestBehavior.translucent,
                     onPointerDown: (_) => _onActivity(isTap: true),
-                    child: child!,
+                    child: child,
                   ),
                   _settingsOpen ? _settingsScreen : const SizedBox(),
                 ],

--- a/lib/managers/hotkey_manager.dart
+++ b/lib/managers/hotkey_manager.dart
@@ -28,7 +28,7 @@ abstract class _HotkeyManagerBase with Store, UiLoggy {
   // Initialization //
   // ////////////// //
 
-  KeyModifier get _defaultModifier => Platform.isMacOS ? KeyModifier.meta : KeyModifier.control;
+  static final KeyModifier _defaultModifier = Platform.isMacOS ? KeyModifier.meta : KeyModifier.control;
 
   Future<void> initialize() async {
     await hotKeyManager.unregisterAll();

--- a/lib/managers/live_view_manager.dart
+++ b/lib/managers/live_view_manager.dart
@@ -2,13 +2,13 @@ import 'dart:async';
 
 import 'package:collection/collection.dart';
 import 'package:loggy/loggy.dart';
+import 'package:mobx/mobx.dart';
 import 'package:momento_booth/extensions/camera_state_extension.dart';
 import 'package:momento_booth/hardware_control/gphoto2_camera.dart';
 import 'package:momento_booth/hardware_control/live_view_streaming/live_view_source.dart';
 import 'package:momento_booth/hardware_control/live_view_streaming/noise_source.dart';
-import 'package:momento_booth/managers/settings_manager.dart';
 import 'package:momento_booth/hardware_control/live_view_streaming/nokhwa_camera.dart';
-import 'package:mobx/mobx.dart';
+import 'package:momento_booth/managers/settings_manager.dart';
 import 'package:momento_booth/managers/stats_manager.dart';
 import 'package:momento_booth/models/settings.dart';
 import 'package:synchronized/synchronized.dart';
@@ -121,8 +121,6 @@ abstract class _LiveViewManagerBase with Store, UiLoggy {
           _currentLiveViewSource = cameras.firstWhereOrNull((camera) => camera.friendlyName == webcamIdSetting);
         case LiveViewMethod.gphoto2:
           _currentLiveViewSource = _gPhoto2Camera;
-        default:
-          throw "Unknown live view method";
       }
 
       await _ensureTextureAvailable();
@@ -134,7 +132,7 @@ abstract class _LiveViewManagerBase with Store, UiLoggy {
   }
 
   Future<void> _checkLiveViewState() async {
-    _lock.synchronized(() async {
+    await _lock.synchronized(() async {
       var liveViewState = await _currentLiveViewSource?.getCameraState();
       if (liveViewState == null) return;
 

--- a/lib/managers/photos_manager.dart
+++ b/lib/managers/photos_manager.dart
@@ -1,8 +1,8 @@
 import 'dart:io';
 import 'dart:typed_data';
 
-import 'package:momento_booth/managers/settings_manager.dart';
 import 'package:mobx/mobx.dart';
+import 'package:momento_booth/managers/settings_manager.dart';
 import 'package:momento_booth/utils/hardware.dart';
 import 'package:path/path.dart' show basename, join; // Without show mobx complains
 import 'package:path_provider/path_provider.dart';

--- a/lib/managers/settings_manager.dart
+++ b/lib/managers/settings_manager.dart
@@ -1,10 +1,10 @@
 import 'dart:io';
 
 import 'package:loggy/loggy.dart';
-import 'package:momento_booth/models/settings.dart';
 import 'package:mobx/mobx.dart';
-import 'package:path_provider/path_provider.dart';
+import 'package:momento_booth/models/settings.dart';
 import 'package:path/path.dart' hide context;
+import 'package:path_provider/path_provider.dart';
 import 'package:toml/toml.dart';
 
 part 'settings_manager.g.dart';
@@ -77,7 +77,7 @@ abstract class _SettingsManagerBase with Store, UiLoggy {
     Map<String, dynamic> settingsMap = _settings!.toJson();
     TomlDocument settingsDocument = TomlDocument.fromMap(settingsMap);
     String settingsAsToml = settingsDocument.toString();
-    _settingsFile.writeAsString(settingsAsToml);
+    await _settingsFile.writeAsString(settingsAsToml);
 
     loggy.debug("Saved settings");
   }

--- a/lib/models/settings.dart
+++ b/lib/models/settings.dart
@@ -1,15 +1,16 @@
 import 'dart:io';
+import 'dart:ui' as ui;
 
 import 'package:fluent_ui/fluent_ui.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:momento_booth/exceptions/default_setting_restore_exception.dart';
 import 'package:momento_booth/rust_bridge/library_api.generated.dart';
 import 'package:path/path.dart';
 import 'package:toml/toml.dart';
-import 'dart:ui' as ui;
 
+part 'settings.enums.dart';
 part 'settings.freezed.dart';
 part 'settings.g.dart';
-part 'settings.enums.dart';
 
 // ///////////// //
 // Root settings //
@@ -143,7 +144,7 @@ String _getHome() {
   } else if (Platform.isWindows) {
     return envVars['UserProfile']!;
   }
-  throw 'Could not find the user\'s home folder: Platform unsupported';
+  throw DefaultSettingRestoreException('Could not find the user\'s home folder: Platform unsupported');
 }
 
 // /////////// //

--- a/lib/rust_bridge/library_bridge.dart
+++ b/lib/rust_bridge/library_bridge.dart
@@ -15,32 +15,26 @@ final rustLibraryApi = MomentoBoothNativeHelpersImpl(_dylib);
 
 Future<void> init() async {
   // Initialize log
-  Stream<LogEvent> logStream = rustLibraryApi.initializeLog();
-  logStream.listen(processLogEvent);
+  rustLibraryApi.initializeLog().listen(processLogEvent);
 
   // Initialize hardware
-  Stream<HardwareInitializationFinishedEvent> hardwareInitResultStream = rustLibraryApi.initializeHardware();
-  hardwareInitResultStream.listen(processHardwareInitEvent);
+  rustLibraryApi.initializeHardware().listen(processHardwareInitEvent);
 }
 
 void processLogEvent(LogEvent event) {
   switch (event.level) {
     case LogLevel.Debug:
       loggy.logDebug("Lib: ${event.message}");
-      break;
     case LogLevel.Info:
       loggy.logInfo("Lib: ${event.message}");
-      break;
     case LogLevel.Warning:
       loggy.logWarning("Lib: ${event.message}");
-      break;
     case LogLevel.Error:
       loggy.logError("Lib: ${event.message}");
-      break;
   }
 }
 
-void processHardwareInitEvent(HardwareInitializationFinishedEvent event) async {
+void processHardwareInitEvent(HardwareInitializationFinishedEvent event) {
   switch (event.step) {
     
     case HardwareInitializationStep.Nokhwa:

--- a/lib/utils/environment_variables.dart
+++ b/lib/utils/environment_variables.dart
@@ -7,10 +7,8 @@ import 'package:ffi/ffi.dart';
 
 final DynamicLibrary msvcrt = Platform.isWindows ? DynamicLibrary.open('msvcrt.dll') : DynamicLibrary.process();
 
-typedef _putenv_s_func = Int32 Function(Pointer<Utf8> e, Pointer<Utf8> v);
-typedef _putenv_s_func_dart = int Function(Pointer<Utf8> e, Pointer<Utf8> v);
 
-final _putenv_s = msvcrt.lookupFunction<_putenv_s_func, _putenv_s_func_dart>('_putenv_s');
+final _putenv_s = msvcrt.lookupFunction<Int32 Function(Pointer<Utf8>, Pointer<Utf8>), int Function(Pointer<Utf8>, Pointer<Utf8>)>('_putenv_s');
 
 int putenv_s(String e, String v) {
   return using((arena) {

--- a/lib/views/base/build_context_abstractor.dart
+++ b/lib/views/base/build_context_abstractor.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/widgets.dart';
+import 'package:go_router/go_router.dart';
 import 'package:momento_booth/app_localizations.dart';
 import 'package:momento_booth/extensions/build_context_extension.dart';
 import 'package:momento_booth/theme/momento_booth_theme_data.dart';
 import 'package:momento_booth/views/base/build_context_accessor.dart';
-import 'package:go_router/go_router.dart';
 
 mixin BuildContextAbstractor {
 

--- a/lib/views/base/screen_controller_base.dart
+++ b/lib/views/base/screen_controller_base.dart
@@ -1,7 +1,7 @@
-import 'package:momento_booth/views/base/build_context_accessor.dart';
-import 'package:momento_booth/views/base/build_context_abstractor.dart';
-import 'package:momento_booth/views/base/screen_view_model_base.dart';
 import 'package:meta/meta.dart';
+import 'package:momento_booth/views/base/build_context_abstractor.dart';
+import 'package:momento_booth/views/base/build_context_accessor.dart';
+import 'package:momento_booth/views/base/screen_view_model_base.dart';
 
 abstract class ScreenControllerBase<T extends ScreenViewModelBase> with BuildContextAbstractor {
 

--- a/lib/views/base/screen_view_model_base.dart
+++ b/lib/views/base/screen_view_model_base.dart
@@ -1,6 +1,6 @@
-import 'package:momento_booth/views/base/build_context_accessor.dart';
-import 'package:momento_booth/views/base/build_context_abstractor.dart';
 import 'package:meta/meta.dart';
+import 'package:momento_booth/views/base/build_context_abstractor.dart';
+import 'package:momento_booth/views/base/build_context_accessor.dart';
 
 abstract class ScreenViewModelBase with BuildContextAbstractor {
 

--- a/lib/views/capture_screen/capture_screen_view_model.dart
+++ b/lib/views/capture_screen/capture_screen_view_model.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 
 import 'package:flutter/widgets.dart';
 import 'package:loggy/loggy.dart';
+import 'package:mobx/mobx.dart';
 import 'package:momento_booth/hardware_control/photo_capturing/live_view_stream_snapshot_capturer.dart';
 import 'package:momento_booth/hardware_control/photo_capturing/photo_capture_method.dart';
 import 'package:momento_booth/hardware_control/photo_capturing/sony_remote_photo_capture.dart';
@@ -10,10 +11,9 @@ import 'package:momento_booth/managers/live_view_manager.dart';
 import 'package:momento_booth/managers/photos_manager.dart';
 import 'package:momento_booth/managers/settings_manager.dart';
 import 'package:momento_booth/managers/stats_manager.dart';
-import 'package:momento_booth/views/base/screen_view_model_base.dart';
 import 'package:momento_booth/models/settings.dart';
+import 'package:momento_booth/views/base/screen_view_model_base.dart';
 import 'package:momento_booth/views/custom_widgets/photo_collage.dart';
-import 'package:mobx/mobx.dart';
 import 'package:momento_booth/views/share_screen/share_screen.dart';
 
 part 'capture_screen_view_model.g.dart';
@@ -84,14 +84,14 @@ abstract class CaptureScreenViewModelBase extends ScreenViewModelBase with Store
     capturer = switch (SettingsManager.instance.settings.hardware.captureMethod) {
       CaptureMethod.sonyImagingEdgeDesktop => SonyRemotePhotoCapture(SettingsManager.instance.settings.hardware.captureLocation),
       CaptureMethod.liveViewSource => LiveViewStreamSnapshotCapturer(),
-      CaptureMethod.gPhoto2 => LiveViewManager.instance.gPhoto2Camera,
+      CaptureMethod.gPhoto2 => LiveViewManager.instance.gPhoto2Camera!,
     } as PhotoCaptureMethod;
     Future.delayed(photoDelay).then((_) => captureAndGetPhoto());
   }
 
   String get outputFolder => SettingsManager.instance.settings.output.localFolder;
 
-  void onCounterFinished() async {
+  Future<void> onCounterFinished() async {
     showFlash = true;
     showCounter = false;
     await Future.delayed(flashAnimationDuration);
@@ -102,7 +102,7 @@ abstract class CaptureScreenViewModelBase extends ScreenViewModelBase with Store
     navigateAfterCapture();
   }
 
-  void captureAndGetPhoto() async {
+  Future<void> captureAndGetPhoto() async {
     try {
       final image = await capturer.captureAndGetPhoto();
       StatsManager.instance.addCapturedPhoto();

--- a/lib/views/choose_capture_mode_screen/choose_capture_mode_screen_view_model.dart
+++ b/lib/views/choose_capture_mode_screen/choose_capture_mode_screen_view_model.dart
@@ -1,6 +1,6 @@
 import 'package:auto_size_text/auto_size_text.dart';
-import 'package:momento_booth/views/base/screen_view_model_base.dart';
 import 'package:mobx/mobx.dart';
+import 'package:momento_booth/views/base/screen_view_model_base.dart';
 
 part 'choose_capture_mode_screen_view_model.g.dart';
 

--- a/lib/views/collage_maker_screen/collage_maker_screen.dart
+++ b/lib/views/collage_maker_screen/collage_maker_screen.dart
@@ -1,8 +1,8 @@
 import 'package:momento_booth/views/base/build_context_accessor.dart';
 import 'package:momento_booth/views/base/screen_base.dart';
 import 'package:momento_booth/views/collage_maker_screen/collage_maker_screen_controller.dart';
-import 'package:momento_booth/views/collage_maker_screen/collage_maker_screen_view_model.dart';
 import 'package:momento_booth/views/collage_maker_screen/collage_maker_screen_view.dart';
+import 'package:momento_booth/views/collage_maker_screen/collage_maker_screen_view_model.dart';
 
 class CollageMakerScreen extends ScreenBase<CollageMakerScreenViewModel, CollageMakerScreenController, CollageMakerScreenView> {
 

--- a/lib/views/collage_maker_screen/collage_maker_screen_controller.dart
+++ b/lib/views/collage_maker_screen/collage_maker_screen_controller.dart
@@ -33,7 +33,7 @@ class CollageMakerScreenController extends ScreenControllerBase<CollageMakerScre
 
   DateTime? latestCapture;
 
-  void captureCollage() async {
+  Future<void> captureCollage() async {
     viewModel.readyToContinue = false;
     
     // It can happen that a previous capture takes longer than the latest one.
@@ -53,7 +53,7 @@ class CollageMakerScreenController extends ScreenControllerBase<CollageMakerScre
     if (latestCapture == thisCapture) {
       PhotosManager.instance.outputImage = exportImage;
       loggy.debug("Written collage image to output image memory");
-      PhotosManager.instance.writeOutput();
+      await PhotosManager.instance.writeOutput();
       viewModel.readyToContinue = true;
     }
   }

--- a/lib/views/collage_maker_screen/collage_maker_screen_view.dart
+++ b/lib/views/collage_maker_screen/collage_maker_screen_view.dart
@@ -98,7 +98,7 @@ class CollageMakerScreenView extends ScreenViewBase<CollageMakerScreenViewModel,
         for (int i = 0; i < PhotosManager.instance.photos.length; i++)
           GestureDetector(
             onTap: () => controller.togglePicture(i),
-            child: Observer(builder: (BuildContext context) {
+            child: Observer(builder: (context) {
               return Stack(
                 children: [
                   ImageWithLoaderFallback.memory(PhotosManager.instance.photos[i]),

--- a/lib/views/collage_maker_screen/collage_maker_screen_view_model.dart
+++ b/lib/views/collage_maker_screen/collage_maker_screen_view_model.dart
@@ -1,7 +1,7 @@
+import 'package:mobx/mobx.dart';
 import 'package:momento_booth/managers/photos_manager.dart';
 import 'package:momento_booth/managers/settings_manager.dart';
 import 'package:momento_booth/views/base/screen_view_model_base.dart';
-import 'package:mobx/mobx.dart';
 
 part 'collage_maker_screen_view_model.g.dart';
 

--- a/lib/views/custom_widgets/photo_collage.dart
+++ b/lib/views/custom_widgets/photo_collage.dart
@@ -3,8 +3,12 @@ import 'dart:typed_data';
 import 'dart:ui' as ui;
 
 import 'package:auto_size_text/auto_size_text.dart';
+import 'package:flutter/material.dart' hide Action, RawImage;
+import 'package:flutter_layout_grid/flutter_layout_grid.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
+import 'package:flutter_svg/flutter_svg.dart';
 import 'package:loggy/loggy.dart';
+import 'package:mobx/mobx.dart';
 import 'package:momento_booth/app_localizations.dart';
 import 'package:momento_booth/managers/photos_manager.dart';
 import 'package:momento_booth/managers/settings_manager.dart';
@@ -12,10 +16,6 @@ import 'package:momento_booth/models/settings.dart';
 import 'package:momento_booth/rust_bridge/library_api.generated.dart';
 import 'package:momento_booth/rust_bridge/library_bridge.dart';
 import 'package:momento_booth/theme/momento_booth_theme_data.dart';
-import 'package:flutter/material.dart' hide Action, RawImage;
-import 'package:flutter_layout_grid/flutter_layout_grid.dart';
-import 'package:flutter_svg/flutter_svg.dart';
-import 'package:mobx/mobx.dart';
 import 'package:momento_booth/views/custom_widgets/image_with_loader_fallback.dart';
 import 'package:path/path.dart';
 import 'package:screenshot/screenshot.dart';
@@ -100,7 +100,7 @@ class PhotoCollageState extends State<PhotoCollage> with UiLoggy {
     TemplateKind.back: <int, File?>{},
   };
   
-  void findTemplates() async {
+  Future<void> findTemplates() async {
     if (widget.singleMode) {
       templates[TemplateKind.front]?[1] = await _templateResolver(TemplateKind.front, 1);
       templates[TemplateKind.back]?[1] = await _templateResolver(TemplateKind.back, 1);
@@ -156,7 +156,7 @@ class PhotoCollageState extends State<PhotoCollage> with UiLoggy {
           if (initialized > 0 && templates[TemplateKind.back]?[i] != null)
             Opacity(
               opacity: i == nChosen && widget.showBackground ? 1 : 0,
-              child: ImageWithLoaderFallback.file(templates[TemplateKind.back]![i]!, fit: BoxFit.cover),
+              child: ImageWithLoaderFallback.file(templates[TemplateKind.back]?[i], fit: BoxFit.cover),
             ),
         ],
         if (widget.debug == null)
@@ -181,7 +181,7 @@ class PhotoCollageState extends State<PhotoCollage> with UiLoggy {
           if (initialized > 0 && templates[TemplateKind.front]?[i] != null)
             Opacity(
               opacity: i == nChosen && widget.showForeground ? 1 : 0,
-              child: ImageWithLoaderFallback.file(templates[TemplateKind.front]![i]!, fit: BoxFit.cover),
+              child: ImageWithLoaderFallback.file(templates[TemplateKind.front]?[i], fit: BoxFit.cover),
             ),
         ],
       ]

--- a/lib/views/gallery_screen/gallery_screen.dart
+++ b/lib/views/gallery_screen/gallery_screen.dart
@@ -1,8 +1,8 @@
 import 'package:momento_booth/views/base/build_context_accessor.dart';
 import 'package:momento_booth/views/base/screen_base.dart';
 import 'package:momento_booth/views/gallery_screen/gallery_screen_controller.dart';
-import 'package:momento_booth/views/gallery_screen/gallery_screen_view_model.dart';
 import 'package:momento_booth/views/gallery_screen/gallery_screen_view.dart';
+import 'package:momento_booth/views/gallery_screen/gallery_screen_view_model.dart';
 
 class GalleryScreen extends ScreenBase<GalleryScreenViewModel, GalleryScreenController, GalleryScreenView> {
 

--- a/lib/views/gallery_screen/gallery_screen_view_model.dart
+++ b/lib/views/gallery_screen/gallery_screen_view_model.dart
@@ -1,9 +1,9 @@
 import 'dart:io';
 
+import 'package:mobx/mobx.dart';
 import 'package:momento_booth/managers/photos_manager.dart';
 import 'package:momento_booth/managers/settings_manager.dart';
 import 'package:momento_booth/views/base/screen_view_model_base.dart';
-import 'package:mobx/mobx.dart';
 import 'package:path/path.dart' hide context;
 
 part 'gallery_screen_view_model.g.dart';

--- a/lib/views/manual_collage_screen/manual_collage_screen.dart
+++ b/lib/views/manual_collage_screen/manual_collage_screen.dart
@@ -1,8 +1,8 @@
 import 'package:momento_booth/views/base/build_context_accessor.dart';
 import 'package:momento_booth/views/base/screen_base.dart';
 import 'package:momento_booth/views/manual_collage_screen/manual_collage_screen_controller.dart';
-import 'package:momento_booth/views/manual_collage_screen/manual_collage_screen_view_model.dart';
 import 'package:momento_booth/views/manual_collage_screen/manual_collage_screen_view.dart';
+import 'package:momento_booth/views/manual_collage_screen/manual_collage_screen_view_model.dart';
 
 class ManualCollageScreen extends ScreenBase<ManualCollageScreenViewModel, ManualCollageScreenController, ManualCollageScreenView> {
   

--- a/lib/views/manual_collage_screen/manual_collage_screen_controller.dart
+++ b/lib/views/manual_collage_screen/manual_collage_screen_controller.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/widgets.dart';
 import 'package:loggy/loggy.dart';
 import 'package:momento_booth/managers/photos_manager.dart';
@@ -36,7 +38,7 @@ class ManualCollageScreenController extends ScreenControllerBase<ManualCollageSc
     loggy.debug("Cleared selection");
   }
 
-  void tapPhoto(SelectableImage file) async {
+  Future<void> tapPhoto(SelectableImage file) async {
     loggy.debug("Tapped image #${file.index} (${basename(file.file.path)}), selected: ${file.isSelected} at index ${file.selectedIndex}");
     
     final index = selectedPhotos.length;
@@ -55,8 +57,9 @@ class ManualCollageScreenController extends ScreenControllerBase<ManualCollageSc
       if (index > 3) return;
 
       selectedPhotos.add(file);
-      file.isSelected = true;
-      file.selectedIndex = index;
+      file
+        ..isSelected = true
+        ..selectedIndex = index;
       PhotosManager.instance.photos.add(await file.file.readAsBytes());
       PhotosManager.instance.chosen.add(index);
       viewModel.numSelected = index+1;
@@ -65,7 +68,7 @@ class ManualCollageScreenController extends ScreenControllerBase<ManualCollageSc
 
   String get outputFolder => SettingsManager.instance.settings.output.localFolder;
 
-  void captureCollage() async {
+  Future<void> captureCollage() async {
     if (viewModel.numSelected < 1 || viewModel.isSaving) return;
 
     viewModel.isSaving = true;
@@ -77,7 +80,7 @@ class ManualCollageScreenController extends ScreenControllerBase<ManualCollageSc
     loggy.debug('captureCollage took ${stopwatch.elapsed}');
   
     PhotosManager.instance.outputImage = exportImage;
-    PhotosManager.instance.writeOutput(advance: true);
+    unawaited(PhotosManager.instance.writeOutput(advance: true));
     loggy.debug("Saved collage image to disk");
     viewModel.isSaving = false;
   }

--- a/lib/views/manual_collage_screen/manual_collage_screen_controller.dart
+++ b/lib/views/manual_collage_screen/manual_collage_screen_controller.dart
@@ -80,7 +80,7 @@ class ManualCollageScreenController extends ScreenControllerBase<ManualCollageSc
     loggy.debug('captureCollage took ${stopwatch.elapsed}');
   
     PhotosManager.instance.outputImage = exportImage;
-    unawaited(PhotosManager.instance.writeOutput(advance: true));
+    await PhotosManager.instance.writeOutput(advance: true);
     loggy.debug("Saved collage image to disk");
     viewModel.isSaving = false;
   }

--- a/lib/views/manual_collage_screen/manual_collage_screen_view_model.dart
+++ b/lib/views/manual_collage_screen/manual_collage_screen_view_model.dart
@@ -1,9 +1,9 @@
 import 'dart:io';
 
 import 'package:loggy/loggy.dart';
+import 'package:mobx/mobx.dart';
 import 'package:momento_booth/managers/settings_manager.dart';
 import 'package:momento_booth/views/base/screen_view_model_base.dart';
-import 'package:mobx/mobx.dart';
 
 part 'manual_collage_screen_view_model.g.dart';
 

--- a/lib/views/multi_capture_screen/multi_capture_screen_view.dart
+++ b/lib/views/multi_capture_screen/multi_capture_screen_view.dart
@@ -4,11 +4,11 @@ import 'package:fluent_ui/fluent_ui.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
 import 'package:momento_booth/managers/photos_manager.dart';
 import 'package:momento_booth/views/base/screen_view_base.dart';
+import 'package:momento_booth/views/custom_widgets/capture_counter.dart';
 import 'package:momento_booth/views/custom_widgets/image_with_loader_fallback.dart';
 import 'package:momento_booth/views/custom_widgets/wrappers/live_view_background.dart';
 import 'package:momento_booth/views/multi_capture_screen/multi_capture_screen_controller.dart';
 import 'package:momento_booth/views/multi_capture_screen/multi_capture_screen_view_model.dart';
-import 'package:momento_booth/views/custom_widgets/capture_counter.dart';
 
 class MultiCaptureScreenView extends ScreenViewBase<MultiCaptureScreenViewModel, MultiCaptureScreenController> {
   const MultiCaptureScreenView({

--- a/lib/views/multi_capture_screen/multi_capture_screen_view_model.dart
+++ b/lib/views/multi_capture_screen/multi_capture_screen_view_model.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:flutter/animation.dart';
 import 'package:loggy/loggy.dart';
+import 'package:mobx/mobx.dart';
 import 'package:momento_booth/hardware_control/photo_capturing/live_view_stream_snapshot_capturer.dart';
 import 'package:momento_booth/hardware_control/photo_capturing/photo_capture_method.dart';
 import 'package:momento_booth/hardware_control/photo_capturing/sony_remote_photo_capture.dart';
@@ -9,9 +10,8 @@ import 'package:momento_booth/managers/live_view_manager.dart';
 import 'package:momento_booth/managers/photos_manager.dart';
 import 'package:momento_booth/managers/settings_manager.dart';
 import 'package:momento_booth/managers/stats_manager.dart';
-import 'package:momento_booth/views/base/screen_view_model_base.dart';
 import 'package:momento_booth/models/settings.dart';
-import 'package:mobx/mobx.dart';
+import 'package:momento_booth/views/base/screen_view_model_base.dart';
 import 'package:momento_booth/views/collage_maker_screen/collage_maker_screen.dart';
 import 'package:momento_booth/views/multi_capture_screen/multi_capture_screen.dart';
 
@@ -62,12 +62,12 @@ abstract class MultiCaptureScreenViewModelBase extends ScreenViewModelBase with 
     capturer = switch (SettingsManager.instance.settings.hardware.captureMethod) {
       CaptureMethod.liveViewSource => LiveViewStreamSnapshotCapturer(),
       CaptureMethod.sonyImagingEdgeDesktop => SonyRemotePhotoCapture(SettingsManager.instance.settings.hardware.captureLocation),
-      CaptureMethod.gPhoto2 => LiveViewManager.instance.gPhoto2Camera,
+      CaptureMethod.gPhoto2 => LiveViewManager.instance.gPhoto2Camera!,
     } as PhotoCaptureMethod;
     Future.delayed(photoDelay).then((_) => captureAndGetPhoto());
   }
 
-  void onCounterFinished() async {
+  Future<void> onCounterFinished() async {
     showFlash = true;
     showCounter = false;
     await Future.delayed(flashAnimationDuration);
@@ -78,7 +78,7 @@ abstract class MultiCaptureScreenViewModelBase extends ScreenViewModelBase with 
     navigateAfterCapture();
   }
 
-  void captureAndGetPhoto() async {
+  Future<void> captureAndGetPhoto() async {
     try {
       final image = await capturer.captureAndGetPhoto();
       StatsManager.instance.addCapturedPhoto();

--- a/lib/views/photo_details_screen/photo_details_screen.dart
+++ b/lib/views/photo_details_screen/photo_details_screen.dart
@@ -1,8 +1,8 @@
 import 'package:momento_booth/views/base/build_context_accessor.dart';
 import 'package:momento_booth/views/base/screen_base.dart';
 import 'package:momento_booth/views/photo_details_screen/photo_details_screen_controller.dart';
-import 'package:momento_booth/views/photo_details_screen/photo_details_screen_view_model.dart';
 import 'package:momento_booth/views/photo_details_screen/photo_details_screen_view.dart';
+import 'package:momento_booth/views/photo_details_screen/photo_details_screen_view_model.dart';
 
 class PhotoDetailsScreen extends ScreenBase<PhotoDetailsScreenViewModel, PhotoDetailsScreenController, PhotoDetailsScreenView> {
   

--- a/lib/views/photo_details_screen/photo_details_screen_controller.dart
+++ b/lib/views/photo_details_screen/photo_details_screen_controller.dart
@@ -28,7 +28,7 @@ class PhotoDetailsScreenController extends ScreenControllerBase<PhotoDetailsScre
     viewModel.sliderKey.currentState!.animateBackward();
   }
   
-  void onClickGetQR() async {
+  Future<void> onClickGetQR() async {
     if (viewModel.uploadState == UploadState.done) {
       viewModel.qrShown = true;
       viewModel.sliderKey.currentState!.animateForward();
@@ -40,16 +40,22 @@ class PhotoDetailsScreenController extends ScreenControllerBase<PhotoDetailsScre
 
     loggy.debug("Uploading ${file.path}");
     var stream = rustLibraryApi.ffsendUploadFile(filePath: file.path, hostUrl: ffSendUrl, downloadFilename: "MomentoBooth image.$ext");
-    viewModel.qrText = localizations.photoDetailsScreenQrUploading;
-    viewModel.uploadState = UploadState.uploading;
+
+    viewModel
+      ..qrText = localizations.photoDetailsScreenQrUploading
+      ..uploadState = UploadState.uploading;
+
     stream.listen((event) {
       if (event.isFinished) {
         loggy.debug("Upload complete: ${event.downloadUrl}");
-        viewModel.uploadState = UploadState.done;
-        viewModel.qrText = localizations.photoDetailsScreenShowQrButton;
-        viewModel.qrUrl = event.downloadUrl!;
-        viewModel.qrShown = true;
-        viewModel.sliderKey.currentState!.animateForward();
+
+        viewModel
+          ..uploadState = UploadState.done
+          ..qrText = localizations.photoDetailsScreenShowQrButton
+          ..qrUrl = event.downloadUrl!
+          ..qrShown = true
+          ..sliderKey.currentState!.animateForward();
+
         StatsManager.instance.addUploadedPhoto();
       } else {
         loggy.debug("Uploading: ${event.transferredBytes}/${event.totalBytes} bytes");
@@ -64,16 +70,19 @@ class PhotoDetailsScreenController extends ScreenControllerBase<PhotoDetailsScre
   static const _printTextDuration = Duration(seconds: 4);
 
   void resetPrint() {
-    viewModel.printText = successfulPrints > 0 ? "${localizations.genericPrintButton} +1" : localizations.genericPrintButton;
-    viewModel.printEnabled = true;
+    viewModel
+      ..printText = successfulPrints > 0 ? "${localizations.genericPrintButton} +1" : localizations.genericPrintButton
+      ..printEnabled = true;
   }
 
   Future<void> onClickPrint() async {
     if (!viewModel.printEnabled) return;
 
     loggy.debug("Printing photo");
-    viewModel.printEnabled = false;
-    viewModel.printText = localizations.photoDetailsScreenPrinting;
+
+    viewModel
+      ..printEnabled = false
+      ..printText = localizations.photoDetailsScreenPrinting;
 
     // Get photo and print it.
     final pdfData = await getImagePDF(await viewModel.file.readAsBytes());

--- a/lib/views/photo_details_screen/photo_details_screen_view.dart
+++ b/lib/views/photo_details_screen/photo_details_screen_view.dart
@@ -1,8 +1,8 @@
 import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
-import 'package:momento_booth/views/base/settings_based_transition_page.dart';
 import 'package:momento_booth/views/base/screen_view_base.dart';
+import 'package:momento_booth/views/base/settings_based_transition_page.dart';
 import 'package:momento_booth/views/custom_widgets/image_with_loader_fallback.dart';
 import 'package:momento_booth/views/custom_widgets/wrappers/animated_box_decoration_hero.dart';
 import 'package:momento_booth/views/custom_widgets/wrappers/delayed_widget.dart';

--- a/lib/views/photo_details_screen/photo_details_screen_view_model.dart
+++ b/lib/views/photo_details_screen/photo_details_screen_view_model.dart
@@ -1,9 +1,9 @@
 import 'dart:io';
 
 import 'package:flutter/widgets.dart';
+import 'package:mobx/mobx.dart';
 import 'package:momento_booth/managers/settings_manager.dart';
 import 'package:momento_booth/views/base/screen_view_model_base.dart';
-import 'package:mobx/mobx.dart';
 import 'package:momento_booth/views/custom_widgets/wrappers/slider_widget.dart';
 import 'package:path/path.dart' hide context;
 

--- a/lib/views/settings_screen/settings_screen.dart
+++ b/lib/views/settings_screen/settings_screen.dart
@@ -1,8 +1,8 @@
 import 'package:momento_booth/views/base/build_context_accessor.dart';
 import 'package:momento_booth/views/base/screen_base.dart';
 import 'package:momento_booth/views/settings_screen/settings_screen_controller.dart';
-import 'package:momento_booth/views/settings_screen/settings_screen_view_model.dart';
 import 'package:momento_booth/views/settings_screen/settings_screen_view.dart';
+import 'package:momento_booth/views/settings_screen/settings_screen_view_model.dart';
 
 class SettingsScreen extends ScreenBase<SettingsScreenViewModel, SettingsScreenController, SettingsScreenView> {
 

--- a/lib/views/settings_screen/settings_screen_controller.dart
+++ b/lib/views/settings_screen/settings_screen_controller.dart
@@ -34,7 +34,7 @@ class SettingsScreenController extends ScreenControllerBase<SettingsScreenViewMo
     viewModel.paneIndex = newIndex;
   }
 
-  void exportTemplate() async {
+  Future<void> exportTemplate() async {
     final stopwatch = Stopwatch()..start();
     final pixelRatio = viewModel.resolutionMultiplier;
     final format = viewModel.exportFormat;

--- a/lib/views/settings_screen/settings_screen_view_model.dart
+++ b/lib/views/settings_screen/settings_screen_view_model.dart
@@ -1,10 +1,10 @@
 import 'package:fluent_ui/fluent_ui.dart';
+import 'package:mobx/mobx.dart';
 import 'package:momento_booth/hardware_control/gphoto2_camera.dart';
-import 'package:momento_booth/managers/settings_manager.dart';
 import 'package:momento_booth/hardware_control/live_view_streaming/nokhwa_camera.dart';
+import 'package:momento_booth/managers/settings_manager.dart';
 import 'package:momento_booth/models/settings.dart';
 import 'package:momento_booth/views/base/screen_view_model_base.dart';
-import 'package:mobx/mobx.dart';
 import 'package:momento_booth/views/custom_widgets/photo_collage.dart';
 import 'package:printing/printing.dart';
 
@@ -71,22 +71,25 @@ abstract class SettingsScreenViewModelBase extends ScreenViewModelBase with Stor
 
   final String unsedPrinterValue = "UNUSED";
 
-  void setPrinterList() async {
+  Future<void> setPrinterList() async {
     final printers = await Printing.listPrinters();
-    printerOptions.clear();
-    printerOptions.add(ComboBoxItem(value: unsedPrinterValue, child: _printerCardText("- Not used -", false, false)));
+
+    printerOptions
+      ..clear()
+      ..add(ComboBoxItem(value: unsedPrinterValue, child: _printerCardText("- Not used -", false, false)));
+
     for (var printer in printers) {
       printerOptions.add(ComboBoxItem(value: printer.name, child: _printerCardText(printer.name, printer.isAvailable, printer.isDefault)));
       
       // If there is no setting yet, set it to the default printer.
       if (printer.isDefault && printersSetting.isEmpty) {
-        updateSettings((settings) => settings.copyWith.hardware(printerNames: [printer.name]));
+        await updateSettings((settings) => settings.copyWith.hardware(printerNames: [printer.name]));
       }
     }
   }
   
-  void setWebcamList() async => webcams = await NokhwaCamera.getCamerasAsComboBoxItems();
-  void setCameraList() async => gPhoto2Cameras = await GPhoto2Camera.getCamerasAsComboBoxItems();
+  Future<void> setWebcamList() async => webcams = await NokhwaCamera.getCamerasAsComboBoxItems();
+  Future<void> setCameraList() async => gPhoto2Cameras = await GPhoto2Camera.getCamerasAsComboBoxItems();
 
   // Current values
 

--- a/lib/views/share_screen/share_screen.dart
+++ b/lib/views/share_screen/share_screen.dart
@@ -1,8 +1,8 @@
 import 'package:momento_booth/views/base/build_context_accessor.dart';
 import 'package:momento_booth/views/base/screen_base.dart';
 import 'package:momento_booth/views/share_screen/share_screen_controller.dart';
-import 'package:momento_booth/views/share_screen/share_screen_view_model.dart';
 import 'package:momento_booth/views/share_screen/share_screen_view.dart';
+import 'package:momento_booth/views/share_screen/share_screen_view_model.dart';
 
 class ShareScreen extends ScreenBase<ShareScreenViewModel, ShareScreenController, ShareScreenView> {
   

--- a/lib/views/share_screen/share_screen_controller.dart
+++ b/lib/views/share_screen/share_screen_controller.dart
@@ -43,7 +43,7 @@ class ShareScreenController extends ScreenControllerBase<ShareScreenViewModel> w
     viewModel.sliderKey.currentState!.animateBackward();
   }
   
-  void onClickGetQR() async {
+  Future<void> onClickGetQR() async {
     if (viewModel.uploadState == UploadState.done) {
       viewModel.qrShown = true;
       viewModel.sliderKey.currentState!.animateForward();
@@ -55,16 +55,22 @@ class ShareScreenController extends ScreenControllerBase<ShareScreenViewModel> w
 
     loggy.debug("Uploading ${file.path}");
     var stream = rustLibraryApi.ffsendUploadFile(filePath: file.path, hostUrl: ffSendUrl, downloadFilename: "MomentoBooth image.$ext");
-    viewModel.qrText = localizations.shareScreenQrUploading;
-    viewModel.uploadState = UploadState.uploading;
+
+    viewModel
+      ..qrText = localizations.shareScreenQrUploading
+      ..uploadState = UploadState.uploading;
+
     stream.listen((event) {
       if (event.isFinished) {
         loggy.debug("Upload complete: ${event.downloadUrl}");
-        viewModel.uploadState = UploadState.done;
-        viewModel.qrText = localizations.shareScreenShowQrButton;
-        viewModel.qrUrl = event.downloadUrl!;
-        viewModel.qrShown = true;
-        viewModel.sliderKey.currentState!.animateForward();
+
+        viewModel
+          ..uploadState = UploadState.done
+          ..qrText = localizations.shareScreenShowQrButton
+          ..qrUrl = event.downloadUrl!
+          ..qrShown = true
+          ..sliderKey.currentState!.animateForward();
+
         StatsManager.instance.addUploadedPhoto();
       } else {
         loggy.debug("Uploading: ${event.transferredBytes}/${event.totalBytes} bytes");
@@ -79,16 +85,19 @@ class ShareScreenController extends ScreenControllerBase<ShareScreenViewModel> w
   static const _printTextDuration = Duration(seconds: 4);
 
   void resetPrint() {
-    viewModel.printText = successfulPrints > 0 ? "${localizations.genericPrintButton} +1" : localizations.genericPrintButton;
-    viewModel.printEnabled = true;
+    viewModel
+      ..printText = successfulPrints > 0 ? "${localizations.genericPrintButton} +1" : localizations.genericPrintButton
+      ..printEnabled = true;
   }
 
   Future<void> onClickPrint() async {
     if (!viewModel.printEnabled) return;
 
     loggy.debug("Printing photo");
-    viewModel.printEnabled = false;
-    viewModel.printText = localizations.shareScreenPrinting;
+
+    viewModel
+      ..printEnabled = false
+      ..printText = localizations.shareScreenPrinting;
     
     // Get photo and print it.
     final pdfData = await PhotosManager.instance.getOutputPDF();

--- a/lib/views/share_screen/share_screen_view_model.dart
+++ b/lib/views/share_screen/share_screen_view_model.dart
@@ -2,11 +2,11 @@ import 'dart:typed_data';
 
 import 'package:confetti/confetti.dart';
 import 'package:flutter/widgets.dart';
+import 'package:mobx/mobx.dart';
 import 'package:momento_booth/managers/photos_manager.dart';
 import 'package:momento_booth/managers/settings_manager.dart';
 import 'package:momento_booth/views/base/screen_view_model_base.dart';
 import 'package:momento_booth/views/custom_widgets/wrappers/slider_widget.dart';
-import 'package:mobx/mobx.dart';
 
 part 'share_screen_view_model.g.dart';
 

--- a/lib/views/start_screen/start_screen_view.dart
+++ b/lib/views/start_screen/start_screen_view.dart
@@ -1,10 +1,10 @@
 import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/widgets.dart';
+import 'package:flutter_svg/flutter_svg.dart';
 import 'package:momento_booth/theme/momento_booth_theme_data.dart';
 import 'package:momento_booth/views/base/screen_view_base.dart';
 import 'package:momento_booth/views/start_screen/start_screen_controller.dart';
 import 'package:momento_booth/views/start_screen/start_screen_view_model.dart';
-import 'package:flutter_svg/flutter_svg.dart';
 
 class StartScreenView extends ScreenViewBase<StartScreenViewModel, StartScreenController> {
 

--- a/lib/views/start_screen/start_screen_view_model.dart
+++ b/lib/views/start_screen/start_screen_view_model.dart
@@ -1,6 +1,6 @@
+import 'package:mobx/mobx.dart';
 import 'package:momento_booth/managers/photos_manager.dart';
 import 'package:momento_booth/views/base/screen_view_model_base.dart';
-import 'package:mobx/mobx.dart';
 
 part 'start_screen_view_model.g.dart';
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -85,10 +85,10 @@ packages:
     dependency: transitive
     description:
       name: bidi
-      sha256: dc00274c7edabae2ab30c676e736ea1eb0b1b7a1b436cb5fe372e431ccb39ab0
+      sha256: "6794b226bc939731308b8539c49bb6c2fdbf0e78c3a65e9b9e81e727c256dfe6"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.6"
+    version: "2.0.7"
   boolean_selector:
     dependency: transitive
     description:
@@ -430,18 +430,18 @@ packages:
     dependency: "direct dev"
     description:
       name: freezed
-      sha256: a9520490532087cf38bf3f7de478ab6ebeb5f68bb1eb2641546d92719b224445
+      sha256: "2df89855fe181baae3b6d714dc3c4317acf4fccd495a6f36e5e00f24144c6c3b"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.5"
+    version: "2.4.1"
   freezed_annotation:
     dependency: "direct main"
     description:
       name: freezed_annotation
-      sha256: aeac15850ef1b38ee368d4c53ba9a847e900bb2c53a4db3f6881cbb3cb684338
+      sha256: c3fd9336eb55a38cc1bbd79ab17573113a8deccd0ecbbf926cca3c62803b5c2d
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.4.1"
   frontend_server_client:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -40,7 +40,7 @@ dependencies:
   flutter_mobx: 2.0.6+5
 
   # Models
-  freezed_annotation: 2.2.0
+  freezed_annotation: 2.4.1
   json_annotation: 4.8.1
 
   # Interop
@@ -84,7 +84,7 @@ dev_dependencies:
   dart_code_metrics_presets: 1.8.0
 
   # Models
-  freezed: 2.3.5
+  freezed: 2.4.1
   json_serializable: 6.7.1
 
   # Code generation


### PR DESCRIPTION
This PR:
- Enable lots of linter rules
- Fixes all new issues raised by these linter rules
- Upgrade Flutter to 3.10.6
- Adds a workaround to be able to open the Manual College screen again