### PR TITLE
More documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ MomentoBooth is a cross-platform open source photo booth software. Capture your 
 
 [Download from GitHub](https://github.com/h3x4d3c1m4l/momento-booth/releases)
 
+Check the online documentation at [https://h3x4d3c1m4l.github.io/momento-booth/](https://h3x4d3c1m4l.github.io/momento-booth/).
+
 ## Features
 
 * Single capture

--- a/documentation/src/SUMMARY.md
+++ b/documentation/src/SUMMARY.md
@@ -3,7 +3,7 @@
 [Introduction](./introduction.md)
 
 # Set up
-
+- [Getting started](./getting_started.md)
 - [Camera](./camera_setup.md)
 - [Printer](./printer_setup.md)
 - [Templates](./template_setup.md)

--- a/documentation/src/SUMMARY.md
+++ b/documentation/src/SUMMARY.md
@@ -17,3 +17,4 @@
   - [User interface settings](./settings_ui.md)
   - [Templating settings](./settings_templating.md)
   - [Statistics & debug settings](./settings_debug.md)
+  - [Log panel](./settings_log.md)

--- a/documentation/src/SUMMARY.md
+++ b/documentation/src/SUMMARY.md
@@ -14,3 +14,5 @@
   - [General settings](./settings_general.md)
   - [Hardware settings](./settings_hardware.md)
   - [Output settings](./settings_output.md)
+  - [User interface settings](./settings_ui.md)
+  - [Statistics & debug settings](./settings_debug.md)

--- a/documentation/src/SUMMARY.md
+++ b/documentation/src/SUMMARY.md
@@ -1,6 +1,6 @@
 # Summary
 
-[Introduction](../../README.md)
+[Introduction](./introduction.md)
 
 # Set up
 

--- a/documentation/src/SUMMARY.md
+++ b/documentation/src/SUMMARY.md
@@ -10,3 +10,6 @@
 - [Checklist for events](./event_checklist.md)
 
 # Settings
+- [Settings panel](./settings_panel.md)
+  - [General settings](./settings_general.md)
+  - [Hardware settings](./settings_hardware.md)

--- a/documentation/src/SUMMARY.md
+++ b/documentation/src/SUMMARY.md
@@ -13,3 +13,4 @@
 - [Settings panel](./settings_panel.md)
   - [General settings](./settings_general.md)
   - [Hardware settings](./settings_hardware.md)
+  - [Output settings](./settings_output.md)

--- a/documentation/src/SUMMARY.md
+++ b/documentation/src/SUMMARY.md
@@ -15,4 +15,5 @@
   - [Hardware settings](./settings_hardware.md)
   - [Output settings](./settings_output.md)
   - [User interface settings](./settings_ui.md)
+  - [Templating settings](./settings_templating.md)
   - [Statistics & debug settings](./settings_debug.md)

--- a/documentation/src/getting_started.md
+++ b/documentation/src/getting_started.md
@@ -1,0 +1,19 @@
+# Getting started
+
+Getting started with MomentoBooth is easy! You only need a computer/laptop with webcam. Specifically, follow these steps:
+
+1. Download the latest MomentoBooth release for your OS from the [GitHub releases page](https://github.com/h3x4d3c1m4l/momento-booth/releases).
+1. Extract the zip file and run the MomentoBooth executable.
+    * It may be convenient to place a shortcut on your desktop.
+1. You will be greeted by the homescreen saying "Touch to start" and a green background. Press `Ctrl+S` to open the settings panel. → [See all shortcuts](settings_general.md#hotkeys).
+1. Go to the **hardware** tab
+1. Ensure [live view method](settings_hardware.md#live-view-method) is set to "Webcam" and select your webcam from the list in the [webcam setting](settings_hardware.md#webcam). The [capture method](settings_hardware.md#capture-method) is set to "Live view source" by default.
+    * If you do not have a webcam available you can also select "Static noise" as a live view source for testing.
+1. Next, go to the **output** tab.
+1. Set an [output directory](settings_output.md#local-photo-storage-location) to save your photos.
+1. Next, go to the **templating** tab.
+1. Set a [template directory](settings_templating.md#template-location) to look for template files.
+1. Go to that directory in your file explorer and place a background (portrait) image called `background.jpg` or `background.png`.
+1. You are now ready to shoot your first pictures! Press `Ctrl+S` again to exit the settings screen and click on or touch the screen to get started.
+
+Once you have the basics up and running you can try [connecting a camera](camera_setup.md#camera), [adding a printer](printer_setup.md), or designing a beautiful [template](template_setup.md) for your next event.

--- a/documentation/src/introduction.md
+++ b/documentation/src/introduction.md
@@ -1,0 +1,1 @@
+{{#include ../../README.md}}

--- a/documentation/src/printer_setup.md
+++ b/documentation/src/printer_setup.md
@@ -1,1 +1,23 @@
 # Printer
+
+Printing your photos and having a physical reminder of an awesome event is one of the most fun parts of having a photo booth. Therefore MomentoBooth has well-configurable printer support! For an overview of the available settings to tune printing, see the [printer hardware settings](settings_hardware.md#printing) and [template settings](settings_templating.md).
+
+Getting the print settings right requires quite a bit of trial and error. Ideally a print shows the full collage without parts being cut-off or white borders. For this purpose you probably want to use borderless printing.
+
+## Recommended settings for Canon Selphy CP1300/CP1500
+
+The Canon Selphy series of printers is quite convenient for photo booth purposes. Here are settings that are known to be approximately right for using this type of printer.
+
+| Property | Value |
+|---|---|
+| [Collage aspect ratio](settings_templating.md#collage-aspect-ratio) | 1.48 |
+| [Collage padding](settings_templating.md#collage-padding) | 10 |
+| [Page height](settings_hardware.md#page-height) | 148 |
+| [Page width](settings_hardware.md#page-width) | 100 |
+| [Printer margin top](settings_hardware.md#page-margins-used-for-printing) | 0.0 |
+| [Printer margin right](settings_hardware.md#page-margins-used-for-printing) | 1.6 |
+| [Printer margin bottom](settings_hardware.md#page-margins-used-for-printing) | 0.5 |
+| [Printer margin left](settings_hardware.md#page-margins-used-for-printing) | 1.6 |
+| [Use printer settings](settings_hardware.md#use-printer-settings-for-printing) | On |
+
+Make sure to set the default settings of the printer to **portrait mode**, **borderless**, and the right paper-size.

--- a/documentation/src/settings/capture_delay.md
+++ b/documentation/src/settings/capture_delay.md
@@ -1,0 +1,3 @@
+### Capture delay
+This settings specifies the capture delay, a.k.a. countdown time, that is used when making photo captures.  
+**Unit:** Seconds

--- a/documentation/src/settings/capture_delay_gphoto2.md
+++ b/documentation/src/settings/capture_delay_gphoto2.md
@@ -1,0 +1,8 @@
+### Capture Delay for gPhoto2 Camera
+
+This setting specifies the capture delay for cameras controlled using `gPhoto2` as the capture method. Please note that this setting is only visible when the `gPhoto2` is selected as the capture method.
+
+**Unit:** Milliseconds (ms)
+
+**Description:**  
+The capture delay is the time delay applied before the photo capture takes place.

--- a/documentation/src/settings/capture_delay_sony.md
+++ b/documentation/src/settings/capture_delay_sony.md
@@ -1,0 +1,8 @@
+### Capture Delay for Sony Camera
+
+This setting specifies the capture delay for Sony cameras when using `Sony Imaging Edge Desktop automation` as the capture method. Please note that this setting is only visible when the `Sony Imaging Edge Desktop automation` is selected as the capture method.
+
+**Unit:** Milliseconds (ms)
+
+**Description:**  
+The capture delay is the time delay applied before the photo capture takes place. Sensible values for the capture delay are between 165 ms (for manual focus) and 500 ms.

--- a/documentation/src/settings/capture_location.md
+++ b/documentation/src/settings/capture_location.md
@@ -1,0 +1,6 @@
+### Capture Location
+
+This setting specifies the location where the photo booth application will look for images captured by an external tool, such as `Sony Imaging Edge Desktop`.
+
+**Description:**  
+The "Capture Location" is the folder path where the photo booth application will search for images captured using external tools. This allows the photo booth to access and display images taken separately, for instance, with `Sony Imaging Edge Desktop`.

--- a/documentation/src/settings/capture_method.md
+++ b/documentation/src/settings/capture_method.md
@@ -1,0 +1,8 @@
+### Capture Method
+
+This setting determines the method used for **capturing** the images within the photo booth application.
+
+**Available Options:**
+- Live view source
+- Sony Imaging Edge Desktop automation
+- gPhoto2

--- a/documentation/src/settings/capture_special_handling.md
+++ b/documentation/src/settings/capture_special_handling.md
@@ -1,0 +1,7 @@
+### Use Special Handling for Camera
+
+This setting determines the kind of special handling used for the camera when using `gPhoto2` as the capture or live view method. This mostly relates to special vendor-specific operations, such as re-activating live-view for Nikon cameras.
+
+**Available Options:**
+- None
+- Nikon DSLR

--- a/documentation/src/settings/collage_aspect_ratio.md
+++ b/documentation/src/settings/collage_aspect_ratio.md
@@ -1,0 +1,3 @@
+### Collage Aspect Ratio
+
+This setting controls the aspect ratio of the generated collage images. Consider this aspect ratio in conjunction with the desired paper print size for optimal results. Typical values are 1.5 for 3/2 photos or the aspect ratio of your paper.

--- a/documentation/src/settings/collage_padding.md
+++ b/documentation/src/settings/collage_padding.md
@@ -1,0 +1,3 @@
+### Collage Padding
+
+This setting controls the padding **around the aspect ratio** of the generated collages images. Consider this padding in conjunction with the desired paper print size for optimal results.

--- a/documentation/src/settings/display_confetti.md
+++ b/documentation/src/settings/display_confetti.md
@@ -1,0 +1,3 @@
+### Display Confetti 🎉
+
+This setting controls the display of a confetti shower on the share screen within the photo booth application.

--- a/documentation/src/settings/export_format.md
+++ b/documentation/src/settings/export_format.md
@@ -1,0 +1,9 @@
+### Image File Type
+
+This setting determines the type of image file to generate for image export within the photo booth application.
+
+**Available Options:**  
+- JPG
+- PNG
+
+**Default:** JPG

--- a/documentation/src/settings/fake_error_debug.md
+++ b/documentation/src/settings/fake_error_debug.md
@@ -1,0 +1,3 @@
+### Report Fake Error
+
+This button allows you to test the error reporting functionality. When you click the "Report Fake Error" button, the application will intentionally throw an exception, generating a fake error that will be reported to Sentry.

--- a/documentation/src/settings/ffsend_url.md
+++ b/documentation/src/settings/ffsend_url.md
@@ -1,0 +1,3 @@
+### Firefox Send URL
+
+This setting specifies the Firefox Send server URL used to generate a QR code for easy image downloads to your phone using the [Firefox Send service](https://github.com/timvisee/send).

--- a/documentation/src/settings/filter_quality_live_view.md
+++ b/documentation/src/settings/filter_quality_live_view.md
@@ -1,0 +1,9 @@
+### Filter Quality for Live View
+
+This setting controls the filter quality used for displaying the live view.
+
+**Available Options:**  
+- None
+- Low
+- Medium
+- High

--- a/documentation/src/settings/filter_quality_screen.md
+++ b/documentation/src/settings/filter_quality_screen.md
@@ -1,0 +1,9 @@
+### Filter Quality for Screen Transitions
+
+This setting controls the filter quality used during the screen transition scale animation.
+
+**Available Options:**  
+- None
+- Low
+- Medium
+- High

--- a/documentation/src/settings/flip_image.md
+++ b/documentation/src/settings/flip_image.md
@@ -1,0 +1,11 @@
+### Flip Image
+
+This setting determines whether the **preview** image (not the final picture) should be flipped along none, one, or both axes within the photo booth application.
+
+**Available Options:**
+- None
+- Horizontal
+- Vertical
+- Both
+
+**Default:** Horizontal

--- a/documentation/src/settings/gphoto2_camera.md
+++ b/documentation/src/settings/gphoto2_camera.md
@@ -1,0 +1,6 @@
+### Camera (gPhoto2)
+
+This setting allows you to pick the camera to use for capturing within the photo booth application when `gPhoto2` is selected for live view or capture method.
+
+**Description:**  
+The "gPhoto2 Camera" setting provides a list of available cameras recognized by the `gPhoto2` library. You can select the desired camera to use for capturing live view and still frames.

--- a/documentation/src/settings/hotkeys.md
+++ b/documentation/src/settings/hotkeys.md
@@ -1,0 +1,6 @@
+| Hotkey                | Effect                                    |
+|-----------------------|-------------------------------------------|
+| `Ctrl+S`              | Toggle the settings screen.               |
+| `Ctrl+F`, `Alt+Enter` | Toggle fullscreen mode.                   |
+| `Ctrl+M`              | Go to the manual collage creation screen. |
+| `Ctrl+H`              | Return to the home screen.                |

--- a/documentation/src/settings/image_resolution_multiplier.md
+++ b/documentation/src/settings/image_resolution_multiplier.md
@@ -1,0 +1,9 @@
+### Output Resolution Multiplier
+
+This setting controls the image resolution multiplier within the photo booth application, which in turn controls the image resolution of the exported photos. A factor of `1.0` results in a resolution of `1000` pixels on the long side of the image and `1000/aspect ratio` on the short side without padding.
+
+The calculation of the total image height is as follows:  
+`resolutionMultiplier * (1000 + collagePaddingSetting * 2)`
+
+And the width:  
+`resolutionMultiplier * (1000/collageAspectRatioSetting + collagePaddingSetting * 2)`

--- a/documentation/src/settings/jpg_quality.md
+++ b/documentation/src/settings/jpg_quality.md
@@ -1,0 +1,7 @@
+### JPG Quality
+
+This setting specifies the export quality for JPG images within the photo booth application. Higher quality values result in larger file sizes, while lower values lead to smaller files with potentially reduced image quality.
+
+**Value Range:**  
+Minimum: 1  
+Maximum: 100

--- a/documentation/src/settings/language.md
+++ b/documentation/src/settings/language.md
@@ -1,0 +1,7 @@
+### Language
+
+This setting allows you to choose the language used for the app's user interface (except for the settings screen).
+
+**Available Options:**  
+- English
+- Dutch

--- a/documentation/src/settings/live_view_method.md
+++ b/documentation/src/settings/live_view_method.md
@@ -1,0 +1,12 @@
+### Live View Method
+
+This setting determines the method used for live previewing within the photo booth application.
+
+**Available Options:**
+- Debug – Static noise
+- Webcam
+- gPhoto2
+
+**Selected Option:** [Option]
+
+Please note that the selected option is based on the current configuration and can be changed by the user.

--- a/documentation/src/settings/output_local_folder.md
+++ b/documentation/src/settings/output_local_folder.md
@@ -1,0 +1,3 @@
+### Local Photo Storage Location
+
+This setting allows you to specify the folder path where the photo booth application will save the captured images. All single & collage photos taken in the booth will be stored in this folder, but will be overwritten by a retake.

--- a/documentation/src/settings/page_height.md
+++ b/documentation/src/settings/page_height.md
@@ -1,0 +1,9 @@
+### Page Height
+
+This setting specifies the page format height used for printing within the photo booth application.
+
+**Unit:** Millimeters (mm)
+
+**Description:**  
+The "Page Height" setting represents the height of the page format used for printing photos. Set it to your printers page height for the paper type you wish to use.
+

--- a/documentation/src/settings/page_margins.md
+++ b/documentation/src/settings/page_margins.md
@@ -1,0 +1,10 @@
+### Page Margins Used for Printing
+
+This setting allows you to specify the page margins used for printing.
+
+**Description:**  
+The "Page Margins Used for Printing" setting compensates for printers that may cut off some part of the image during printing. You can adjust the margins to ensure that the entire image is captured on the printed page.
+
+**Unit:** Millimeters (mm)
+
+**Order of Margins:** Top, Right, Bottom, Left – CSS order

--- a/documentation/src/settings/page_width.md
+++ b/documentation/src/settings/page_width.md
@@ -1,0 +1,9 @@
+### Page Width
+
+This setting specifies the page format width used for printing within the photo booth application.
+
+**Unit:** Millimeters (mm)
+
+**Description:**  
+The "Page Width" setting represents the width of the page format used for printing photos. Set it to your printers page width for the paper type you wish to use.
+

--- a/documentation/src/settings/printer.md
+++ b/documentation/src/settings/printer.md
@@ -1,0 +1,6 @@
+### Printer
+Like explained in the MomentoBooth capabilities, the application has multi-printer support. The `Printer i` setting with `i` `1, 2, ...` allows selecting which printer(s) to use. Every selected printer will create another printer setting in the UI.
+
+The options for a printer selection (in the form of a combo-box) are the printers currently configured on the OS. Icons show if the selected printer is currently connected and whether it is the system's default printer or not.
+
+It is possible to select the same printer multiple times. Prints are assigned round-robin.

--- a/documentation/src/settings/queue_threshold.md
+++ b/documentation/src/settings/queue_threshold.md
@@ -1,0 +1,3 @@
+### Queue Warning Threshold
+
+This setting specifies the number of photos in the OS's printer queue before a "Printer queue is long" warning is shown to the user to indicate it may take a while for the picture to appear. This feature is currently only supported on Windows systems.

--- a/documentation/src/settings/screen_transition.md
+++ b/documentation/src/settings/screen_transition.md
@@ -1,0 +1,8 @@
+### Screen Transition Animation
+
+This setting determines the screen transition effect that occurs when navigating between different screens.
+
+**Available Options:**  
+- None
+- Fade and Scale
+- Fade and Slide

--- a/documentation/src/settings/single_photo_collage.md
+++ b/documentation/src/settings/single_photo_collage.md
@@ -1,0 +1,7 @@
+### Treat Single Photo as Collage
+
+This setting determines how a single photo is processed within the photo booth application.
+
+If enabled, a single picture will be treated as if it were a collage with 1 photo selected. This means that the photo will undergo collage processing, even though it contains only one photo.
+
+If disabled, the single photo will be used unaltered.

--- a/documentation/src/settings/template_location.md
+++ b/documentation/src/settings/template_location.md
@@ -1,0 +1,3 @@
+### Template Location
+
+This setting specifies the location where the photo booth application will look for template files for generating the collage images. See [template set-up](template_setup.md) for details.

--- a/documentation/src/settings/use_printer_settings.md
+++ b/documentation/src/settings/use_printer_settings.md
@@ -1,0 +1,3 @@
+### Use Printer Settings for Printing
+
+This setting controls the `usePrinterSettings` property of the [Flutter printing library](https://pub.dev/packages/printing) within the photo booth application. This setting is Windows only, and makes a difference on some but not all printers, experiment.

--- a/documentation/src/settings/webcam_selection.md
+++ b/documentation/src/settings/webcam_selection.md
@@ -1,0 +1,3 @@
+### Webcam
+
+This setting allows you to pick the webcam to use for live view when `Webcam` is selected for live view. It can also be used for capture by selecting `Live view` as capture method.

--- a/documentation/src/settings_debug.md
+++ b/documentation/src/settings_debug.md
@@ -1,0 +1,32 @@
+# Statistics & Debug settings
+In the statistics and debug settings panel, you will find fun statistics about app usage and some debug-related settings.
+
+## Statistics
+The app keeps track of the following statistics:
+
+- **Taps**
+  The number of taps in the app (outside settings).
+
+- **Live view frames**
+  The number of live view frames processed from the start of the camera. Value shows: Valid frames / Undecodable frames.
+
+- **Printed pictures**
+  The number of prints (e.g. 2 prints of the same pictures will count as 2 as well).
+
+- **Uploaded pictures**
+  The number of uploaded pictures.
+
+- **Captured photos**
+  The number of photo captures (e.g. a multi-capture picture would increase this by 4).
+
+- **Created single shot pictures**
+  The number of single-capture pictures created.
+
+- **Retakes**
+  The number of retakes for (single) photo captures.
+
+- **Created multi shot pictures**
+  The number of multi-shot pictures created.
+
+## Debug
+{{#include ./settings/fake_error_debug.md}}

--- a/documentation/src/settings_general.md
+++ b/documentation/src/settings_general.md
@@ -1,0 +1,8 @@
+# General settings
+In the general settings, you will find settings that influence the behaviour of the program.
+
+{{#include ./settings/capture_delay.md}}
+{{#include ./settings/single_photo_collage.md}}
+
+## Hotkeys
+{{#include ./settings/hotkeys.md}}

--- a/documentation/src/settings_hardware.md
+++ b/documentation/src/settings_hardware.md
@@ -1,0 +1,21 @@
+# Hardware settings
+In the hardware settings, you will find settings related to live view, photo capture and printing. Everything related to the hardware the program interfaces with.
+
+## Live View
+{{#include ./settings/live_view_method.md}}
+{{#include ./settings/flip_image.md}}
+
+## Photo Capture
+{{#include ./settings/capture_method.md}}
+{{#include ./settings/capture_delay_sony.md}}
+{{#include ./settings/capture_delay_gphoto2.md}}
+{{#include ./settings/gphoto2_camera.md}}
+{{#include ./settings/capture_special_handling.md}}
+{{#include ./settings/capture_location.md}}
+
+## Printing
+{{#include ./settings/printer.md}}
+{{#include ./settings/page_height.md}}
+{{#include ./settings/page_width.md}}
+{{#include ./settings/page_margins.md}}
+{{#include ./settings/queue_threshold.md}}

--- a/documentation/src/settings_hardware.md
+++ b/documentation/src/settings_hardware.md
@@ -18,4 +18,5 @@ In the hardware settings, you will find settings related to live view, photo cap
 {{#include ./settings/page_height.md}}
 {{#include ./settings/page_width.md}}
 {{#include ./settings/page_margins.md}}
+{{#include ./settings/use_printer_settings.md}}
 {{#include ./settings/queue_threshold.md}}

--- a/documentation/src/settings_hardware.md
+++ b/documentation/src/settings_hardware.md
@@ -3,6 +3,7 @@ In the hardware settings, you will find settings related to live view, photo cap
 
 ## Live View
 {{#include ./settings/live_view_method.md}}
+{{#include ./settings/webcam_selection.md}}
 {{#include ./settings/flip_image.md}}
 
 ## Photo Capture

--- a/documentation/src/settings_log.md
+++ b/documentation/src/settings_log.md
@@ -1,0 +1,3 @@
+# Log panel
+
+The log panel simply displays the log that is also printed in the debug console to enable viewing the log in the field. The log shows the **log level**, **time**, **message**, and **component**.

--- a/documentation/src/settings_output.md
+++ b/documentation/src/settings_output.md
@@ -1,0 +1,13 @@
+# Hardware settings
+In the hardware settings, you will find settings related to live view, photo capture and printing. Everything related to the hardware the program interfaces with.
+
+## Local
+{{#include ./settings/output_local_folder.md}}
+
+## Share using internet
+{{#include ./settings/ffsend_url.md}}
+
+## Image settings
+{{#include ./settings/export_format.md}}
+{{#include ./settings/jpg_quality.md}}
+{{#include ./settings/image_resolution_multiplier.md}}

--- a/documentation/src/settings_panel.md
+++ b/documentation/src/settings_panel.md
@@ -1,9 +1,9 @@
 # Settings panel
 The settings panel can be opened by pressing `Ctrl+S`. When opened you will be greeted by a screen with a few tabs. These tabs are:
- * General
- * Hardware
- * Output
- * User interface
- * Templating
- * Debug
- * Log
+ * [General](settings_general.md)
+ * [Hardware](settings_hardware.md)
+ * [Output](settings_output.md)
+ * [User interface](settings_ui.md)
+ * [Templating](settings_templating.md)
+ * [Debug](settings_debug.md)
+ * [Log](settings_log.md)

--- a/documentation/src/settings_panel.md
+++ b/documentation/src/settings_panel.md
@@ -1,0 +1,9 @@
+# Settings panel
+The settings panel can be opened by pressing `Ctrl+S`. When opened you will be greeted by a screen with a few tabs. These tabs are:
+ * General
+ * Hardware
+ * Output
+ * User interface
+ * Templating
+ * Debug
+ * Log

--- a/documentation/src/settings_templating.md
+++ b/documentation/src/settings_templating.md
@@ -1,0 +1,20 @@
+# Templating settings
+In the templating settings, you will find the settings related to the generation of collage images such as template images, shape and padding, resolution. This settings tab conveniently also features a template preview section.
+
+## Creative settings
+{{#include ./settings/template_location.md}}
+{{#include ./settings/collage_aspect_ratio.md}}
+{{#include ./settings/collage_padding.md}}
+{{#include ./settings/image_resolution_multiplier.md}}
+> The above setting is repeated from [output settings](settings_output.md).
+
+## Template preview
+The template preview section allows you to quickly check if your designed template images give the desired results. A placeholder image is inserted for every field that will contain user captures during operation.
+
+Using the buttons you can select which collage type you want to see (no selection, 1, 2, 3, 4 photos) and export the result for further inspection. The background and foreground layers of the collage can be toggled on and off to see the individual effect of those layers, or for generating a clean and transparent reference to design around (see note below).
+
+> Please note that exporting generates the file type specified in the [output settings](settings_output.md). Select `png` for file type if you want lossless images or transparency.
+
+The red border shown in the preview is the printing padding added "collage padding" setting. If set correctly this will not be visible/cut-off on the print. The white border is the standard gap present for the collage grid. The section also shows the template files that are selected for the selected collage after searching the template directory.
+
+> To refresh the templates, switch to another settings tab and back.

--- a/documentation/src/settings_ui.md
+++ b/documentation/src/settings_ui.md
@@ -1,0 +1,12 @@
+# User interface settings
+In the user interface settings, you will find settings related to live view, photo capture and printing. Everything related to the hardware the program interfaces with.
+
+{{#include ./settings/language.md}}
+
+## Animations
+{{#include ./settings/display_confetti.md}}
+{{#include ./settings/screen_transition.md}}
+
+## Advanced
+{{#include ./settings/filter_quality_screen.md}}
+{{#include ./settings/filter_quality_live_view.md}}

--- a/documentation/src/template_setup.md
+++ b/documentation/src/template_setup.md
@@ -8,6 +8,9 @@ A collage output is constructed of 3 layers:
 * Collage photos
 * Foreground template image
 
+Together with the shape and resolution modifying settings in [templating settings](settings_templating.md) the template-images define the look of your collage photos. It is recommended to get the template settings right before designing your template images. This avoids extra work to incorporate a different resolution, padding, or aspect ratio.
+
+## Template-file selection
 The application will search for template files in the configured template directory. Different templates can be supplied for different collage layouts (1 photo, 2 photos, 3 photos, 4 photos, 0 no photos selected yet).
 
 The template search & selection for a 3 photo collage, for example, works as follows:


### PR DESCRIPTION
#181 added the first bits of documentation and #184 fixed deployment. This PR adds a lot of missing documentation.

- The introduction link is fixed by doing an include instead of referring directly to the readme.
- Documentation has been added for all settings. Each setting is its own file that is included on the relevant settings page(s).
- A getting started guide has been added for an easy introduction of what to do to get testing quickly.
- Set-up guide for printing and improved templating one.
- A link to the docs has been added to the readme.