### PR TITLE
Allow saving captures photos to disk

### DIFF
--- a/lib/hardware_control/gphoto2_camera.dart
+++ b/lib/hardware_control/gphoto2_camera.dart
@@ -48,6 +48,9 @@ class GPhoto2Camera extends LiveViewSource implements PhotoCaptureMethod {
     await rustLibraryApi.gphoto2StartLiveview(handleId: handleId, operations: [
       const ImageOperation.cropToAspectRatio(3 / 2),
     ], texturePtr: texturePtr);
+    rustLibraryApi.gphoto2SetExtraFileCallback(handleId: handleId).listen((element) {
+      print("Extra file ${element.filename} received of length: ${element.data.length}");
+    });
   }
 
   @override
@@ -66,7 +69,7 @@ class GPhoto2Camera extends LiveViewSource implements PhotoCaptureMethod {
   Future<Uint8List> captureAndGetPhoto() async {
     await _ensureLibraryInitialized();
     String captureTarget = SettingsManager.instance.settings.hardware.gPhoto2CaptureTarget;
-    return await rustLibraryApi.gphoto2CapturePhoto(handleId: handleId, captureTargetValue: captureTarget);
+    return (await rustLibraryApi.gphoto2CapturePhoto(handleId: handleId, captureTargetValue: captureTarget)).data;
   }
 
   @override

--- a/lib/hardware_control/gphoto2_camera.dart
+++ b/lib/hardware_control/gphoto2_camera.dart
@@ -1,4 +1,5 @@
 
+import 'dart:async';
 import 'dart:typed_data';
 
 import 'package:fluent_ui/fluent_ui.dart' show ComboBoxItem, Text;
@@ -78,6 +79,8 @@ class GPhoto2Camera extends PhotoCaptureMethod implements LiveViewSource {
     String captureTarget = SettingsManager.instance.settings.hardware.gPhoto2CaptureTarget;
     var capture = await rustLibraryApi.gphoto2CapturePhoto(handleId: handleId, captureTargetValue: captureTarget);
     await storePhotoSafe(capture.filename, capture.data);
+    
+    unawaited(clearPreviousEvents());
 
     return capture.data;
   }

--- a/lib/hardware_control/live_view_streaming/live_view_source.dart
+++ b/lib/hardware_control/live_view_streaming/live_view_source.dart
@@ -2,10 +2,8 @@ import 'package:momento_booth/rust_bridge/library_api.generated.dart';
 
 abstract class LiveViewSource {
 
-  final String id;
-  final String friendlyName;
-
-  LiveViewSource({required this.id, required this.friendlyName});
+  String get id;
+  String get friendlyName;
 
   Future<void> openStream({required int texturePtr});
 

--- a/lib/hardware_control/live_view_streaming/noise_source.dart
+++ b/lib/hardware_control/live_view_streaming/noise_source.dart
@@ -4,9 +4,15 @@ import 'package:momento_booth/rust_bridge/library_bridge.dart';
 
 class NoiseSource extends LiveViewSource {
 
+  @override
+  final String id = '';
+
+  @override
+  final String friendlyName = '';
+
   late int _handleId;
 
-  NoiseSource() : super(id: '', friendlyName: '');
+  NoiseSource();
 
   @override
   Future<void> openStream({required int texturePtr}) async => _handleId = await rustLibraryApi.noiseOpen(texturePtr: texturePtr);

--- a/lib/hardware_control/live_view_streaming/nokhwa_camera.dart
+++ b/lib/hardware_control/live_view_streaming/nokhwa_camera.dart
@@ -7,9 +7,15 @@ import 'package:momento_booth/rust_bridge/library_bridge.dart';
 
 class NokhwaCamera extends LiveViewSource {
 
+  @override
+  final String id;
+
+  @override
+  final String friendlyName;
+
   late int handleId;
 
-  NokhwaCamera({required super.id, required super.friendlyName});
+  NokhwaCamera({required this.id, required this.friendlyName});
 
   // //////////// //
   // List cameras //

--- a/lib/hardware_control/photo_capturing/live_view_stream_snapshot_capturer.dart
+++ b/lib/hardware_control/photo_capturing/live_view_stream_snapshot_capturer.dart
@@ -4,17 +4,17 @@ import 'package:momento_booth/hardware_control/photo_capturing/photo_capture_met
 import 'package:momento_booth/managers/live_view_manager.dart';
 import 'package:momento_booth/rust_bridge/library_bridge.dart';
 
-class LiveViewStreamSnapshotCapturer with UiLoggy implements PhotoCaptureMethod {
+class LiveViewStreamSnapshotCapturer extends PhotoCaptureMethod with UiLoggy {
 
   @override
   Duration get captureDelay => const Duration(milliseconds: -17);
 
   @override
   Future<Uint8List> captureAndGetPhoto() async {
-    final stopwatch = Stopwatch()..start();
     final rawImage = await LiveViewManager.instance.currentLiveViewSource?.getLastFrame();
     final jpegData = await rustLibraryApi.jpegEncode(rawImage: rawImage!, quality: 80, operationsBeforeEncoding: []);
-    loggy.debug('JPEG encoding took ${stopwatch.elapsed}');
+
+    await storePhotoSafe('liveview.jpg', jpegData);
 
     return jpegData;
   }

--- a/lib/hardware_control/photo_capturing/photo_capture_method.dart
+++ b/lib/hardware_control/photo_capturing/photo_capture_method.dart
@@ -1,4 +1,10 @@
+import 'dart:io';
 import 'dart:typed_data';
+
+import 'package:intl/intl.dart';
+import 'package:loggy/loggy.dart' as loggy;
+import 'package:momento_booth/managers/settings_manager.dart';
+import 'package:path/path.dart' as path;
 
 abstract class PhotoCaptureMethod {
 
@@ -7,5 +13,23 @@ abstract class PhotoCaptureMethod {
   Future<void> clearPreviousEvents();
 
   Future<Uint8List> captureAndGetPhoto();
+
+  Future<void> storePhotoSafe(String filename, Uint8List fileData) async {
+    if (SettingsManager.instance.settings.hardware.saveCapturesToDisk) {
+      try {
+        DateFormat formatter = DateFormat('yyyyMMdd_HHmmss');
+        String currentDateTime = formatter.format(DateTime.now());
+        String fileName = "${currentDateTime}_$filename";
+
+        await Directory(SettingsManager.instance.settings.hardware.captureStorageLocation).create(recursive: true);
+
+        File file = File(path.join(SettingsManager.instance.settings.hardware.captureStorageLocation, fileName));
+        await file.writeAsBytes(fileData, mode: FileMode.writeOnly);
+        loggy.logDebug("Stored incoming photo to disk: ${file.path}");
+      } catch (exception, stacktrace) {
+        loggy.logError("Could not save photo to disk", exception, stacktrace);
+      }
+    }
+  }
 
 }

--- a/lib/models/settings.dart
+++ b/lib/models/settings.dart
@@ -66,6 +66,8 @@ class HardwareSettings with _$HardwareSettings implements TomlEncodableValue {
     @Default(100) int captureDelayGPhoto2,
     @Default(200) int captureDelaySony,
     @JsonKey(defaultValue: _captureLocationFromJson) required String captureLocation,
+    @Default(true) bool saveCapturesToDisk,
+    @JsonKey(defaultValue: _captureStorageLocationFromJson) required String captureStorageLocation,
     @Default([]) List<String> printerNames,
     @Default(148) double pageHeight,
     @Default(100) double pageWidth,
@@ -206,6 +208,7 @@ class MqttIntegrationSettings with _$MqttIntegrationSettings implements TomlEnco
 
 String _templatesFolderFromJson() => join(_getHome(), "Pictures", "MomentoBooth", "Templates");
 String _captureLocationFromJson() => join(_getHome(), "Pictures", "MomentoBooth", "Captures");
+String _captureStorageLocationFromJson() => join(_getHome(), "Pictures", "MomentoBooth", "From camera");
 String _localFolderFromJson() => join(_getHome(), "Pictures", "MomentoBooth", "Output");
 String _clientIdFromJson() => 'momentobooth-photobooth-${getRandomString()}';
 String _homeAssistantComponentIdFromJson() => 'momentobooth-${getRandomString()}';

--- a/lib/views/settings_screen/settings_screen_controller.dart
+++ b/lib/views/settings_screen/settings_screen_controller.dart
@@ -14,6 +14,9 @@ class SettingsScreenController extends ScreenControllerBase<SettingsScreenViewMo
   TextEditingController? _captureLocationController;
   TextEditingController get captureLocationController => _captureLocationController ??= TextEditingController(text: viewModel.captureLocationSetting);
 
+  TextEditingController? _captureStorageLocationController;
+  TextEditingController get captureStorageLocationController => _captureStorageLocationController ??= TextEditingController(text: viewModel.captureStorageLocationSetting);
+
   TextEditingController? _localFolderController;
   TextEditingController get localFolderSettingController => _localFolderController ??= TextEditingController(text: viewModel.localFolderSetting);
 
@@ -157,6 +160,18 @@ class SettingsScreenController extends ScreenControllerBase<SettingsScreenViewMo
   void onCaptureLocationChanged(String? captureLocation) {
     if (captureLocation != null) {
       viewModel.updateSettings((settings) => settings.copyWith.hardware(captureLocation: captureLocation));
+    }
+  }
+
+  void onSaveCapturesToDiskChanged(bool? saveCapturesToDisk) {
+    if (saveCapturesToDisk != null) {
+      viewModel.updateSettings((settings) => settings.copyWith.hardware(saveCapturesToDisk: saveCapturesToDisk));
+    }
+  }
+
+  void onCaptureStorageLocationChanged(String? captureStorageLocation) {
+    if (captureStorageLocation != null) {
+      viewModel.updateSettings((settings) => settings.copyWith.hardware(captureStorageLocation: captureStorageLocation));
     }
   }
 

--- a/lib/views/settings_screen/settings_screen_view.hardware.dart
+++ b/lib/views/settings_screen/settings_screen_view.hardware.dart
@@ -16,7 +16,9 @@ Widget _getHardwareSettings(SettingsScreenViewModel viewModel, SettingsScreenCon
             onChanged: controller.onLiveViewMethodChanged,
           ),
           Observer(builder: (_) {
-            if (viewModel.liveViewMethodSetting == LiveViewMethod.webcam) return _webcamCard(viewModel, controller);
+            if (viewModel.liveViewMethodSetting == LiveViewMethod.webcam) {
+              return _webcamCard(viewModel, controller);
+            }
             return const SizedBox();
           }),
           _getComboBoxCard(
@@ -90,13 +92,32 @@ Widget _getHardwareSettings(SettingsScreenViewModel viewModel, SettingsScreenCon
             }
             return const SizedBox();
           }),
-          _getFolderPickerCard(
-            icon: FluentIcons.folder,
-            title: "Capture location",
-            subtitle: "Location to look for captured images",
-            controller: controller.captureLocationController,
-            onChanged: controller.onCaptureLocationChanged,
+          Observer(builder: (_) {
+            if (viewModel.captureMethodSetting == CaptureMethod.sonyImagingEdgeDesktop) {
+              return _getFolderPickerCard(
+                icon: FluentIcons.folder,
+                title: "Capture location",
+                subtitle: "Location to look for captured images",
+                controller: controller.captureLocationController,
+                onChanged: controller.onCaptureLocationChanged,
+              );
+            }
+            return const SizedBox();
+          }),
+          _getBooleanInput(
+            icon: FluentIcons.hard_drive,
+            title: "Save captures to disk",
+            subtitle: "Location where all captured photos (as retrieved from the capture implementation) will be saved to",
+            value: () => viewModel.saveCapturesToDiskSetting,
+            onChanged: controller.onSaveCapturesToDiskChanged,
           ),
+          _getFolderPickerCard(
+            icon: FluentIcons.hard_drive,
+            title: "Capture storage location",
+            subtitle: "Location where all captured photos (as retrieved from the capture implementation) will be saved to",
+            controller: controller.captureStorageLocationController,
+            onChanged: controller.onCaptureStorageLocationChanged,
+          )
         ],
       ),
       FluentSettingsBlock(

--- a/lib/views/settings_screen/settings_screen_view.hardware.dart
+++ b/lib/views/settings_screen/settings_screen_view.hardware.dart
@@ -4,168 +4,193 @@ Widget _getHardwareSettings(SettingsScreenViewModel viewModel, SettingsScreenCon
   return FluentSettingsPage(
     title: "Hardware",
     blocks: [
-      FluentSettingsBlock(
-        title: "Live view",
-        settings: [
-          _getComboBoxCard(
-            icon: FluentIcons.camera,
-            title: "Live view method",
-            subtitle: "Method used for live previewing",
-            items: viewModel.liveViewMethods,
-            value: () => viewModel.liveViewMethodSetting,
-            onChanged: controller.onLiveViewMethodChanged,
-          ),
-          Observer(builder: (_) {
-            if (viewModel.liveViewMethodSetting == LiveViewMethod.webcam) {
-              return _webcamCard(viewModel, controller);
-            }
-            return const SizedBox();
-          }),
-          _getComboBoxCard(
-            icon: FluentIcons.camera,
-            title: "Flip image",
-            subtitle: "Whether the image should be flipped in none, one or both axis",
-            items: viewModel.liveViewFlipImageChoices,
-            value: () => viewModel.liveViewFlipImage,
-            onChanged: controller.onLiveViewFlipImageChanged,
-          ),
-        ],
+      _getLiveViewBlock(viewModel, controller),
+      _getPhotoCaptureBlock(viewModel, controller),
+      _getPrintingBlock(viewModel, controller),
+    ],
+  );
+}
+
+Widget _getLiveViewBlock(SettingsScreenViewModel viewModel, SettingsScreenController controller) {
+  return FluentSettingsBlock(
+    title: "Live view",
+    settings: [
+      _getComboBoxCard(
+        icon: FluentIcons.camera,
+        title: "Live view method",
+        subtitle: "Method used for live previewing",
+        items: viewModel.liveViewMethods,
+        value: () => viewModel.liveViewMethodSetting,
+        onChanged: controller.onLiveViewMethodChanged,
       ),
-      FluentSettingsBlock(
-        title: "Photo capture",
-        settings: [
-          _getComboBoxCard(
+      Observer(builder: (_) {
+        if (viewModel.liveViewMethodSetting == LiveViewMethod.webcam) {
+          return _getWebcamCard(viewModel, controller);
+        }
+        return const SizedBox();
+      }),
+      _getComboBoxCard(
+        icon: FluentIcons.camera,
+        title: "Flip image",
+        subtitle: "Whether the image should be flipped in none, one or both axis",
+        items: viewModel.liveViewFlipImageChoices,
+        value: () => viewModel.liveViewFlipImage,
+        onChanged: controller.onLiveViewFlipImageChanged,
+      ),
+    ],
+  );
+}
+
+Widget _getPhotoCaptureBlock(SettingsScreenViewModel viewModel, SettingsScreenController controller) {
+  return FluentSettingsBlock(
+    title: "Photo capture",
+    settings: [
+      _getComboBoxCard(
+        icon: FluentIcons.camera,
+        title: "Capture method",
+        subtitle: "Method used for capturing final images",
+        items: viewModel.captureMethods,
+        value: () => viewModel.captureMethodSetting,
+        onChanged: controller.onCaptureMethodChanged,
+      ),
+      Observer(builder: (_) {
+        if (viewModel.captureMethodSetting == CaptureMethod.sonyImagingEdgeDesktop) {
+          return _getInput(
+            icon: FluentIcons.timer,
+            title: "Capture delay for Sony camera",
+            subtitle: "Delay in [ms]. Sensible values are between 165 (manual focus) and 500 ms.",
+            value: () => viewModel.captureDelaySonySetting,
+            onChanged: controller.onCaptureDelaySonyChanged,
+          );
+        }
+        return const SizedBox();
+      }),
+      Observer(builder: (_) {
+        if (viewModel.captureMethodSetting == CaptureMethod.gPhoto2 || viewModel.liveViewMethodSetting == LiveViewMethod.gphoto2) {
+            return _gPhoto2CamerasCard(viewModel, controller);
+        }
+        return const SizedBox();
+      }),
+      Observer(builder: (_) {
+        if (viewModel.captureMethodSetting == CaptureMethod.gPhoto2 || viewModel.liveViewMethodSetting == LiveViewMethod.gphoto2) {
+          return _getComboBoxCard(
             icon: FluentIcons.camera,
-            title: "Capture method",
-            subtitle: "Method used for capturing final images",
-            items: viewModel.captureMethods,
-            value: () => viewModel.captureMethodSetting,
-            onChanged: controller.onCaptureMethodChanged,
-          ),
-          Observer(builder: (_) {
-            if (viewModel.captureMethodSetting == CaptureMethod.sonyImagingEdgeDesktop) {
-              return _getInput(
-                icon: FluentIcons.timer,
-                title: "Capture delay for Sony camera",
-                subtitle: "Delay in [ms]. Sensible values are between 165 (manual focus) and 500 ms.",
-                value: () => viewModel.captureDelaySonySetting,
-                onChanged: controller.onCaptureDelaySonyChanged,
-              );
-            }
-            return const SizedBox();
-          }),
-          Observer(builder: (_) {
-            if (viewModel.captureMethodSetting == CaptureMethod.gPhoto2 || viewModel.liveViewMethodSetting == LiveViewMethod.gphoto2) {
-                return _gPhoto2CamerasCard(viewModel, controller);
-            }
-            return const SizedBox();
-          }),
-          Observer(builder: (_) {
-            if (viewModel.captureMethodSetting == CaptureMethod.gPhoto2 || viewModel.liveViewMethodSetting == LiveViewMethod.gphoto2) {
-              return _getComboBoxCard(
-                icon: FluentIcons.camera,
-                title: "Use special handling for camera",
-                subtitle: "Kind of special handling used for the camera. Pick \"Nikon DSLR\" for cameras like the D-series. The \"None\" might work for most mirrorless camera as they are always in live view mode.",
-                items: viewModel.gPhoto2SpecialHandlingOptions,
-                value: () => viewModel.gPhoto2SpecialHandling,
-                onChanged: controller.onGPhoto2SpecialHandlingChanged,
-              );
-            }
-            return const SizedBox();
-          }),
-          _getTextInput(
+            title: "Use special handling for camera",
+            subtitle: "Kind of special handling used for the camera. Pick \"Nikon DSLR\" for cameras like the D-series. The \"None\" might work for most mirrorless camera as they are always in live view mode.",
+            items: viewModel.gPhoto2SpecialHandlingOptions,
+            value: () => viewModel.gPhoto2SpecialHandling,
+            onChanged: controller.onGPhoto2SpecialHandlingChanged,
+          );
+        }
+        return const SizedBox();
+      }),
+      Observer(builder: (_) {
+        if (viewModel.captureMethodSetting == CaptureMethod.gPhoto2) {
+          return _getTextInput(
             icon: FluentIcons.s_d_card,
             title: "Camera capture target",
             subtitle: "Sets the camera's 'capturetarget'. When unsure, leave empty as it could cause capture issues. Values can be found in the libgphoto2 source code.",
             controller: controller.gPhoto2CaptureTargetController,
             onChanged: controller.onGPhoto2CaptureTargetChanged,
-          ),
-          Observer(builder: (_) {
-            if (viewModel.captureMethodSetting == CaptureMethod.gPhoto2) {
-              return _getInput(
-                icon: FluentIcons.timer,
-                title: "Capture delay for gPhoto2 camera.",
-                subtitle: "Delay in [ms].",
-                value: () => viewModel.captureDelayGPhoto2Setting,
-                onChanged: controller.onCaptureDelayGPhoto2Changed,
-              );
-            }
-            return const SizedBox();
-          }),
-          Observer(builder: (_) {
-            if (viewModel.captureMethodSetting == CaptureMethod.sonyImagingEdgeDesktop) {
-              return _getFolderPickerCard(
-                icon: FluentIcons.folder,
-                title: "Capture location",
-                subtitle: "Location to look for captured images.",
-                controller: controller.captureLocationController,
-                onChanged: controller.onCaptureLocationChanged,
-              );
-            }
-            return const SizedBox();
-          }),
-          if (viewModel.captureMethodSetting != CaptureMethod.sonyImagingEdgeDesktop)
-            _getBooleanInput(
-              icon: FluentIcons.hard_drive,
-              title: "Save captures to disk",
-              subtitle: "Whether to save captures to disk.",
-              value: () => viewModel.saveCapturesToDiskSetting,
-              onChanged: controller.onSaveCapturesToDiskChanged,
-            ),
-          if (viewModel.captureMethodSetting != CaptureMethod.sonyImagingEdgeDesktop)
-            _getFolderPickerCard(
-              icon: FluentIcons.hard_drive,
-              title: "Capture storage location",
-              subtitle: "Location where all captured photos (as retrieved from the capture implementation) will be saved to",
-              controller: controller.captureStorageLocationController,
-              onChanged: controller.onCaptureStorageLocationChanged,
-            ),
-        ],
+          );
+        }
+        return const SizedBox();
+      }),
+      Observer(builder: (_) {
+        if (viewModel.captureMethodSetting == CaptureMethod.gPhoto2) {
+          return _getInput(
+            icon: FluentIcons.timer,
+            title: "Capture delay for gPhoto2 camera.",
+            subtitle: "Delay in [ms].",
+            value: () => viewModel.captureDelayGPhoto2Setting,
+            onChanged: controller.onCaptureDelayGPhoto2Changed,
+          );
+        }
+        return const SizedBox();
+      }),
+      Observer(builder: (_) {
+        if (viewModel.captureMethodSetting == CaptureMethod.sonyImagingEdgeDesktop) {
+          return _getFolderPickerCard(
+            icon: FluentIcons.folder,
+            title: "Capture location",
+            subtitle: "Location to look for captured images.",
+            controller: controller.captureLocationController,
+            onChanged: controller.onCaptureLocationChanged,
+          );
+        }
+        return const SizedBox();
+      }),
+      Observer(builder: (_) {
+        if (viewModel.captureMethodSetting != CaptureMethod.sonyImagingEdgeDesktop) {
+          return _getBooleanInput(
+            icon: FluentIcons.hard_drive,
+            title: "Save captures to disk",
+            subtitle: "Whether to save captures to disk.",
+            value: () => viewModel.saveCapturesToDiskSetting,
+            onChanged: controller.onSaveCapturesToDiskChanged,
+          );
+        }
+        return const SizedBox();
+      }),
+      Observer(builder: (_) {
+        if (viewModel.captureMethodSetting != CaptureMethod.sonyImagingEdgeDesktop && viewModel.saveCapturesToDiskSetting) {
+          return _getFolderPickerCard(
+            icon: FluentIcons.hard_drive,
+            title: "Capture storage location",
+            subtitle: "Location where all captured photos (as retrieved from the capture implementation) will be saved to",
+            controller: controller.captureStorageLocationController,
+            onChanged: controller.onCaptureStorageLocationChanged,
+          );
+        }
+        return const SizedBox();
+      }),
+    ],
+  );
+}
+
+Widget _getPrintingBlock(SettingsScreenViewModel viewModel, SettingsScreenController controller) {
+  return FluentSettingsBlock(
+    title: "Printing",
+    settings: [
+      Observer(builder: (context) =>
+        Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            for (int i = 0; i <= viewModel.printersSetting.length; i++)
+              _printerCard(viewModel, controller, "Printer ${i+1}", i),
+          ],
+        ),
       ),
-      FluentSettingsBlock(
-        title: "Printing",
-        settings: [
-          Observer(builder: (context) =>
-            Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                for (int i = 0; i <= viewModel.printersSetting.length; i++)
-                  _printerCard(viewModel, controller, "Printer ${i+1}", i),
-              ],
-            ),
-          ),
-          _getInput(
-            icon: FluentIcons.page,
-            title: "Page height",
-            subtitle: 'Page format height used for printing [mm]',
-            value: () => viewModel.pageHeightSetting,
-            onChanged: controller.onPageHeightChanged,
-            smallChange: 0.1,
-          ),
-          _getInput(
-            icon: FluentIcons.page,
-            title: "Page width",
-            subtitle: 'Page format width used for printing [mm]',
-            value: () => viewModel.pageWidthSetting,
-            onChanged: controller.onPageWidthChanged,
-            smallChange: 0.1,
-          ),
-          _printerMargins(viewModel, controller),
-          _getBooleanInput(
-            icon: FluentIcons.settings,
-            title: "usePrinterSettings for printing",
-            subtitle: "Control the usePrinterSettings property of the Flutter printing library.",
-            value: () => viewModel.usePrinterSettingsSetting,
-            onChanged: controller.onUsePrinterSettingsChanged,
-          ),
-          _getInput<int>(
-            icon: FluentIcons.queue_advanced,
-            title: "Queue warning threshold",
-            subtitle: "Number of photos in the OS's printer queue before a warning is shown (Windows only for now).",
-            value: () => viewModel.printerQueueWarningThresholdSetting,
-            onChanged: controller.onPrinterQueueWarningThresholdChanged,
-          ),
-        ],
+      _getInput(
+        icon: FluentIcons.page,
+        title: "Page height",
+        subtitle: 'Page format height used for printing [mm]',
+        value: () => viewModel.pageHeightSetting,
+        onChanged: controller.onPageHeightChanged,
+        smallChange: 0.1,
+      ),
+      _getInput(
+        icon: FluentIcons.page,
+        title: "Page width",
+        subtitle: 'Page format width used for printing [mm]',
+        value: () => viewModel.pageWidthSetting,
+        onChanged: controller.onPageWidthChanged,
+        smallChange: 0.1,
+      ),
+      _printerMargins(viewModel, controller),
+      _getBooleanInput(
+        icon: FluentIcons.settings,
+        title: "usePrinterSettings for printing",
+        subtitle: "Control the usePrinterSettings property of the Flutter printing library.",
+        value: () => viewModel.usePrinterSettingsSetting,
+        onChanged: controller.onUsePrinterSettingsChanged,
+      ),
+      _getInput<int>(
+        icon: FluentIcons.queue_advanced,
+        title: "Queue warning threshold",
+        subtitle: "Number of photos in the OS's printer queue before a warning is shown (Windows only for now).",
+        value: () => viewModel.printerQueueWarningThresholdSetting,
+        onChanged: controller.onPrinterQueueWarningThresholdChanged,
       ),
     ],
   );
@@ -228,7 +253,7 @@ FluentSettingCard _printerMargins(SettingsScreenViewModel viewModel, SettingsScr
   );
 }
 
-FluentSettingCard _webcamCard(SettingsScreenViewModel viewModel, SettingsScreenController controller) {
+FluentSettingCard _getWebcamCard(SettingsScreenViewModel viewModel, SettingsScreenController controller) {
   return FluentSettingCard(
     icon: FluentIcons.camera,
     title: "Webcam",

--- a/lib/views/settings_screen/settings_screen_view.hardware.dart
+++ b/lib/views/settings_screen/settings_screen_view.hardware.dart
@@ -84,7 +84,7 @@ Widget _getHardwareSettings(SettingsScreenViewModel viewModel, SettingsScreenCon
             if (viewModel.captureMethodSetting == CaptureMethod.gPhoto2) {
               return _getInput(
                 icon: FluentIcons.timer,
-                title: "Capture delay for gPhoto2 camera",
+                title: "Capture delay for gPhoto2 camera.",
                 subtitle: "Delay in [ms].",
                 value: () => viewModel.captureDelayGPhoto2Setting,
                 onChanged: controller.onCaptureDelayGPhoto2Changed,
@@ -97,27 +97,29 @@ Widget _getHardwareSettings(SettingsScreenViewModel viewModel, SettingsScreenCon
               return _getFolderPickerCard(
                 icon: FluentIcons.folder,
                 title: "Capture location",
-                subtitle: "Location to look for captured images",
+                subtitle: "Location to look for captured images.",
                 controller: controller.captureLocationController,
                 onChanged: controller.onCaptureLocationChanged,
               );
             }
             return const SizedBox();
           }),
-          _getBooleanInput(
-            icon: FluentIcons.hard_drive,
-            title: "Save captures to disk",
-            subtitle: "Location where all captured photos (as retrieved from the capture implementation) will be saved to",
-            value: () => viewModel.saveCapturesToDiskSetting,
-            onChanged: controller.onSaveCapturesToDiskChanged,
-          ),
-          _getFolderPickerCard(
-            icon: FluentIcons.hard_drive,
-            title: "Capture storage location",
-            subtitle: "Location where all captured photos (as retrieved from the capture implementation) will be saved to",
-            controller: controller.captureStorageLocationController,
-            onChanged: controller.onCaptureStorageLocationChanged,
-          )
+          if (viewModel.captureMethodSetting != CaptureMethod.sonyImagingEdgeDesktop)
+            _getBooleanInput(
+              icon: FluentIcons.hard_drive,
+              title: "Save captures to disk",
+              subtitle: "Whether to save captures to disk.",
+              value: () => viewModel.saveCapturesToDiskSetting,
+              onChanged: controller.onSaveCapturesToDiskChanged,
+            ),
+          if (viewModel.captureMethodSetting != CaptureMethod.sonyImagingEdgeDesktop)
+            _getFolderPickerCard(
+              icon: FluentIcons.hard_drive,
+              title: "Capture storage location",
+              subtitle: "Location where all captured photos (as retrieved from the capture implementation) will be saved to",
+              controller: controller.captureStorageLocationController,
+              onChanged: controller.onCaptureStorageLocationChanged,
+            ),
         ],
       ),
       FluentSettingsBlock(

--- a/lib/views/settings_screen/settings_screen_view.helpers.dart
+++ b/lib/views/settings_screen/settings_screen_view.helpers.dart
@@ -145,7 +145,7 @@ FluentSettingCard _getFolderPickerCard<TValue>({
           child: SizedBox(
             width: 250,
             child: TextBox(
-              enabled: false,
+              readOnly: true,
               controller: controller,
               onChanged: onChanged,
             ),

--- a/lib/views/settings_screen/settings_screen_view.templating.dart
+++ b/lib/views/settings_screen/settings_screen_view.templating.dart
@@ -7,21 +7,21 @@ Widget _getTemplatingSettings(SettingsScreenViewModel viewModel, SettingsScreenC
   return FluentSettingsPage(
     title: "Templating",
     blocks: [
-      _templateSettings(viewModel, controller),
+      _getTemplateSettings(viewModel, controller),
       FluentSettingsBlock(
         title: "Template preview",
         settings: [
           Row(
             children: [
-              templateButton(viewModel, controller, "No photo", 0),
+              _getTemplateButton(viewModel, controller, "No photo", 0),
               buttonMargin,
-              templateButton(viewModel, controller, "1 photo", 1),
+              _getTemplateButton(viewModel, controller, "1 photo", 1),
               buttonMargin,
-              templateButton(viewModel, controller, "2 photos", 2),
+              _getTemplateButton(viewModel, controller, "2 photos", 2),
               buttonMargin,
-              templateButton(viewModel, controller, "3 photos", 3),
+              _getTemplateButton(viewModel, controller, "3 photos", 3),
               buttonMargin,
-              templateButton(viewModel, controller, "4 photos", 4),
+              _getTemplateButton(viewModel, controller, "4 photos", 4),
               buttonMargin,
               FilledButton(
                 onPressed: controller.exportTemplate,
@@ -57,7 +57,7 @@ Widget _getTemplatingSettings(SettingsScreenViewModel viewModel, SettingsScreenC
   );
 }
 
-Widget templateButton(SettingsScreenViewModel viewModel, SettingsScreenController controller, String text, int index) {
+Widget _getTemplateButton(SettingsScreenViewModel viewModel, SettingsScreenController controller, String text, int index) {
   return Observer(
     builder: (context) => Button(
       onPressed: viewModel.previewTemplate == index ? null : () => viewModel.previewTemplate = index,
@@ -91,7 +91,7 @@ Widget _getTemplateExampleRow(SettingsScreenViewModel viewModel, SettingsScreenC
   );
 }
 
-Widget _templateSettings(SettingsScreenViewModel viewModel, SettingsScreenController controller) {
+Widget _getTemplateSettings(SettingsScreenViewModel viewModel, SettingsScreenController controller) {
   return FluentSettingsBlock(
     title: "Creative",
     settings: [

--- a/lib/views/settings_screen/settings_screen_view_model.dart
+++ b/lib/views/settings_screen/settings_screen_view_model.dart
@@ -108,6 +108,8 @@ abstract class SettingsScreenViewModelBase extends ScreenViewModelBase with Stor
   int get captureDelayGPhoto2Setting => SettingsManager.instance.settings.hardware.captureDelayGPhoto2;
   int get captureDelaySonySetting => SettingsManager.instance.settings.hardware.captureDelaySony;
   String get captureLocationSetting => SettingsManager.instance.settings.hardware.captureLocation;
+  bool get saveCapturesToDiskSetting => SettingsManager.instance.settings.hardware.saveCapturesToDisk;
+  String get captureStorageLocationSetting => SettingsManager.instance.settings.hardware.captureStorageLocation;
   List<String> get printersSetting => SettingsManager.instance.settings.hardware.printerNames;
   double get pageHeightSetting => SettingsManager.instance.settings.hardware.pageHeight;
   double get pageWidthSetting => SettingsManager.instance.settings.hardware.pageWidth;


### PR DESCRIPTION
This PR:
- Changes the Rust-to-Dart interface to send over camera file info from gphoto2
- Allows saving captured photos to disk
- Allows saving additional available photos (e.g. RAW when using JPEG+RAW camera setting) to disk
- Should not change anything for the Sony Imaging Edge automation capture method
- Cleanups Settings screen code and makes sure some hardware settings are only available when certain capture method is selected