### PR TITLE
Home Assistant integration

### DIFF
--- a/lib/managers/settings_manager.dart
+++ b/lib/managers/settings_manager.dart
@@ -61,13 +61,12 @@ abstract class _SettingsManagerBase with Store, UiLoggy {
     Map<String, dynamic> settingsMap = settingsDocument.toMap();
     try {
       _settings = Settings.fromJson(settingsMap);
+      loggy.debug("Loaded settings: ${_settings?.toJson().toString() ?? "null"}");
     } catch (_) {
       // Fixme: Failed to parse, load defaults and create settings file
       _settings = Settings.withDefaults();
-      await _save();
-      return;
     }
-    loggy.debug("Loaded settings: ${_settings?.toJson().toString() ?? "null"}");
+    await _save();
   }
 
   Future<void> _save() async {

--- a/lib/models/home_assistant/home_assistant_discovery_payload.dart
+++ b/lib/models/home_assistant/home_assistant_discovery_payload.dart
@@ -1,0 +1,40 @@
+// ignore_for_file: invalid_annotation_target
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'home_assistant_discovery_payload.freezed.dart';
+part 'home_assistant_discovery_payload.g.dart';
+
+// ///////////// //
+// Root settings //
+// ///////////// //
+
+@Freezed(toJson: true)
+class HomeAssistantDiscoveryPayload with _$HomeAssistantDiscoveryPayload {
+
+  const HomeAssistantDiscoveryPayload._();
+
+  const factory HomeAssistantDiscoveryPayload.sensor({
+    
+    @JsonKey(name: 'name') required String name,
+    @JsonKey(name: 'state_topic') required String stateTopic,
+    @JsonKey(name: 'unique_id') required String uniqueId,
+    @JsonKey(name: 'device') required HomeAssistantDevice device,
+  }) = HomeAssistantSensorDiscoveryPayload;
+
+}
+
+@Freezed(toJson: true)
+class HomeAssistantDevice with _$HomeAssistantDevice {
+
+  const HomeAssistantDevice._();
+
+  const factory HomeAssistantDevice({
+    @JsonKey(name: 'identifiers') required List<String> identifiers,
+    @JsonKey(name: 'manufacturer') required String manufacturer,
+    @JsonKey(name: 'model') required String model,
+    @JsonKey(name: 'name') required String name,
+    @JsonKey(name: 'sw_version') required String softwareVersion,
+  }) = _HomeAssistantDevice;
+
+}

--- a/lib/models/home_assistant/home_assistant_discovery_payload.dart
+++ b/lib/models/home_assistant/home_assistant_discovery_payload.dart
@@ -15,12 +15,20 @@ class HomeAssistantDiscoveryPayload with _$HomeAssistantDiscoveryPayload {
   const HomeAssistantDiscoveryPayload._();
 
   const factory HomeAssistantDiscoveryPayload.sensor({
-    
     @JsonKey(name: 'name') required String name,
     @JsonKey(name: 'state_topic') required String stateTopic,
     @JsonKey(name: 'unique_id') required String uniqueId,
     @JsonKey(name: 'device') required HomeAssistantDevice device,
   }) = HomeAssistantSensorDiscoveryPayload;
+
+  const factory HomeAssistantDiscoveryPayload.deviceTrigger({
+    @JsonKey(name: 'automation_type') @Default("trigger") String automationType,
+    @JsonKey(name: 'payload') required String payload,
+    @JsonKey(name: 'topic') required String topic,
+    @JsonKey(name: 'type') required String type,
+    @JsonKey(name: 'subtype') required String subtype,
+    @JsonKey(name: 'device') required HomeAssistantDevice device,
+  }) = HomeAssistantDeviceTriggerDiscoveryPayload;
 
 }
 

--- a/lib/models/home_assistant/home_assistant_integration_type.dart
+++ b/lib/models/home_assistant/home_assistant_integration_type.dart
@@ -1,0 +1,9 @@
+enum HomeAssistantIntegrationType {
+
+  sensor('sensor');
+
+  final String mqttName;
+
+  const HomeAssistantIntegrationType(this.mqttName);
+
+}

--- a/lib/models/settings.dart
+++ b/lib/models/settings.dart
@@ -1,11 +1,13 @@
+// ignore_for_file: invalid_annotation_target
+
 import 'dart:io';
-import 'dart:math';
 import 'dart:ui' as ui;
 
 import 'package:fluent_ui/fluent_ui.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:momento_booth/exceptions/default_setting_restore_exception.dart';
 import 'package:momento_booth/rust_bridge/library_api.generated.dart';
+import 'package:momento_booth/utils/random_string.dart';
 import 'package:path/path.dart';
 import 'package:toml/toml.dart';
 
@@ -27,36 +29,17 @@ class Settings with _$Settings implements TomlEncodableValue {
     @Default(1.5) double collageAspectRatio,
     @Default(0) double collagePadding,
     @Default(true) bool singlePhotoIsCollage,
-    @Default("") String templatesFolder,
-    @Default(HardwareSettings()) HardwareSettings hardware,
-    @Default(OutputSettings()) OutputSettings output,
-    @Default(UiSettings()) UiSettings ui,
-    @Default(MqttIntegrationSettings()) MqttIntegrationSettings mqttIntegration,
+    @JsonKey(defaultValue: _templatesFolderFromJson) required String templatesFolder,
+    @JsonKey(defaultValue: HardwareSettings.withDefaults) required HardwareSettings hardware,
+    @JsonKey(defaultValue: OutputSettings.withDefaults) required OutputSettings output,
+    @JsonKey(defaultValue: UiSettings.withDefaults) required UiSettings ui,
+    @JsonKey(defaultValue: MqttIntegrationSettings.withDefaults) required MqttIntegrationSettings mqttIntegration,
     //@Default(DebugSettings()) DebugSettings debug,
   }) = _Settings;
 
   factory Settings.withDefaults() => Settings.fromJson({});
 
