### PR TITLE
Add Lottie animations to start screen, update Flutter and packages

### DIFF
--- a/.fvm/fvm_config.json
+++ b/.fvm/fvm_config.json
@@ -1,4 +1,4 @@
 {
-  "flutterSdkVersion": "3.13.6",
+  "flutterSdkVersion": "3.13.7",
   "flavors": {}
 }

--- a/lib/models/settings.dart
+++ b/lib/models/settings.dart
@@ -134,6 +134,7 @@ class UiSettings with _$UiSettings implements TomlEncodableValue {
 
   const factory UiSettings({
     @Default(Language.english) Language language,
+    @Default([]) List<LottieAnimationSettings> introScreenLottieAnimations,
     @Default(true) bool displayConfetti,
     @Default(false) bool enableSfx,
     @Default("") String shareScreenSfxFile,
@@ -145,6 +146,28 @@ class UiSettings with _$UiSettings implements TomlEncodableValue {
   factory UiSettings.withDefaults() => UiSettings.fromJson({});
 
   factory UiSettings.fromJson(Map<String, Object?> json) => _$UiSettingsFromJson(json);
+
+  @override
+  Map<String, dynamic> toTomlValue() => toJson();
+}
+
+@Freezed(fromJson: true, toJson: true)
+class LottieAnimationSettings with _$LottieAnimationSettings implements TomlEncodableValue {
+  const LottieAnimationSettings._();
+
+  const factory LottieAnimationSettings({
+    @Default("") String file,
+    @Default(0) double width,
+    @Default(0) double height,
+    @Default(AnimationAnchor.screen) AnimationAnchor anchor,
+    @Default(0) double alignmentX,
+    @Default(0) double alignmentY,
+    @Default(0) double offsetDx,
+    @Default(0) double offsetDy,
+    @Default(0) double rotation,
+  }) = _LottieAnimationSettings;
+
+  factory LottieAnimationSettings.fromJson(Map<String, Object?> json) => _$LottieAnimationSettingsFromJson(json);
 
   @override
   Map<String, dynamic> toTomlValue() => toJson();

--- a/lib/models/settings.enums.dart
+++ b/lib/models/settings.enums.dart
@@ -156,13 +156,12 @@ enum Language {
 
 enum AnimationAnchor {
 
-  touchToStart(0, "Touch to start"),
-  logo(1, "Logo"),
-  screen(2, "Screen");
+  //touchToStart("Touch to start"), // TODO: implement
+  //logo("Logo"), // TODO: implement
+  screen("Screen");
 
-  final int value;
   final String name;
 
-  const AnimationAnchor(this.value, this.name);
+  const AnimationAnchor(this.name);
 
 }

--- a/lib/models/settings.enums.dart
+++ b/lib/models/settings.enums.dart
@@ -153,3 +153,16 @@ enum Language {
   Locale toLocale() => Locale(code);
 
 }
+
+enum AnimationAnchor {
+
+  touchToStart(0, "Touch to start"),
+  logo(1, "Logo"),
+  screen(2, "Screen");
+
+  final int value;
+  final String name;
+
+  const AnimationAnchor(this.value, this.name);
+
+}

--- a/lib/views/custom_widgets/wrappers/lottie_animation_wrapper.dart
+++ b/lib/views/custom_widgets/wrappers/lottie_animation_wrapper.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:lottie/lottie.dart';
 import 'package:momento_booth/models/settings.dart';
@@ -13,27 +14,25 @@ class LottieAnimationWrapper extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Stack(
-      fit: StackFit.passthrough,
       children: [
         child,
         for (LottieAnimationSettings animation in animationSettings)
-          LayoutBuilder(
-            builder: (context, snapshot) {
-              return Transform.translate(
-                offset: Offset(
-                  0.5 * animation.alignmentX * snapshot.maxWidth + animation.offsetDx,
-                  0.5 * animation.alignmentY * snapshot.maxHeight + animation.offsetDy,
+          Align(
+            alignment: Alignment(animation.alignmentX, animation.alignmentY),
+            child: Transform.translate(
+              offset: Offset(
+                animation.offsetDx,
+                animation.offsetDy,
+              ),
+              child: Transform.rotate(
+                angle: animation.rotation,
+                child: Lottie.file(
+                  File(animation.file),
+                  height: animation.height,
+                  width: animation.width,
                 ),
-                child: Transform.rotate(
-                  angle: animation.rotation,
-                  child: Lottie.file(
-                    File(animation.file),
-                    height: animation.height,
-                    width: animation.width,
-                  ),
-                ),
-              );
-            }
+              ),
+            ),
           ),
       ],
     );

--- a/lib/views/custom_widgets/wrappers/lottie_animation_wrapper.dart
+++ b/lib/views/custom_widgets/wrappers/lottie_animation_wrapper.dart
@@ -1,0 +1,41 @@
+import 'dart:io';
+
+import 'package:flutter/widgets.dart';
+import 'package:lottie/lottie.dart';
+import 'package:momento_booth/models/settings.dart';
+
+class LottieAnimationWrapper extends StatelessWidget {
+  final Widget child;
+  final List<LottieAnimationSettings> animationSettings;
+
+  const LottieAnimationWrapper({super.key, required this.child, required this.animationSettings});
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      fit: StackFit.passthrough,
+      children: [
+        child,
+        for (LottieAnimationSettings animation in animationSettings)
+          LayoutBuilder(
+            builder: (context, snapshot) {
+              return Transform.translate(
+                offset: Offset(
+                  0.5 * animation.alignmentX * snapshot.maxWidth + animation.offsetDx,
+                  0.5 * animation.alignmentY * snapshot.maxHeight + animation.offsetDy,
+                ),
+                child: Transform.rotate(
+                  angle: animation.rotation,
+                  child: Lottie.file(
+                    File(animation.file),
+                    height: animation.height,
+                    width: animation.width,
+                  ),
+                ),
+              );
+            }
+          ),
+      ],
+    );
+  }
+}

--- a/lib/views/start_screen/start_screen_view.dart
+++ b/lib/views/start_screen/start_screen_view.dart
@@ -3,6 +3,7 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:momento_booth/theme/momento_booth_theme_data.dart';
 import 'package:momento_booth/views/base/screen_view_base.dart';
+import 'package:momento_booth/views/custom_widgets/wrappers/lottie_animation_wrapper.dart';
 import 'package:momento_booth/views/start_screen/start_screen_controller.dart';
 import 'package:momento_booth/views/start_screen/start_screen_view_model.dart';
 
@@ -13,30 +14,33 @@ class StartScreenView extends ScreenViewBase<StartScreenViewModel, StartScreenCo
     required super.controller,
     required super.contextAccessor,
   });
-  
+
   @override
   Widget get body {
-    return Stack(
-      children: [
-        GestureDetector(
-          onTap: controller.onPressedContinue,
-          behavior: HitTestBehavior.opaque,
-          child: _foregroundElements,
-        ),
-        Padding(
-          padding: const EdgeInsets.all(30),
-          child: Align(
-            alignment: Alignment.bottomLeft,
-            child: GestureDetector(
-              onTap: controller.onPressedGallery,
-              child: AutoSizeText(
-                localizations.startScreenGalleryButton,
-                style: theme.subTitleStyle,
+    return LottieAnimationWrapper(
+      animationSettings: viewModel.screenAnimations,
+      child: Stack(
+        children: [
+          GestureDetector(
+            onTap: controller.onPressedContinue,
+            behavior: HitTestBehavior.opaque,
+            child: _foregroundElements,
+          ),
+          Padding(
+            padding: const EdgeInsets.all(30),
+            child: Align(
+              alignment: Alignment.bottomLeft,
+              child: GestureDetector(
+                onTap: controller.onPressedGallery,
+                child: AutoSizeText(
+                  localizations.startScreenGalleryButton,
+                  style: theme.subTitleStyle,
+                ),
               ),
             ),
           ),
-        ),
-      ],
+        ],
+      ),
     );
   }
 
@@ -50,9 +54,12 @@ class StartScreenView extends ScreenViewBase<StartScreenViewModel, StartScreenCo
         Expanded(
           flex: 2,
           child: Center(
-            child: AutoSizeText(
-              localizations.startScreenTouchToStartButton,
-              style: theme.titleStyle,
+            child: LottieAnimationWrapper(
+              animationSettings: viewModel.touchToStartAnimations,
+              child: AutoSizeText(
+                localizations.startScreenTouchToStartButton,
+                style: theme.titleStyle,
+              ),
             ),
           ),
         ),
@@ -69,10 +76,13 @@ class StartScreenView extends ScreenViewBase<StartScreenViewModel, StartScreenCo
       width: 450,
       child: Padding(
         padding: const EdgeInsets.only(bottom: 32),
-        child: SvgPicture.asset(
-          "assets/svg/logo.svg",
-          colorFilter: ColorFilter.mode(themeData.defaultPageBackgroundColor, BlendMode.srcIn),
-          alignment: Alignment.bottomCenter,
+        child: LottieAnimationWrapper(
+          animationSettings: viewModel.logoAnimations,
+          child: SvgPicture.asset(
+            "assets/svg/logo.svg",
+            colorFilter: ColorFilter.mode(themeData.defaultPageBackgroundColor, BlendMode.srcIn),
+            alignment: Alignment.bottomCenter,
+          ),
         ),
       ),
     );

--- a/lib/views/start_screen/start_screen_view.dart
+++ b/lib/views/start_screen/start_screen_view.dart
@@ -18,7 +18,7 @@ class StartScreenView extends ScreenViewBase<StartScreenViewModel, StartScreenCo
   @override
   Widget get body {
     return LottieAnimationWrapper(
-      animationSettings: viewModel.screenAnimations,
+      animationSettings: viewModel.introScreenLottieAnimations,
       child: Stack(
         children: [
           GestureDetector(
@@ -54,12 +54,9 @@ class StartScreenView extends ScreenViewBase<StartScreenViewModel, StartScreenCo
         Expanded(
           flex: 2,
           child: Center(
-            child: LottieAnimationWrapper(
-              animationSettings: viewModel.touchToStartAnimations,
-              child: AutoSizeText(
-                localizations.startScreenTouchToStartButton,
-                style: theme.titleStyle,
-              ),
+            child: AutoSizeText(
+              localizations.startScreenTouchToStartButton,
+              style: theme.titleStyle,
             ),
           ),
         ),
@@ -76,13 +73,10 @@ class StartScreenView extends ScreenViewBase<StartScreenViewModel, StartScreenCo
       width: 450,
       child: Padding(
         padding: const EdgeInsets.only(bottom: 32),
-        child: LottieAnimationWrapper(
-          animationSettings: viewModel.logoAnimations,
-          child: SvgPicture.asset(
-            "assets/svg/logo.svg",
-            colorFilter: ColorFilter.mode(themeData.defaultPageBackgroundColor, BlendMode.srcIn),
-            alignment: Alignment.bottomCenter,
-          ),
+        child: SvgPicture.asset(
+          "assets/svg/logo.svg",
+          colorFilter: ColorFilter.mode(themeData.defaultPageBackgroundColor, BlendMode.srcIn),
+          alignment: Alignment.bottomCenter,
         ),
       ),
     );

--- a/lib/views/start_screen/start_screen_view_model.dart
+++ b/lib/views/start_screen/start_screen_view_model.dart
@@ -1,5 +1,7 @@
 import 'package:mobx/mobx.dart';
 import 'package:momento_booth/managers/photos_manager.dart';
+import 'package:momento_booth/managers/settings_manager.dart';
+import 'package:momento_booth/models/settings.dart';
 import 'package:momento_booth/views/base/screen_view_model_base.dart';
 
 part 'start_screen_view_model.g.dart';
@@ -7,6 +9,23 @@ part 'start_screen_view_model.g.dart';
 class StartScreenViewModel = StartScreenViewModelBase with _$StartScreenViewModel;
 
 abstract class StartScreenViewModelBase extends ScreenViewModelBase with Store {
+
+  @computed
+  List<LottieAnimationSettings> get introScreenLottieAnimations =>  SettingsManager.instance.settings.ui.introScreenLottieAnimations;
+
+  @computed
+  List<LottieAnimationSettings> get touchToStartAnimations => 
+    introScreenLottieAnimations.where((animation) => animation.anchor == AnimationAnchor.touchToStart).toList();
+
+  @computed
+  List<LottieAnimationSettings> get logoAnimations =>
+      introScreenLottieAnimations
+          .where((animation) => animation.anchor == AnimationAnchor.logo)
+          .toList();
+
+  @computed
+  List<LottieAnimationSettings> get screenAnimations =>
+      introScreenLottieAnimations.where((animation) => animation.anchor == AnimationAnchor.screen).toList();
 
   StartScreenViewModelBase({required super.contextAccessor}) {
     // Remove images in memory

--- a/lib/views/start_screen/start_screen_view_model.dart
+++ b/lib/views/start_screen/start_screen_view_model.dart
@@ -13,19 +13,6 @@ abstract class StartScreenViewModelBase extends ScreenViewModelBase with Store {
   @computed
   List<LottieAnimationSettings> get introScreenLottieAnimations =>  SettingsManager.instance.settings.ui.introScreenLottieAnimations;
 
-  @computed
-  List<LottieAnimationSettings> get touchToStartAnimations => 
-    introScreenLottieAnimations.where((animation) => animation.anchor == AnimationAnchor.touchToStart).toList();
-
-  @computed
-  List<LottieAnimationSettings> get logoAnimations =>
-      introScreenLottieAnimations
-          .where((animation) => animation.anchor == AnimationAnchor.logo)
-          .toList();
-
-  @computed
-  List<LottieAnimationSettings> get screenAnimations =>
-      introScreenLottieAnimations.where((animation) => animation.anchor == AnimationAnchor.screen).toList();
 
   StartScreenViewModelBase({required super.contextAccessor}) {
     // Remove images in memory

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -29,10 +29,10 @@ packages:
     dependency: transitive
     description:
       name: archive
-      sha256: ca12e6c9ac022f33fd89128e7007fb5e97ab6e814d4fa05dd8d4f2db1e3c69cb
+      sha256: "7e0d52067d05f2e0324268097ba723b71cb41ac8a6a2b24d1edf9c536b987b03"
       url: "https://pub.dev"
     source: hosted
-    version: "3.4.5"
+    version: "3.4.6"
   args:
     dependency: transitive
     description:
@@ -229,10 +229,10 @@ packages:
     dependency: transitive
     description:
       name: cross_file
-      sha256: fd832b5384d0d6da4f6df60b854d33accaaeb63aa9e10e736a87381f08dee2cb
+      sha256: "445db18de832dba8d851e287aff8ccf169bed30d2e94243cb54c7d2f1ed2142c"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.3+5"
+    version: "0.3.3+6"
   crypto:
     dependency: transitive
     description:
@@ -507,10 +507,10 @@ packages:
     dependency: "direct main"
     description:
       name: go_router
-      sha256: "1bd28265168045adb2df3da178bdbd44d37dddca0e7cfc867f8665d4f6b31f0c"
+      sha256: "2ccd74480706e0a70a0e0dfa9543dede41bc11d0fe3b146a6ad7b7686f6b4407"
       url: "https://pub.dev"
     source: hosted
-    version: "11.1.3"
+    version: "11.1.4"
   graphs:
     dependency: transitive
     description:
@@ -1182,26 +1182,26 @@ packages:
     dependency: transitive
     description:
       name: vector_graphics
-      sha256: "670f6e07aca990b4a2bcdc08a784193c4ccdd1932620244c3a86bb72a0eac67f"
+      sha256: b16dadf7eb610e20da044c141b4a0199a5e8082ca21daba68322756f953ce714
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.7"
+    version: "1.1.9"
   vector_graphics_codec:
     dependency: transitive
     description:
       name: vector_graphics_codec
-      sha256: "7451721781d967db9933b63f5733b1c4533022c0ba373a01bdd79d1a5457f69f"
+      sha256: a4b01403d5c613db115e30e71eca33f7e9e09f2d3c52c3fb84e16333ecddc539
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.7"
+    version: "1.1.9"
   vector_graphics_compiler:
     dependency: transitive
     description:
       name: vector_graphics_compiler
-      sha256: "80a13c613c8bde758b1464a1755a7b3a8f2b6cec61fbf0f5a53c94c30f03ba2e"
+      sha256: d26c0e2f237476426523eb25512e4c09fa27c6d33ed659a0e69d79e20b5dc47f
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.7"
+    version: "1.1.9"
   vector_math:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -660,6 +660,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.3"
+  lottie:
+    dependency: "direct main"
+    description:
+      name: lottie
+      sha256: b8bdd54b488c54068c57d41ae85d02808da09e2bee8b8dd1f59f441e7efa60cd
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.6.0"
   matcher:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   # UI
   auto_size_text: 3.0.0
   fluent_ui: 4.7.6
-  go_router: 11.1.3
+  go_router: 11.1.4
   flutter_svg: 2.0.7
   animated_text_kit: 4.2.2
   flutter_scroll_shadow: 1.2.3

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,6 +29,7 @@ dependencies:
   wave: 0.2.2
   texture_rgba_renderer:
     git: https://github.com/h3x4d3c1m4l/flutter_texture_rgba_renderer
+  lottie: 2.6.0
 
   # Printscreen/Image processing
   screenshot: 2.1.0

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -817,9 +817,9 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6c98ee8095e9d1dcbf2fcc6d95acccb90d1c81db1e44725c6a984b1dbdfb010"
+checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -849,9 +849,9 @@ dependencies = [
 
 [[package]]
 name = "flutter_rust_bridge"
-version = "1.82.2"
+version = "1.82.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f67a14d52484b361d05949fe40109198e618605a7fa5b106c274a3cfbbfbe98c"
+checksum = "898aef1ddc8d2d357c726a9e758f55935e62dacc946097455225414b3856eb60"
 dependencies = [
  "allo-isolate",
  "anyhow",
@@ -875,9 +875,9 @@ dependencies = [
 
 [[package]]
 name = "flutter_rust_bridge_macros"
-version = "1.82.2"
+version = "1.82.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef0d85dddb8fa2960c09a80a576edc351daa42186ca4c9babfb28e1cb61668f"
+checksum = "d1ab3d175f0a09c1adb55fd98d7b6460b00af72c4e889b9eec2c5aee88273996"
 
 [[package]]
 name = "fnv"
@@ -2392,9 +2392,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3cbb081b9784b07cceb8824c8583f86db4814d172ab043f3c23f7dc600bf83d"
+checksum = "56d84fdd47036b038fc80dd333d10b6aab10d5d31f4a366e20014def75328d33"
 
 [[package]]
 name = "reqwest"
@@ -2495,9 +2495,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.18"
+version = "0.38.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a74ee2d7c2581cd139b42447d7d9389b889bdaad3a73f1ebb16f2a3237bb19c"
+checksum = "745ecfa778e66b2b63c88a61cb36e0eea109e803b0b86bf9879fbc77c70e86ed"
 dependencies = [
  "bitflags 2.4.0",
  "errno",
@@ -2620,18 +2620,18 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.188"
+version = "1.0.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
+checksum = "8e422a44e74ad4001bdc8eede9a4570ab52f71190e9c076d14369f38b9200537"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.188"
+version = "1.0.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
+checksum = "1e48d1f918009ce3145511378cf68d613e3b3d9137d67272562080d68a2b32d5"
 dependencies = [
  "proc-macro2 1.0.69",
  "quote 1.0.33",
@@ -3185,20 +3185,19 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
-version = "0.1.37"
+version = "0.1.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
+checksum = "ee2ef2af84856a50c1d430afce2fdded0a4ec7eda868db86409b4543df0797f9"
 dependencies = [
- "cfg-if 1.0.0",
  "pin-project-lite",
  "tracing-core",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.31"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
+checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
 ]


### PR DESCRIPTION
This PR:
- Adds Lottie animations to the Start screen
- Updates Flutter to 3.13.7 and upgrades packages

Still TODO:
- Allow anchoring the animation to elements like the MomentoBooth logo or the "Tap to start" text
- Settings UI for the animations (edit the TOML settings file for now...)