### PR TITLE
Add gphoto2 capturetarget setting

### DIFF
--- a/.github/workflows/pr-ci-app.yml
+++ b/.github/workflows/pr-ci-app.yml
@@ -58,7 +58,7 @@ jobs:
     - name: Setup Rust cache
       uses: Swatinem/rust-cache@v2
       with:
-        workspaces: "rust -> ../build/windows/x64/Debug/cargo/build"
+        workspaces: "rust -> ../build/windows/x64/Release/cargo/build"
 
     - name: Setup sccache-cache
       uses: mozilla-actions/sccache-action@v0.0.3

--- a/.github/workflows/release-win-x64.yml
+++ b/.github/workflows/release-win-x64.yml
@@ -64,7 +64,7 @@ jobs:
     - name: Setup Rust cache
       uses: Swatinem/rust-cache@v2
       with:
-        workspaces: "rust -> ../build/windows/x64/Debug/cargo/build"
+        workspaces: "rust -> ../build/windows/x64/Release/cargo/build"
 
     - name: Setup sccache-cache
       uses: mozilla-actions/sccache-action@v0.0.3

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,8 +1,6 @@
 include: package:flutter_lints/flutter.yaml
 
 analyzer:
-  plugins:
-    - dart_code_metrics
   exclude:
     - '**/*.g.dart'
     - '**/*.freezed.dart'
@@ -55,7 +53,3 @@ linter:
     - use_string_buffers
     - use_super_parameters
     - use_to_and_as_if_applicable
-
-dart_code_metrics:
-  rules:
-    - prefer-conditional-expressions

--- a/distribute_options.yaml
+++ b/distribute_options.yaml
@@ -1,9 +1,0 @@
-output: dist/
-releases:
-  - name: dev
-    jobs:
-      # Build and publish for Linux AppImage
-      - name: release-linux-appimage
-        package:
-          platform: linux
-          target: appimage

--- a/lib/hardware_control/gphoto2_camera.dart
+++ b/lib/hardware_control/gphoto2_camera.dart
@@ -60,7 +60,8 @@ class GPhoto2Camera extends LiveViewSource implements PhotoCaptureMethod {
 
   @override
   Future<Uint8List> captureAndGetPhoto() async {
-    return await rustLibraryApi.gphoto2CapturePhoto(handleId: handleId);
+    String captureTarget = SettingsManager.instance.settings.hardware.gPhoto2CaptureTarget;
+    return await rustLibraryApi.gphoto2CapturePhoto(handleId: handleId, captureTargetValue: captureTarget);
   }
 
   @override

--- a/lib/models/settings.dart
+++ b/lib/models/settings.dart
@@ -74,6 +74,7 @@ class HardwareSettings with _$HardwareSettings implements TomlEncodableValue {
     @Default(CaptureMethod.liveViewSource) CaptureMethod captureMethod,
     @Default("") String gPhoto2CameraId,
     @Default(GPhoto2SpecialHandling.none) GPhoto2SpecialHandling gPhoto2SpecialHandling,
+    @Default("") String gPhoto2CaptureTarget,
     @Default(100) int captureDelayGPhoto2,
     @Default(200) int captureDelaySony,
     @Default("") String captureLocation,

--- a/lib/views/settings_screen/settings_screen_controller.dart
+++ b/lib/views/settings_screen/settings_screen_controller.dart
@@ -22,6 +22,9 @@ class SettingsScreenController extends ScreenControllerBase<SettingsScreenViewMo
 
   TextEditingController? _firefoxSendServerUrlController;
   TextEditingController get firefoxSendServerUrlController => _firefoxSendServerUrlController ??= TextEditingController(text: viewModel.firefoxSendServerUrlSetting);
+  
+  TextEditingController? _gPhoto2CaptureTargetController;
+  TextEditingController get gPhoto2CaptureTargetController => _gPhoto2CaptureTargetController ??= TextEditingController(text: viewModel.gPhoto2CaptureTargetSetting);
 
   // Initialization/Deinitialization
 
@@ -109,6 +112,12 @@ class SettingsScreenController extends ScreenControllerBase<SettingsScreenViewMo
   void onGPhoto2SpecialHandlingChanged(GPhoto2SpecialHandling? gPhoto2SpecialHandling) {
     if (gPhoto2SpecialHandling != null) {
       viewModel.updateSettings((settings) => settings.copyWith.hardware(gPhoto2SpecialHandling: gPhoto2SpecialHandling));
+    }
+  }
+
+  void onGPhoto2CaptureTargetChanged(String? gPhoto2CaptureTarget) {
+    if (gPhoto2CaptureTarget != null) {
+      viewModel.updateSettings((settings) => settings.copyWith.hardware(gPhoto2CaptureTarget: gPhoto2CaptureTarget));
     }
   }
   

--- a/lib/views/settings_screen/settings_screen_view.hardware.dart
+++ b/lib/views/settings_screen/settings_screen_view.hardware.dart
@@ -71,6 +71,13 @@ Widget _getHardwareSettings(SettingsScreenViewModel viewModel, SettingsScreenCon
             }
             return const SizedBox();
           }),