-  factory Settings.fromJson(Map<String, Object?> json) {
-    // Default settings
-    if (!json.containsKey("templatesFolder")) {
-      json["templatesFolder"] = _getHome();
-    }
-    if (!json.containsKey("hardware")) {
-      json["hardware"] = HardwareSettings.withDefaults().toJson();
-    }
-    if (!json.containsKey("output")) {
-      json["output"] = OutputSettings.withDefaults().toJson();
-    }
-    if (!json.containsKey("mqttIntegration")) {
-      json["mqttIntegration"] = MqttIntegrationSettings.withDefaults().toJson();
-    }
-    // if (!json.containsKey("debug")) {
-    //   json["debug"] = DebugSettings.withDefaults().toJson();
-    // }
-
-    return _$SettingsFromJson(json);
-  }
+  factory Settings.fromJson(Map<String, Object?> json) => _$SettingsFromJson(json);
   
   @override
   Map<String, dynamic> toTomlValue() => toJson();
@@ -82,7 +65,7 @@ class HardwareSettings with _$HardwareSettings implements TomlEncodableValue {
     @Default("") String gPhoto2CaptureTarget,
     @Default(100) int captureDelayGPhoto2,
     @Default(200) int captureDelaySony,
-    @Default("") String captureLocation,
+    @JsonKey(defaultValue: _captureLocationFromJson) required String captureLocation,
     @Default([]) List<String> printerNames,
     @Default(148) double pageHeight,
     @Default(100) double pageWidth,
@@ -96,14 +79,7 @@ class HardwareSettings with _$HardwareSettings implements TomlEncodableValue {
 
   factory HardwareSettings.withDefaults() => HardwareSettings.fromJson({});
 
-  factory HardwareSettings.fromJson(Map<String, Object?> json) {
-    // Default settings
-    if (!json.containsKey("captureLocation")) {
-      json["captureLocation"] = _getHome();
-    }
-
-    return _$HardwareSettingsFromJson(json);
-  }
+  factory HardwareSettings.fromJson(Map<String, Object?> json) => _$HardwareSettingsFromJson(json);
   
   @override
   Map<String, dynamic> toTomlValue() => toJson();
@@ -120,23 +96,16 @@ class OutputSettings with _$OutputSettings implements TomlEncodableValue {
   const OutputSettings._();
 
   const factory OutputSettings({
-    @Default("") String localFolder,
-    @Default(80)  int jpgQuality,
-    @Default(4.0)  double resolutionMultiplier,
-    @Default(ExportFormat.jpgFormat)  ExportFormat exportFormat,
-    @Default("https://send.vis.ee/")  String firefoxSendServerUrl,
+    @JsonKey(defaultValue: _localFolderFromJson) required String localFolder,
+    @Default(80) int jpgQuality,
+    @Default(4.0) double resolutionMultiplier,
+    @Default(ExportFormat.jpgFormat) ExportFormat exportFormat,
+    @Default("https://send.vis.ee/") String firefoxSendServerUrl,
   }) = _OutputSettings;
 
   factory OutputSettings.withDefaults() => OutputSettings.fromJson({});
 
-  factory OutputSettings.fromJson(Map<String, Object?> json) {
-    // Default settings
-    if (!json.containsKey("localFolder")) {
-      json["localFolder"] = join(_getHome(), "Pictures");
-    }
-
-    return _$OutputSettingsFromJson(json);
-  }
+  factory OutputSettings.fromJson(Map<String, Object?> json) => _$OutputSettingsFromJson(json);
 
   @override
   Map<String, dynamic> toTomlValue() => toJson();
@@ -194,21 +163,16 @@ class MqttIntegrationSettings with _$MqttIntegrationSettings implements TomlEnco
     @Default(false) bool useWebSocket,
     @Default("") String username,
     @Default("") String password,
-    @Default("") String clientId,
+    @JsonKey(defaultValue: _clientIdFromJson) required String clientId,
     @Default("momento-booth") String rootTopic,
+    @Default(false) bool enableHomeAssistantDiscovery,
+    @Default("homeassistant") String homeAssistantDiscoveryTopicPrefix,
+    @JsonKey(defaultValue: _homeAssistantComponentIdFromJson) required String homeAssistantComponentId,
   }) = _MqttIntegrationSettings;
 
   factory MqttIntegrationSettings.withDefaults() => MqttIntegrationSettings.fromJson({});
 
-  factory MqttIntegrationSettings.fromJson(Map<String, Object?> json) {
-    if (!json.containsKey('clientId')) {
-      var possibleChars = 'abcdefghijklmnopqrstuvwxyz0123456789';
-      var random = Random();
-      json['clientId'] = 'momento-booth-photobooth-${List.generate(6, (index) => possibleChars[random.nextInt(possibleChars.length)]).join()}';
-    }
-
-    return _$MqttIntegrationSettingsFromJson(json);
-  }
+  factory MqttIntegrationSettings.fromJson(Map<String, Object?> json) => _$MqttIntegrationSettingsFromJson(json);
 
   @override
   Map<String, dynamic> toTomlValue() => toJson();
@@ -235,3 +199,13 @@ class MqttIntegrationSettings with _$MqttIntegrationSettings implements TomlEnco
 //   Map<String, dynamic> toTomlValue() => toJson();
 
 // }
+
+// /////////////// //
+// Default helpers //
+// /////////////// //
+
+String _templatesFolderFromJson() => join(_getHome(), "Pictures", "MomentoBooth", "Templates");
+String _captureLocationFromJson() => join(_getHome(), "Pictures", "MomentoBooth", "Captures");
+String _localFolderFromJson() => join(_getHome(), "Pictures", "MomentoBooth", "Output");
+String _clientIdFromJson() => 'momento-booth-photobooth-${getRandomString()}';
+String _homeAssistantComponentIdFromJson() => 'momento-booth-${getRandomString()}';

--- a/lib/models/settings.dart
+++ b/lib/models/settings.dart
@@ -164,7 +164,7 @@ class MqttIntegrationSettings with _$MqttIntegrationSettings implements TomlEnco
     @Default("") String username,
     @Default("") String password,
     @JsonKey(defaultValue: _clientIdFromJson) required String clientId,
-    @Default("momento-booth") String rootTopic,
+    @Default("momentobooth") String rootTopic,
     @Default(false) bool enableHomeAssistantDiscovery,
     @Default("homeassistant") String homeAssistantDiscoveryTopicPrefix,
     @JsonKey(defaultValue: _homeAssistantComponentIdFromJson) required String homeAssistantComponentId,
@@ -207,5 +207,5 @@ class MqttIntegrationSettings with _$MqttIntegrationSettings implements TomlEnco
 String _templatesFolderFromJson() => join(_getHome(), "Pictures", "MomentoBooth", "Templates");
 String _captureLocationFromJson() => join(_getHome(), "Pictures", "MomentoBooth", "Captures");
 String _localFolderFromJson() => join(_getHome(), "Pictures", "MomentoBooth", "Output");
-String _clientIdFromJson() => 'momento-booth-photobooth-${getRandomString()}';
-String _homeAssistantComponentIdFromJson() => 'momento-booth-${getRandomString()}';
+String _clientIdFromJson() => 'momentobooth-photobooth-${getRandomString()}';
+String _homeAssistantComponentIdFromJson() => 'momentobooth-${getRandomString()}';

--- a/lib/utils/random_string.dart
+++ b/lib/utils/random_string.dart
@@ -1,0 +1,6 @@
+import 'dart:math';
+
+String getRandomString({int length = 6, String possibleChars = 'abcdefghijklmnopqrstuvwxyz0123456789'}) {
+  var random = Random();
+  return List.generate(length, (index) => possibleChars[random.nextInt(possibleChars.length)]).join();
+}

--- a/lib/views/settings_screen/settings_screen_controller.dart
+++ b/lib/views/settings_screen/settings_screen_controller.dart
@@ -41,6 +41,12 @@ class SettingsScreenController extends ScreenControllerBase<SettingsScreenViewMo
   TextEditingController? _mqttIntegrationRootTopicController;
   TextEditingController get mqttIntegrationRootTopicController => _mqttIntegrationRootTopicController ??= TextEditingController(text: viewModel.mqttIntegrationRootTopicSetting);
 
+  TextEditingController? _mqttIntegrationHomeAssistantDiscoveryTopicPrefixController;
+  TextEditingController get mqttIntegrationHomeAssistantDiscoveryTopicPrefixController => _mqttIntegrationHomeAssistantDiscoveryTopicPrefixController ??= TextEditingController(text: viewModel.mqttIntegrationHomeAssistantDiscoveryTopicPrefixSetting);
+
+  TextEditingController? _mqttIntegrationHomeAssistantComponentIdController;
+  TextEditingController get mqttIntegrationHomeAssistantComponentIdController => _mqttIntegrationHomeAssistantComponentIdController ??= TextEditingController(text: viewModel.mqttIntegrationHomeAssistantComponentIdSetting);
+
   // Initialization/Deinitialization
 
   SettingsScreenController({
@@ -337,6 +343,24 @@ class SettingsScreenController extends ScreenControllerBase<SettingsScreenViewMo
   void onMqttIntegrationRootTopicChanged(String? rootTopic) {
     if (rootTopic != null) {
       viewModel.updateSettings((settings) => settings.copyWith.mqttIntegration(rootTopic: rootTopic, enable: false));
+    }
+  }
+
+  void onMqttIntegrationEnableHomeAssistantDiscoveryChanged(bool? enableHomeAssistantDiscovery) {
+    if (enableHomeAssistantDiscovery != null) {
+      viewModel.updateSettings((settings) => settings.copyWith.mqttIntegration(enableHomeAssistantDiscovery: enableHomeAssistantDiscovery, enable: false));
+    }
+  }
+
+  void onMqttIntegrationHomeAssistantDiscoveryTopicPrefixChanged(String? homeAssistantDiscoveryTopicPrefix) {
+    if (homeAssistantDiscoveryTopicPrefix != null) {
+      viewModel.updateSettings((settings) => settings.copyWith.mqttIntegration(homeAssistantDiscoveryTopicPrefix: homeAssistantDiscoveryTopicPrefix, enable: false));
+    }
+  }
+
+  void onMqttIntegrationHomeAssistantComponentIdChanged(String? homeAssistantComponentId) {
+    if (homeAssistantComponentId != null) {
+      viewModel.updateSettings((settings) => settings.copyWith.mqttIntegration(homeAssistantComponentId: homeAssistantComponentId, enable: false));
     }
   }
 

--- a/lib/views/settings_screen/settings_screen_view.mqtt_integration.dart
+++ b/lib/views/settings_screen/settings_screen_view.mqtt_integration.dart
@@ -12,6 +12,17 @@ Widget _getMqttIntegrationSettings(SettingsScreenViewModel viewModel, SettingsSc
         onChanged: controller.onMqttIntegrationEnableChanged,
         prefixWidget: const MqttConnectionStateIndicator(),
       ),
+      _getConnectionBlock(viewModel, controller),
+      _getClientBlock(viewModel, controller),
+      _getHomeAssistantBlock(viewModel, controller),
+    ],
+  );
+}
+
+Widget _getConnectionBlock(SettingsScreenViewModel viewModel, SettingsScreenController controller) {
+  return FluentSettingsBlock(
+    title: "Connection",
+    settings: [
       _getTextInput(
         icon: FluentIcons.server,
         title: "MQTT broker address",
@@ -55,6 +66,14 @@ Widget _getMqttIntegrationSettings(SettingsScreenViewModel viewModel, SettingsSc
         controller: controller.mqttIntegrationPasswordController,
         onChanged: controller.onMqttIntegrationPasswordChanged,
       ),
+    ],
+  );
+}
+
+Widget _getClientBlock(SettingsScreenViewModel viewModel, SettingsScreenController controller) {
+  return FluentSettingsBlock(
+    title: "Client",
+    settings: [
       _getTextInput(
         icon: FluentIcons.remote_application,
         title: "MQTT client ID",
@@ -68,6 +87,35 @@ Widget _getMqttIntegrationSettings(SettingsScreenViewModel viewModel, SettingsSc
         subtitle: "The root topic to use when publishing and subscribing to MQTT messages. You might want to add some unique identifier to avoid conflicts with other instances of Momento Booth on the same MQTT broker.",
         controller: controller.mqttIntegrationRootTopicController,
         onChanged: controller.onMqttIntegrationRootTopicChanged,
+      ),
+    ],
+  );
+}
+
+Widget _getHomeAssistantBlock(SettingsScreenViewModel viewModel, SettingsScreenController controller) {
+  return FluentSettingsBlock(
+    title: "Home Assistant integration",
+    settings: [
+      _getBooleanInput(
+        icon: FluentIcons.toggle_border,
+        title: "Enable Home Assistant integration",
+        subtitle: "If enabled, the application will publish the discovery topics for Home Assistant.",
+        value: () => viewModel.mqttIntegrationEnableHomeAssistantDiscoverySetting,
+        onChanged: controller.onMqttIntegrationEnableHomeAssistantDiscoveryChanged,
+      ),
+      _getTextInput(
+        icon: FluentIcons.chat,
+        title: "Discovery topic",
+        subtitle: "The discovery topic as configured in Home Assistant. Use the default value if you haven't changed it in Home Assistant.",
+        controller: controller.mqttIntegrationHomeAssistantDiscoveryTopicPrefixController,
+        onChanged: controller.onMqttIntegrationHomeAssistantDiscoveryTopicPrefixChanged,
+      ),
+        _getTextInput(
+        icon: FluentIcons.device_run,
+        title: "Device ID",
+        subtitle: "The device ID to use when publishing the discovery topics for Home Assistant.",
+        controller: controller.mqttIntegrationHomeAssistantComponentIdController,
+        onChanged: controller.onMqttIntegrationHomeAssistantComponentIdChanged,
       ),
     ],
   );

--- a/lib/views/settings_screen/settings_screen_view.mqtt_integration.dart
+++ b/lib/views/settings_screen/settings_screen_view.mqtt_integration.dart
@@ -58,14 +58,14 @@ Widget _getMqttIntegrationSettings(SettingsScreenViewModel viewModel, SettingsSc
       _getTextInput(
         icon: FluentIcons.remote_application,
         title: "MQTT client ID",
-        subtitle: "If enabled, the application will use a custom client ID when connecting to the MQTT broker.",
+        subtitle: "The identifier for this MQTT client.",
         controller: controller.mqttIntegrationClientIdController,
         onChanged: controller.onMqttIntegrationClientIdChanged,
       ),
       _getTextInput(
         icon: FluentIcons.chat,
         title: "MQTT root topic",
-        subtitle: "The root topic to use when publishing and subscribing to MQTT messages.",
+        subtitle: "The root topic to use when publishing and subscribing to MQTT messages. You might want to add some unique identifier to avoid conflicts with other instances of Momento Booth on the same MQTT broker.",
         controller: controller.mqttIntegrationRootTopicController,
         onChanged: controller.onMqttIntegrationRootTopicChanged,
       ),

--- a/lib/views/settings_screen/settings_screen_view_model.dart
+++ b/lib/views/settings_screen/settings_screen_view_model.dart
@@ -137,6 +137,9 @@ abstract class SettingsScreenViewModelBase extends ScreenViewModelBase with Stor
   String get mqttIntegrationPasswordSetting => SettingsManager.instance.settings.mqttIntegration.password;
   String get mqttIntegrationClientIdSetting => SettingsManager.instance.settings.mqttIntegration.clientId;
   String get mqttIntegrationRootTopicSetting => SettingsManager.instance.settings.mqttIntegration.rootTopic;
+  bool get mqttIntegrationEnableHomeAssistantDiscoverySetting => SettingsManager.instance.settings.mqttIntegration.enableHomeAssistantDiscovery;
+  String get mqttIntegrationHomeAssistantDiscoveryTopicPrefixSetting => SettingsManager.instance.settings.mqttIntegration.homeAssistantDiscoveryTopicPrefix;
+  String get mqttIntegrationHomeAssistantComponentIdSetting => SettingsManager.instance.settings.mqttIntegration.homeAssistantComponentId;
 
   double get outputResHeightExcl => resolutionMultiplier * 1000;
   double get outputResWidthExcl => outputResHeightExcl/collageAspectRatioSetting;


### PR DESCRIPTION
This PR:
- Optimizes the MQTT topic settings defaults and MQTT topic names (inspired by the great Zigbee2MQTT)
- Adds the publishing of discovery topics for Home Assistant for sensors and triggers
- Adds the new Home Assistant related settings to the Settings UI