### PR TITLE
Cleanup PhotoCollage widget and simplify using it properly

### DIFF
--- a/.github/workflows/pr-ci-app.yml
+++ b/.github/workflows/pr-ci-app.yml
@@ -53,7 +53,7 @@ jobs:
       uses: baptiste0928/cargo-install@v1
       with:
         crate: flutter_rust_bridge_codegen
-        version: "1.79.0"
+        version: "1.80.1"
 
     - name: Install Dependencies
       run: flutter packages get

--- a/.github/workflows/release-linux-appimage-x64.yml
+++ b/.github/workflows/release-linux-appimage-x64.yml
@@ -51,7 +51,7 @@ jobs:
       uses: baptiste0928/cargo-install@v1
       with:
         crate: flutter_rust_bridge_codegen
-        version: "1.79.0"
+        version: "1.80.1"
 
     - name: Install flutter_distributor
       run: dart pub global activate flutter_distributor

--- a/.github/workflows/release-macos-x64.yml
+++ b/.github/workflows/release-macos-x64.yml
@@ -52,7 +52,7 @@ jobs:
       uses: baptiste0928/cargo-install@v1
       with:
         crate: flutter_rust_bridge_codegen
-        version: "1.79.0"
+        version: "1.80.1"
 
     - name: Install flutter_distributor
       run: dart pub global activate flutter_distributor

--- a/.github/workflows/release-win-x64.yml
+++ b/.github/workflows/release-win-x64.yml
@@ -59,7 +59,7 @@ jobs:
       uses: baptiste0928/cargo-install@v1
       with:
         crate: flutter_rust_bridge_codegen
-        version: "1.79.0"
+        version: "1.80.1"
 
     - name: Install flutter_distributor
       run: dart pub global activate flutter_distributor