+          _getTextInput(
+            icon: FluentIcons.s_d_card,
+            title: "Camera capture target",
+            subtitle: "Sets the camera's 'capturetarget'. When unsure, leave empty as it could cause capture issues. Values can be found in the libgphoto2 source code.",
+            controller: controller.gPhoto2CaptureTargetController,
+            onChanged: controller.onGPhoto2CaptureTargetChanged,
+          ),
           Observer(builder: (_) {
             if (viewModel.captureMethodSetting == CaptureMethod.gPhoto2) {
               return _getInput(

--- a/lib/views/settings_screen/settings_screen_view_model.dart
+++ b/lib/views/settings_screen/settings_screen_view_model.dart
@@ -104,6 +104,7 @@ abstract class SettingsScreenViewModelBase extends ScreenViewModelBase with Stor
   CaptureMethod get captureMethodSetting => SettingsManager.instance.settings.hardware.captureMethod;
   String get gPhoto2CameraId => SettingsManager.instance.settings.hardware.gPhoto2CameraId;
   GPhoto2SpecialHandling get gPhoto2SpecialHandling => SettingsManager.instance.settings.hardware.gPhoto2SpecialHandling;
+  String get gPhoto2CaptureTargetSetting => SettingsManager.instance.settings.hardware.gPhoto2CaptureTarget;
   int get captureDelayGPhoto2Setting => SettingsManager.instance.settings.hardware.captureDelayGPhoto2;
   int get captureDelaySonySetting => SettingsManager.instance.settings.hardware.captureDelaySony;
   String get captureLocationSetting => SettingsManager.instance.settings.hardware.captureLocation;

--- a/rust/src/dart_bridge/api.rs
+++ b/rust/src/dart_bridge/api.rs
@@ -274,12 +274,12 @@ pub fn gphoto2_auto_focus(handle_id: usize) {
     }).expect("Could not get result")
 }
 
-pub fn gphoto2_capture_photo(handle_id: usize) -> Vec<u8> {
+pub fn gphoto2_capture_photo(handle_id: usize, capture_target_value: String) -> Vec<u8> {
     let camera_ref = GPHOTO2_HANDLES.get(&handle_id).expect("Invalid gPhoto2 handle ID");
     let camera = camera_ref.clone().lock().expect("Could not lock camera").camera.clone();
 
     TOKIO_RUNTIME.get().expect("Could not get tokio runtime").block_on(async{
-        gphoto2::capture_photo(camera).await        
+        gphoto2::capture_photo(camera, capture_target_value).await        
     }).expect("Could not get result")
 }
 

--- a/rust/src/hardware_control/live_view/gphoto2.rs
+++ b/rust/src/hardware_control/live_view/gphoto2.rs
@@ -2,6 +2,7 @@ use std::{sync::{OnceLock, atomic::{AtomicBool, Ordering}, Arc}, any::Any, cell:
 
 use gphoto2::{Context, list::CameraDescriptor, widget::{TextWidget, RadioWidget}, Camera, Error};
 
+use tokio::sync::Mutex as AsyncMutex;
 use tokio::task::JoinHandle as AsyncJoinHandle;
 
 use crate::{utils::jpeg, dart_bridge::api::RawImage, log_debug};

--- a/rust/src/hardware_control/live_view/gphoto2.rs
+++ b/rust/src/hardware_control/live_view/gphoto2.rs
@@ -2,10 +2,9 @@ use std::{sync::{OnceLock, atomic::{AtomicBool, Ordering}, Arc}, any::Any, cell:
 
 use gphoto2::{Context, list::CameraDescriptor, widget::{TextWidget, RadioWidget}, Camera, Error};
 
-use tokio::{sync::Mutex as AsyncMutex};
 use tokio::task::JoinHandle as AsyncJoinHandle;
 
-use crate::{utils::jpeg, dart_bridge::api::RawImage, log_info};
+use crate::{utils::jpeg, dart_bridge::api::RawImage, log_debug};
 
 static CONTEXT: OnceLock<Context> = OnceLock::new();
 
@@ -119,8 +118,7 @@ pub async fn capture_photo(camera_ref: Arc<AsyncMutex<GPhoto2Camera>>, capture_t
   }
 
   let capture = camera.camera.capture_image().await?;
-  log_info("DFile:".to_string());
-  log_info(capture.folder().to_string());
+  log_debug(format!("Downloading file from camera: {}/{}", capture.folder(), capture.name()));
   
   let file = camera.camera.fs().download(&capture.folder(), &capture.name()).await?;
   let data = file.get_data(get_context()?).await?;

--- a/rust/src/hardware_control/live_view/gphoto2.rs
+++ b/rust/src/hardware_control/live_view/gphoto2.rs
@@ -1,11 +1,11 @@
 use std::{sync::{OnceLock, atomic::{AtomicBool, Ordering}, Arc}, any::Any, cell::Cell};
 
-use gphoto2::{Context, list::CameraDescriptor, widget::{TextWidget}, Camera, Error};
+use gphoto2::{Context, list::CameraDescriptor, widget::{TextWidget, RadioWidget}, Camera, Error};
 
 use tokio::{sync::Mutex as AsyncMutex};
 use tokio::task::JoinHandle as AsyncJoinHandle;
 
-use crate::{utils::jpeg, dart_bridge::api::RawImage};
+use crate::{utils::jpeg, dart_bridge::api::RawImage, log_info};
 
 static CONTEXT: OnceLock<Context> = OnceLock::new();
 
@@ -109,9 +109,18 @@ pub async fn auto_focus(camera_ref: Arc<AsyncMutex<GPhoto2Camera>>) -> Result<()
   Ok(())
 }
 
-pub async fn capture_photo(camera_ref: Arc<AsyncMutex<GPhoto2Camera>>) -> Result<Vec<u8>> {
+pub async fn capture_photo(camera_ref: Arc<AsyncMutex<GPhoto2Camera>>, capture_target_value: String) -> Result<Vec<u8>> {
   let camera = camera_ref.lock().await;
+
+  if !capture_target_value.is_empty() {
+    let opcode = camera.camera.config_key::<RadioWidget>("capturetarget").await?;
+    opcode.set_choice(&capture_target_value)?;
+    camera.camera.set_config(&opcode).await?;
+  }
+
   let capture = camera.camera.capture_image().await?;
+  log_info("DFile:".to_string());
+  log_info(capture.folder().to_string());
   
   let file = camera.camera.fs().download(&capture.folder(), &capture.name()).await?;
   let data = file.get_data(get_context()?).await?;


### PR DESCRIPTION
Kinda experimental but when you leave the setting empty, it will not try to send the config change to the camera.

Works at least for D3400 when using "Memory card" as value.