--- a/lib/views/capture_screen/capture_screen_view.dart
+++ b/lib/views/capture_screen/capture_screen_view.dart
@@ -20,18 +20,14 @@ class CaptureScreenView extends ScreenViewBase<CaptureScreenViewModel, CaptureSc
     return Stack(
       fit: StackFit.expand,
       children: [
-        // Is this very pretty? No. But it works 😅
-        FittedBox(
-          child: Transform.translate(
-            offset: const Offset(3000, 0),
-            child: PhotoCollage(
-              key: viewModel.collageKey,
-              singleMode: true,
-              aspectRatio: 1/viewModel.collageAspectRatio,
-              padding: viewModel.collagePadding,
-              decodeCallback: viewModel.collageReady,
-            ),
-          ),
+        // This widget is just here for the purpose of rendering the collage to a bitmap
+        PhotoCollage(
+          key: viewModel.collageKey,
+          singleMode: true,
+          aspectRatio: 1/viewModel.collageAspectRatio,
+          padding: viewModel.collagePadding,
+          decodeCallback: viewModel.collageReady,
+          isVisible: false,
         ),
         Column(
           mainAxisAlignment: MainAxisAlignment.center,

--- a/lib/views/collage_maker_screen/collage_maker_screen_view.dart
+++ b/lib/views/collage_maker_screen/collage_maker_screen_view.dart
@@ -165,12 +165,10 @@ class CollageMakerScreenView extends ScreenViewBase<CollageMakerScreenViewModel,
             color: const Color.fromARGB(255, 255, 255, 255),
             boxShadow: [theme.chooseCaptureModeButtonShadow],
           ),
-          child: FittedBox(
-            child: PhotoCollage(
-              key: controller.collageKey,
-              aspectRatio: 1/viewModel.collageAspectRatio,
-              padding: viewModel.collagePadding,
-            ),
+          child: PhotoCollage(
+            key: controller.collageKey,
+            aspectRatio: 1/viewModel.collageAspectRatio,
+            padding: viewModel.collagePadding,
           ),
         ),
       ),

--- a/lib/views/custom_widgets/image_with_loader_fallback.dart
+++ b/lib/views/custom_widgets/image_with_loader_fallback.dart
@@ -3,24 +3,23 @@ import 'dart:typed_data';
 
 import 'package:fluent_ui/fluent_ui.dart';
 
-enum _Type {
-  memory(),
-  file(),
-}
-
-void baseCallback() {}
+enum _Type { memory, file }
 
 class ImageWithLoaderFallback extends StatelessWidget {
 
-  late final Uint8List? bytes;
-  late final File? file;
+  final Uint8List? bytes;
+  final File? file;
   final BoxFit? fit;
-  late final _Type _type;
-  // var imageDecoded = false;
-  final VoidCallback decodeCallback;
+  final VoidCallback? decodeCallback;
+  final _Type _type;
 
-  ImageWithLoaderFallback.memory(this.bytes, {super.key, this.fit, this.decodeCallback = baseCallback,}) { _type = _Type.memory; }
-  ImageWithLoaderFallback.file(this.file, {super.key, this.fit, this.decodeCallback = baseCallback,}) { _type = _Type.file; }
+  const ImageWithLoaderFallback.memory(this.bytes, {super.key, this.fit, this.decodeCallback})
+      : _type = _Type.memory,
+        file = null;
+
+  const ImageWithLoaderFallback.file(this.file, {super.key, this.fit, this.decodeCallback})
+      : _type = _Type.file,
+        bytes = null;
 
   Widget _frameBuilder(BuildContext context, Widget child, int? frame, bool wasSynchronouslyLoaded) {
     if (frame == null) {
@@ -28,11 +27,10 @@ class ImageWithLoaderFallback extends StatelessWidget {
     }
     return child;
   }
-  
 
   @override
   Widget build(BuildContext context) {
-    var img = _type == _Type.memory ?
+    Image img = _type == _Type.memory ?
       Image.memory(
         bytes!,
         frameBuilder: _frameBuilder,
@@ -43,13 +41,11 @@ class ImageWithLoaderFallback extends StatelessWidget {
         frameBuilder: _frameBuilder,
         fit: fit,
       );
+
+    // Listen to decode status
     img.image
-    .resolve(ImageConfiguration.empty)
-    .addListener(ImageStreamListener((image, synchronousCall) {
-      // if (imageDecoded) return;
-      // imageDecoded = true;
-      decodeCallback();
-    }));
+        .resolve(ImageConfiguration.empty)
+        .addListener(ImageStreamListener((image, synchronousCall) => decodeCallback?.call()));
 
     return img;
   }

--- a/lib/views/custom_widgets/photo_collage.dart
+++ b/lib/views/custom_widgets/photo_collage.dart
@@ -354,12 +354,12 @@ class PhotoCollageState extends State<PhotoCollage> with UiLoggy {
   }
 
   Future<Uint8List?> getCollageImage({required double pixelRatio, ExportFormat format = ExportFormat.jpgFormat, int jpgQuality = 80}) async {
+    // Await frame render, should workaround the black image issue
+    await waitForPostFrameCallback();
+    
     if (format == ExportFormat.pngFormat) {
       return screenshotController.capture(pixelRatio: pixelRatio);
     }
-
-    // Await frame render, should workaround the black image issue
-    await waitForPostFrameCallback();
 
     // Capture widget as RGBA image
     final image = await screenshotController.captureAsUiImage(pixelRatio: pixelRatio);

--- a/lib/views/manual_collage_screen/manual_collage_screen_view.dart
+++ b/lib/views/manual_collage_screen/manual_collage_screen_view.dart
@@ -135,12 +135,10 @@ class ManualCollageScreenView extends ScreenViewBase<ManualCollageScreenViewMode
             color: const Color.fromARGB(255, 255, 255, 255),
             boxShadow: [theme.chooseCaptureModeButtonShadow],
           ),
-          child: FittedBox(
-            child: PhotoCollage(
-              key: controller.collageKey,
-              aspectRatio: 1/viewModel.collageAspectRatio,
-              padding: viewModel.collagePadding,
-            ),
+          child: PhotoCollage(
+            key: controller.collageKey,
+            aspectRatio: 1/viewModel.collageAspectRatio,
+            padding: viewModel.collagePadding,
           ),
         ),
       ),

--- a/lib/views/settings_screen/settings_screen_view.templating.dart
+++ b/lib/views/settings_screen/settings_screen_view.templating.dart
@@ -76,16 +76,13 @@ Widget _getTemplateExampleRow(SettingsScreenViewModel viewModel, SettingsScreenC
           quarterTurns: -1 * viewModel.previewTemplateRotation,
           child: SizedBox(
             height: height,
-            child: FittedBox(
-              child: PhotoCollage(
-                key: viewModel.collageKey,
-                debug: viewModel.previewTemplate,
-                aspectRatio: 1/viewModel.collageAspectRatioSetting,
-                padding: viewModel.collagePaddingSetting,
-                showBackground: viewModel.previewTemplateShowBack,
-                showForeground: viewModel.previewTemplateShowFront,
-                // decodeCallback: viewModel.collageReady,
-              ),
+            child: PhotoCollage(
+              key: viewModel.collageKey,
+              debug: viewModel.previewTemplate,
+              aspectRatio: 1/viewModel.collageAspectRatioSetting,
+              padding: viewModel.collagePaddingSetting,
+              showBackground: viewModel.previewTemplateShowBack,
+              showForeground: viewModel.previewTemplateShowFront,
             ),
           ),
         )

--- a/lib/views/share_screen/share_screen_view.dart
+++ b/lib/views/share_screen/share_screen_view.dart
@@ -4,7 +4,6 @@ import 'package:auto_size_text/auto_size_text.dart';
 import 'package:confetti/confetti.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
-import 'package:momento_booth/managers/photos_manager.dart';
 import 'package:momento_booth/views/base/screen_view_base.dart';
 import 'package:momento_booth/views/custom_widgets/image_with_loader_fallback.dart';
 import 'package:momento_booth/views/custom_widgets/wrappers/slider_widget.dart';

--- a/lib/views/share_screen/share_screen_view.dart
+++ b/lib/views/share_screen/share_screen_view.dart
@@ -4,6 +4,7 @@ import 'package:auto_size_text/auto_size_text.dart';
 import 'package:confetti/confetti.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
+import 'package:momento_booth/managers/photos_manager.dart';
 import 'package:momento_booth/views/base/screen_view_base.dart';
 import 'package:momento_booth/views/custom_widgets/image_with_loader_fallback.dart';
 import 'package:momento_booth/views/custom_widgets/wrappers/slider_widget.dart';
@@ -47,7 +48,7 @@ class ShareScreenView extends ScreenViewBase<ShareScreenViewModel, ShareScreenCo
         if (viewModel.displayConfetti)
           ... _confettiStack,
         SizedBox.expand(child: _qrCodeBackdrop),
-        _qrCode
+        _qrCode,
       ],
     );
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -404,10 +404,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_rust_bridge
-      sha256: dcb436ba4b466e19da1656ef14622b5ac2ed90efc8fcb0946942c6cd185578d1
+      sha256: ff90d5ddd0cda6d94ed048cc9c4a4d993d1a4bb11605d60a1282fc1bbf173c77
       url: "https://pub.dev"
     source: hosted
-    version: "1.79.0"
+    version: "1.80.1"
   flutter_scroll_shadow:
     dependency: "direct main"
     description:
@@ -664,10 +664,10 @@ packages:
     dependency: transitive
     description:
       name: package_info_plus
-      sha256: ceb027f6bc6a60674a233b4a90a7658af1aebdea833da0b5b53c1e9821a78c7b
+      sha256: "6ff267fcd9d48cb61c8df74a82680e8b82e940231bb5f68356672fde0397334a"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.2"
+    version: "4.1.0"
   package_info_plus_platform_interface:
     dependency: transitive
     description:
@@ -704,42 +704,42 @@ packages:
     dependency: transitive
     description:
       name: path_provider_android
-      sha256: "2cec049d282c7f13c594b4a73976b0b4f2d7a1838a6dd5aaf7bd9719196bee86"
+      sha256: "5d44fc3314d969b84816b569070d7ace0f1dea04bd94a83f74c4829615d22ad8"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.27"
+    version: "2.1.0"
   path_provider_foundation:
     dependency: transitive
     description:
       name: path_provider_foundation
-      sha256: "916731ccbdce44d545414dd9961f26ba5fbaa74bcbb55237d8e65a623a8c7297"
+      sha256: "1b744d3d774e5a879bb76d6cd1ecee2ba2c6960c03b1020cd35212f6aa267ac5"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.4"
+    version: "2.3.0"
   path_provider_linux:
     dependency: transitive
     description:
       name: path_provider_linux
-      sha256: ffbb8cc9ed2c9ec0e4b7a541e56fd79b138e8f47d2fb86815f15358a349b3b57
+      sha256: ba2b77f0c52a33db09fc8caf85b12df691bf28d983e84cf87ff6d693cfa007b3
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.11"
+    version: "2.2.0"
   path_provider_platform_interface:
     dependency: transitive
     description:
       name: path_provider_platform_interface
-      sha256: "57585299a729335f1298b43245842678cb9f43a6310351b18fb577d6e33165ec"
+      sha256: bced5679c7df11190e1ddc35f3222c858f328fff85c3942e46e7f5589bf9eb84
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.6"
+    version: "2.1.0"
   path_provider_windows:
     dependency: transitive
     description:
       name: path_provider_windows
-      sha256: "1cb68ba4cd3a795033de62ba1b7b4564dace301f952de6bfb3cd91b202b6ee96"
+      sha256: ee0e0d164516b90ae1f970bdf29f726f1aa730d7cfc449ecc74c495378b705da
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.7"
+    version: "2.2.0"
   pdf:
     dependency: "direct main"
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -349,10 +349,10 @@ packages:
     dependency: "direct main"
     description:
       name: fluent_ui
-      sha256: "9957c04c0b73f366f94dea1422c80c2c21511453e727d7b1b5836dc457add5bf"
+      sha256: "4a228a8d7dc93a1a8dc339cc99d439cf66ea5816285e76751ac5183f2ea10ced"
       url: "https://pub.dev"
     source: hosted
-    version: "4.7.1"
+    version: "4.7.2"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -832,10 +832,10 @@ packages:
     dependency: transitive
     description:
       name: puppeteer
-      sha256: f00b54703dc22af04eaace8f23a33c56008870f990684c2ad8c4115ac51b0a38
+      sha256: "59e723cc5b69537159a7c34efd645dc08a6a1ac4647d7d7823606802c0f93cdb"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.1"
+    version: "3.2.0"
   qr:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
 
   # UI
   auto_size_text: 3.0.0
-  fluent_ui: 4.7.1
+  fluent_ui: 4.7.2
   go_router: 10.0.0
   flutter_svg: 2.0.7
   animated_text_kit: 4.2.2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -45,7 +45,7 @@ dependencies:
 
   # Interop
   ffi: 2.0.2
-  flutter_rust_bridge: 1.79.0
+  flutter_rust_bridge: 1.80.1
 
   # Printing
   printing: 5.11.0

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -172,7 +172,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.27",
+ "syn 2.0.28",
  "which",
 ]
 
@@ -278,11 +278,12 @@ checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 
 [[package]]
 name = "cc"
-version = "1.0.79"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+checksum = "6c6b2562119bf28c3439f7f02db99faf0aa1a8cdfe5772a2ee155d32227239f0"
 dependencies = [
  "jobserver",
+ "libc",
 ]
 
 [[package]]
@@ -739,9 +740,9 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
+checksum = "6b30f669a7961ef1631673d2766cc92f52d64f7ef354d4fe0ddfd30ed52f0f4f"
 dependencies = [
  "errno-dragonfly",
  "libc",
@@ -851,9 +852,9 @@ dependencies = [
 
 [[package]]
 name = "flutter_rust_bridge"
-version = "1.79.0"
+version = "1.80.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c8be4e3bf1221c2ce3e8006d548f4d3618deda475f192a65e0d55b33796cacc"
+checksum = "fd0305ebc9f097d9826530a55fc2acd63222e912c663f7adce3ab641ecc0f346"
 dependencies = [
  "allo-isolate",
  "anyhow",
@@ -876,9 +877,9 @@ dependencies = [
 
 [[package]]
 name = "flutter_rust_bridge_macros"
-version = "1.79.0"
+version = "1.80.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "237edf0d1cea56e5699ee37f906c265de99d55657df4ff2c006ada9541c04996"
+checksum = "df72ed73cd22d3fb77333d6ed1f02f7284b23266f2f6b5d0cbaed82013a8cd29"
 
 [[package]]
 name = "fnv"
@@ -967,7 +968,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2 1.0.66",
  "quote 1.0.32",
- "syn 2.0.27",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -1449,9 +1450,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.3"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09fc20d2ca12cb9f044c93e3bd6d32d523e6e2ec3db4f7b2939cd99026ecd3f0"
+checksum = "57bcfdad1b858c2db7c38303a6d2ad4dfaf5eb53dfeb0910128b2c26d6158503"
 
 [[package]]
 name = "lock_api"
@@ -1906,7 +1907,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2 1.0.66",
  "quote 1.0.32",
- "syn 2.0.27",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -2048,7 +2049,7 @@ checksum = "ec2e072ecce94ec471b13398d5402c188e76ac03cf74dd1a975161b23a3f6d9c"
 dependencies = [
  "proc-macro2 1.0.66",
  "quote 1.0.32",
- "syn 2.0.27",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -2095,7 +2096,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c64d9ba0963cdcea2e1b2230fbae2bab30eb25a174be395c41e764bfb65dd62"
 dependencies = [
  "proc-macro2 1.0.66",
- "syn 2.0.27",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -2374,9 +2375,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39354c10dd07468c2e73926b23bb9c2caca74c5501e38a35da70406f1d923310"
+checksum = "b7b6d6190b7594385f61bd3911cd1be99dfddcfc365a4160cc2ab5bff4aed294"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2487,9 +2488,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.4"
+version = "0.38.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a962918ea88d644592894bc6dc55acc6c0956488adcebbfb6e273506b7fd6e5"
+checksum = "1ee020b1716f0a80e2ace9b03441a749e402e86712f15f16fe8a8f75afac732f"
 dependencies = [
  "bitflags 2.3.3",
  "errno",
@@ -2500,9 +2501,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.5"
+version = "0.21.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79ea77c539259495ce8ca47f53e66ae0330a8819f67e23ac96ca02f50e7b7d36"
+checksum = "1d1feddffcfcc0b33f5c6ce9a29e341e4cd59c3f78e7ee45f4a40c038b1d6cbb"
 dependencies = [
  "log 0.4.19",
  "ring",
@@ -2612,22 +2613,22 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.176"
+version = "1.0.181"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76dc28c9523c5d70816e393136b86d48909cfb27cecaa902d338c19ed47164dc"
+checksum = "6d3e73c93c3240c0bda063c239298e633114c69a888c3e37ca8bb33f343e9890"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.176"
+version = "1.0.181"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4e7b8c5dc823e3b90651ff1d3808419cd14e5ad76de04feaf37da114e7a306f"
+checksum = "be02f6cb0cd3a5ec20bbcfbcbd749f57daddb1a0882dc2e46a6c236c90b977ed"
 dependencies = [
  "proc-macro2 1.0.66",
  "quote 1.0.32",
- "syn 2.0.27",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -2876,9 +2877,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.27"
+version = "2.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b60f673f44a8255b9c8c657daf66a596d435f2da81a555b06dc644d080ba45e0"
+checksum = "04361975b3f5e348b2189d8dc55bc942f278b2d482a6a0365de5bdd62d351567"
 dependencies = [
  "proc-macro2 1.0.66",
  "quote 1.0.32",
@@ -2915,7 +2916,7 @@ checksum = "090198534930841fab3a5d1bb637cde49e339654e606195f8d9c76eeb081dc96"
 dependencies = [
  "proc-macro2 1.0.66",
  "quote 1.0.32",
- "syn 2.0.27",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -3371,7 +3372,7 @@ dependencies = [
  "once_cell",
  "proc-macro2 1.0.66",
  "quote 1.0.32",
- "syn 2.0.27",
+ "syn 2.0.28",
  "wasm-bindgen-shared",
 ]
 
@@ -3405,7 +3406,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2 1.0.66",
  "quote 1.0.32",
- "syn 2.0.27",
+ "syn 2.0.28",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["lib", "staticlib", "cdylib"]
 [dependencies]
 derive_more = "0.99.17"
 atom_table = "1.1.0"
-flutter_rust_bridge = "1.79.0"
+flutter_rust_bridge = "1.80.1"
 ffsend-api = "0.7.3"
 serde_json = "1.0.103"
 chrono = "0.4.26"


### PR DESCRIPTION
The PR:
- Workarounds the black collage image issue (image captured from camera appearing fully black in capture) by awaiting the postFrameCallback once
- Cleans up the PhotoCollage widget and related code
- Updates Flutter and Rust packages