### PR TITLE
Performance improvements and FPS counter

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -223,6 +223,7 @@ class _AppState extends State<App> with UiLoggy, WidgetsBindingObserver {
             child: LiveViewBackground(
               child: Center(
                 child: Stack(
+                  clipBehavior: Clip.none,
                   children: [
                     Listener(
                       behavior: HitTestBehavior.translucent,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -9,7 +9,9 @@ import 'package:flutter/services.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_loggy/flutter_loggy.dart';
+import 'package:flutter_mobx/flutter_mobx.dart';
 import 'package:go_router/go_router.dart';
+import 'package:lemberfpsmonitor/lemberfpsmonitor.dart';
 import 'package:loggy/loggy.dart';
 import 'package:momento_booth/extensions/build_context_extension.dart';
 import 'package:momento_booth/managers/helper_library_initialization_manager.dart';
@@ -231,6 +233,18 @@ class _AppState extends State<App> with UiLoggy, WidgetsBindingObserver {
                       visible: _settingsOpen,
                       maintainState: true,
                       child: _settingsScreen,
+                    ),
+                    Observer(
+                      builder: (_) {
+                        if (SettingsManager.instance.settings.debug.showFpsCounter) {
+                          return FPSMonitor(
+                            showFPSChart: true,
+                            align: Alignment.topRight,
+                            onFPSChanged: (fps) {},
+                          );
+                        }
+                        return const SizedBox();
+                      },
                     ),
                   ],
                 ),

--- a/lib/managers/live_view_manager.dart
+++ b/lib/managers/live_view_manager.dart
@@ -149,6 +149,7 @@ abstract class _LiveViewManagerBase with Store, UiLoggy {
         // Everything seems to be fine
         StatsManager.instance.validLiveViewFrames = liveViewState.validFrameCount;
         StatsManager.instance.invalidLiveViewFrames = liveViewState.errorFrameCount;
+        StatsManager.instance.duplicateLiveViewFrames = liveViewState.duplicateFrameCount;
         _lastFrameWasInvalid = false;
       }
     });

--- a/lib/managers/stats_manager.dart
+++ b/lib/managers/stats_manager.dart
@@ -45,6 +45,9 @@ abstract class _StatsManagerBase with Store, UiLoggy {
   @observable
   int invalidLiveViewFrames = 0;
 
+  @observable
+  int duplicateLiveViewFrames = 0;
+
   // /////// //
   // Updates //
   // /////// //

--- a/lib/models/settings.dart
+++ b/lib/models/settings.dart
@@ -34,7 +34,7 @@ class Settings with _$Settings implements TomlEncodableValue {
     @JsonKey(defaultValue: OutputSettings.withDefaults) required OutputSettings output,
     @JsonKey(defaultValue: UiSettings.withDefaults) required UiSettings ui,
     @JsonKey(defaultValue: MqttIntegrationSettings.withDefaults) required MqttIntegrationSettings mqttIntegration,
-    //@Default(DebugSettings()) DebugSettings debug,
+    @JsonKey(defaultValue: DebugSettings.withDefaults) required DebugSettings debug,
   }) = _Settings;
 
   factory Settings.withDefaults() => Settings.fromJson({});
@@ -130,6 +130,7 @@ String _getHome() {
 
 @Freezed(fromJson: true, toJson: true)
 class UiSettings with _$UiSettings implements TomlEncodableValue {
+
   const UiSettings._();
 
   const factory UiSettings({
@@ -150,10 +151,12 @@ class UiSettings with _$UiSettings implements TomlEncodableValue {
 
   @override
   Map<String, dynamic> toTomlValue() => toJson();
+
 }
 
 @Freezed(fromJson: true, toJson: true)
 class LottieAnimationSettings with _$LottieAnimationSettings implements TomlEncodableValue {
+
   const LottieAnimationSettings._();
 
   const factory LottieAnimationSettings({
@@ -172,6 +175,7 @@ class LottieAnimationSettings with _$LottieAnimationSettings implements TomlEnco
 
   @override
   Map<String, dynamic> toTomlValue() => toJson();
+
 }
 
 // //////////////////// //
@@ -180,6 +184,7 @@ class LottieAnimationSettings with _$LottieAnimationSettings implements TomlEnco
 
 @Freezed(fromJson: true, toJson: true)
 class MqttIntegrationSettings with _$MqttIntegrationSettings implements TomlEncodableValue {
+
   const MqttIntegrationSettings._();
 
   const factory MqttIntegrationSettings({
@@ -204,29 +209,30 @@ class MqttIntegrationSettings with _$MqttIntegrationSettings implements TomlEnco
 
   @override
   Map<String, dynamic> toTomlValue() => toJson();
+
 }
 
 // ////////////// //
 // Debug Settings //
 // ////////////// //
 
-// @Freezed(fromJson: true, toJson: true)
-// class DebugSettings with _$DebugSettings implements TomlEncodableValue {
+@Freezed(fromJson: true, toJson: true)
+class DebugSettings with _$DebugSettings implements TomlEncodableValue {
 
-//   const DebugSettings._();
+  const DebugSettings._();
 
-//   const factory DebugSettings({
+  const factory DebugSettings({
+    @Default(false) bool showFpsCounter,
+  }) = _DebugSettings;
 
-//   }) = _DebugSettings;
+  factory DebugSettings.withDefaults() => DebugSettings.fromJson({});
 
-//   factory DebugSettings.withDefaults() => DebugSettings.fromJson({});
+  factory DebugSettings.fromJson(Map<String, Object?> json) => _$DebugSettingsFromJson(json);
 
-//   factory DebugSettings.fromJson(Map<String, Object?> json) => _$DebugSettingsFromJson(json);
+  @override
+  Map<String, dynamic> toTomlValue() => toJson();
 
-//   @override
-//   Map<String, dynamic> toTomlValue() => toJson();
-
-// }
+}
 
 // /////////////// //
 // Default helpers //

--- a/lib/views/capture_screen/capture_screen_view.dart
+++ b/lib/views/capture_screen/capture_screen_view.dart
@@ -18,6 +18,7 @@ class CaptureScreenView extends ScreenViewBase<CaptureScreenViewModel, CaptureSc
   @override
   Widget get body {
     return Stack(
+      clipBehavior: Clip.none,
       fit: StackFit.expand,
       children: [
         // This widget is just here for the purpose of rendering the collage to a bitmap

--- a/lib/views/collage_maker_screen/collage_maker_screen_view.dart
+++ b/lib/views/collage_maker_screen/collage_maker_screen_view.dart
@@ -20,6 +20,7 @@ class CollageMakerScreenView extends ScreenViewBase<CollageMakerScreenViewModel,
   @override
   Widget get body {
     return Stack(
+      clipBehavior: Clip.none,
       fit: StackFit.expand,
       children: [
         Row(
@@ -100,6 +101,7 @@ class CollageMakerScreenView extends ScreenViewBase<CollageMakerScreenViewModel,
             onTap: () => controller.togglePicture(i),
             child: Observer(builder: (context) {
               return Stack(
+                clipBehavior: Clip.none,
                 children: [
                   ImageWithLoaderFallback.memory(PhotosManager.instance.photos[i]),
                   AnimatedOpacity(
@@ -107,6 +109,7 @@ class CollageMakerScreenView extends ScreenViewBase<CollageMakerScreenViewModel,
                     duration: const Duration(milliseconds: 200),
                     curve: Curves.easeInOut,
                     child: Stack(
+                      clipBehavior: Clip.none,
                       fit: StackFit.expand,
                       children: [
                         const ColoredBox(color: Color(0x80000000)),

--- a/lib/views/custom_widgets/capture_counter.dart
+++ b/lib/views/custom_widgets/capture_counter.dart
@@ -47,6 +47,7 @@ class CaptureCounterState extends State<CaptureCounter> with SingleTickerProvide
     return AspectRatio(
       aspectRatio: 1,
       child: Stack(
+        clipBehavior: Clip.none,
         fit: StackFit.expand,
         children: [
           Container(

--- a/lib/views/custom_widgets/photo_collage.dart
+++ b/lib/views/custom_widgets/photo_collage.dart
@@ -158,39 +158,43 @@ class PhotoCollageState extends State<PhotoCollage> with UiLoggy {
   }
 
   Widget _getLayout(AppLocalizations localizations) {
-    return Stack(fit: StackFit.expand, children: [
-      for (int i = 0; i <= 4; i++) ...[
-        if (initialized > 0 && templates[TemplateKind.back]?[i] != null)
-          Opacity(
-            opacity: i == nChosen && widget.showBackground ? 1 : 0,
-            child: ImageWithLoaderFallback.file(templates[TemplateKind.back]?[i], fit: BoxFit.cover),
-          ),
-      ],
-      if (widget.debug == null)
-        Padding(
-          padding: EdgeInsets.all(gap + widget.padding),
-          child: _getInnerLayout(localizations),
-        ),
-      if (widget.debug != null)
-        Container(
-          decoration: BoxDecoration(
-            border: Border.all(width: widget.padding, color: const ui.Color.fromARGB(126, 212, 53, 53)),
-          ),
-          child: Container(
-            decoration: BoxDecoration(
-              border: Border.all(width: gap, color: const ui.Color.fromARGB(127, 255, 255, 255)),
+    return Stack(
+      clipBehavior: Clip.none,
+      fit: StackFit.expand,
+      children: [
+        for (int i = 0; i <= 4; i++) ...[
+          if (initialized > 0 && templates[TemplateKind.back]?[i] != null)
+            Opacity(
+              opacity: i == nChosen && widget.showBackground ? 1 : 0,
+              child: ImageWithLoaderFallback.file(templates[TemplateKind.back]?[i], fit: BoxFit.cover),
             ),
+        ],
+        if (widget.debug == null)
+          Padding(
+            padding: EdgeInsets.all(gap + widget.padding),
             child: _getInnerLayout(localizations),
           ),
-        ),
-      for (int i = 0; i <= 4; i++) ...[
-        if (initialized > 0 && templates[TemplateKind.front]?[i] != null)
-          Opacity(
-            opacity: i == nChosen && widget.showForeground ? 1 : 0,
-            child: ImageWithLoaderFallback.file(templates[TemplateKind.front]?[i], fit: BoxFit.cover),
+        if (widget.debug != null)
+          Container(
+            decoration: BoxDecoration(
+              border: Border.all(width: widget.padding, color: const ui.Color.fromARGB(126, 212, 53, 53)),
+            ),
+            child: Container(
+              decoration: BoxDecoration(
+                border: Border.all(width: gap, color: const ui.Color.fromARGB(127, 255, 255, 255)),
+              ),
+              child: _getInnerLayout(localizations),
+            ),
           ),
+        for (int i = 0; i <= 4; i++) ...[
+          if (initialized > 0 && templates[TemplateKind.front]?[i] != null)
+            Opacity(
+              opacity: i == nChosen && widget.showForeground ? 1 : 0,
+              child: ImageWithLoaderFallback.file(templates[TemplateKind.front]?[i], fit: BoxFit.cover),
+            ),
+        ],
       ],
-    ]);
+    );
   }
 
   Widget _getInnerLayout(AppLocalizations localizations) {
@@ -315,6 +319,7 @@ class PhotoCollageState extends State<PhotoCollage> with UiLoggy {
 
   Widget get _fourLayout {
     return Stack(
+      clipBehavior: Clip.none,
       children: [
         LayoutGrid(
           areas: '''

--- a/lib/views/custom_widgets/wrappers/live_view_background.dart
+++ b/lib/views/custom_widgets/wrappers/live_view_background.dart
@@ -25,6 +25,7 @@ class LiveViewBackground extends StatelessWidgetBase {
   @override
   Widget build(BuildContext context) {
     return Stack(
+      clipBehavior: Clip.none,
       fit: StackFit.expand,
       children: [
         _viewState,
@@ -91,6 +92,7 @@ class LiveViewBackground extends StatelessWidgetBase {
     }
 
     return Stack(
+      clipBehavior: Clip.none,
       fit: StackFit.expand,
       children: [
         ColoredBox(color: Colors.green),
@@ -102,7 +104,7 @@ class LiveViewBackground extends StatelessWidgetBase {
           duration: const Duration(milliseconds: 300),
           opacity: _showLiveViewBackground ? 1 : 0,
           curve: Curves.ease,
-          child: const LiveView(),
+          child: const LiveView(fit: BoxFit.contain),
         ),
       ],
     );
@@ -116,29 +118,28 @@ class LiveView extends StatelessWidgetBase {
 
   const LiveView({
     super.key,
-    this.fit = BoxFit.contain,
+    required this.fit,
   });
 
   Flip get _flip => SettingsManager.instance.settings.hardware.liveViewFlipImage;
+  ui.FilterQuality get _filterQuality => SettingsManager.instance.settings.ui.liveViewFilterQuality.toUiFilterQuality();
 
   @override
   Widget build(BuildContext context) {
     return Observer(
-      builder: (context) => Transform(
-        transform: Matrix4.diagonal3Values(_flip.flipX ? -1.0 : 1.0, _flip.flipY ? -1.0 : 1.0, 1.0),
-        alignment: Alignment.center,
-        child: AspectRatio(
-          aspectRatio: 3/2,
-          child: FittedBox(
-            fit: fit,
-            child: SizedBox(
-              width: 3,
-              height: 2,
-              child: Texture(
-                textureId: LiveViewManager.instance.textureId ?? 0,
-                filterQuality: SettingsManager.instance.settings.ui.liveViewFilterQuality.toUiFilterQuality(),
-              ),
-            ),
+      builder: (context) => FittedBox(
+        fit: fit,
+        child: SizedBox(
+          width: 3,
+          height: 2,
+          child: Transform.flip(
+            flipX: _flip.flipX,
+            flipY: _flip.flipY,
+            filterQuality: _filterQuality,
+            child: LiveViewManager.instance.textureId != null ? Texture(
+              textureId: LiveViewManager.instance.textureId!,
+              filterQuality: _filterQuality,
+            ) : null,
           ),
         ),
       ),

--- a/lib/views/custom_widgets/wrappers/lottie_animation_wrapper.dart
+++ b/lib/views/custom_widgets/wrappers/lottie_animation_wrapper.dart
@@ -14,6 +14,7 @@ class LottieAnimationWrapper extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Stack(
+      clipBehavior: Clip.none,
       children: [
         child,
         for (LottieAnimationSettings animation in animationSettings)

--- a/lib/views/gallery_screen/gallery_screen_view.dart
+++ b/lib/views/gallery_screen/gallery_screen_view.dart
@@ -18,6 +18,7 @@ class GalleryScreenView extends ScreenViewBase<GalleryScreenViewModel, GallerySc
   @override
   Widget get body {
     return Stack(
+      clipBehavior: Clip.none,
       children: [
         Observer(
           builder: (context) => GridView.count(

--- a/lib/views/manual_collage_screen/manual_collage_screen_view.dart
+++ b/lib/views/manual_collage_screen/manual_collage_screen_view.dart
@@ -31,6 +31,7 @@ class ManualCollageScreenView extends ScreenViewBase<ManualCollageScreenViewMode
   Widget _photoInst(SelectableImage image) {
     return Observer(
       builder: (context) => Stack(
+        clipBehavior: Clip.none,
         children: [
           Center(
             child: ImageWithLoaderFallback.file(image.file, fit: BoxFit.contain),
@@ -40,6 +41,7 @@ class ManualCollageScreenView extends ScreenViewBase<ManualCollageScreenViewMode
             duration: const Duration(milliseconds: 200),
             curve: Curves.easeInOut,
             child: Stack(
+              clipBehavior: Clip.none,
               fit: StackFit.expand,
               children: [
                 const ColoredBox(color: Color(0x80000000)),

--- a/lib/views/multi_capture_screen/multi_capture_screen_view.dart
+++ b/lib/views/multi_capture_screen/multi_capture_screen_view.dart
@@ -20,6 +20,7 @@ class MultiCaptureScreenView extends ScreenViewBase<MultiCaptureScreenViewModel,
   @override
   Widget get body {
     return Stack(
+      clipBehavior: Clip.none,
       fit: StackFit.expand,
       children: [
         Row(
@@ -34,6 +35,7 @@ class MultiCaptureScreenView extends ScreenViewBase<MultiCaptureScreenViewModel,
               child: AspectRatio(
                 aspectRatio: 1.5,
                 child: Stack(
+                  clipBehavior: Clip.none,
                   children: [
                     _liveViewWithCounter,
                     Observer(builder: (_) {
@@ -84,9 +86,10 @@ class MultiCaptureScreenView extends ScreenViewBase<MultiCaptureScreenViewModel,
 
   Widget get _liveViewWithCounter {
     return Stack(
+      clipBehavior: Clip.none,
       fit: StackFit.expand,
       children: [
-        const LiveView(),
+        const LiveView(fit: BoxFit.contain),
         Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [

--- a/lib/views/photo_details_screen/photo_details_screen_view.dart
+++ b/lib/views/photo_details_screen/photo_details_screen_view.dart
@@ -22,6 +22,7 @@ class PhotoDetailsScreenView extends ScreenViewBase<PhotoDetailsScreenViewModel,
   @override
   Widget get body {
     return Stack(
+      clipBehavior: Clip.none,
       children: [
         Padding(
           padding: const EdgeInsets.all(30),

--- a/lib/views/settings_screen/settings_screen_controller.dart
+++ b/lib/views/settings_screen/settings_screen_controller.dart
@@ -403,4 +403,10 @@ class SettingsScreenController extends ScreenControllerBase<SettingsScreenViewMo
     }
   }
 
+  void onDebugShowFpsCounterChanged(bool? showFpsCounter) {
+    if (showFpsCounter != null) {
+      viewModel.updateSettings((settings) => settings.copyWith.debug(showFpsCounter: showFpsCounter));
+    }
+  }
+
 }

--- a/lib/views/settings_screen/settings_screen_view.debug.dart
+++ b/lib/views/settings_screen/settings_screen_view.debug.dart
@@ -19,8 +19,8 @@ Widget _getDebugTab(SettingsScreenViewModel viewModel, SettingsScreenController 
             builder: (context) => TextDisplayCard(
               icon: FluentIcons.front_camera,
               title: "Live view frames",
-              subtitle: "The number of live view frames processed from the start of the camera\nValue shows: Valid frames / Undecodable frames",
-              text: "${StatsManager.instance.validLiveViewFrames} / ${StatsManager.instance.invalidLiveViewFrames}",
+              subtitle: "The number of live view frames processed from the start of the camera\nValue shows: Valid frames / Undecodable frames / Duplicate frames",
+              text: "${StatsManager.instance.validLiveViewFrames} / ${StatsManager.instance.invalidLiveViewFrames} / ${StatsManager.instance.duplicateLiveViewFrames}",
             ),
           ),
           Observer(

--- a/lib/views/settings_screen/settings_screen_view.debug.dart
+++ b/lib/views/settings_screen/settings_screen_view.debug.dart
@@ -74,6 +74,18 @@ Widget _getDebugTab(SettingsScreenViewModel viewModel, SettingsScreenController 
         ],
       ),
       FluentSettingsBlock(
+        title: "Debug settings",
+        settings: [
+          BooleanInputCard(
+            icon: FluentIcons.count,
+            title: "Show FPS count",
+            subtitle: "Show the FPS count in the upper right corner.",
+            value: () => viewModel.debugShowFpsCounter,
+            onChanged: controller.onDebugShowFpsCounterChanged,
+          ),
+        ],
+      ),
+      FluentSettingsBlock(
         title: "Debug actions",
         settings: [
           ButtonCard(
@@ -84,7 +96,7 @@ Widget _getDebugTab(SettingsScreenViewModel viewModel, SettingsScreenController 
             onPressed: () => throw Exception("This is a fake error to test error reporting"),
           ),
         ],
-      )
+      ),
     ],
   );
 }

--- a/lib/views/settings_screen/settings_screen_view_model.dart
+++ b/lib/views/settings_screen/settings_screen_view_model.dart
@@ -145,6 +145,7 @@ abstract class SettingsScreenViewModelBase extends ScreenViewModelBase with Stor
   bool get mqttIntegrationEnableHomeAssistantDiscoverySetting => SettingsManager.instance.settings.mqttIntegration.enableHomeAssistantDiscovery;
   String get mqttIntegrationHomeAssistantDiscoveryTopicPrefixSetting => SettingsManager.instance.settings.mqttIntegration.homeAssistantDiscoveryTopicPrefix;
   String get mqttIntegrationHomeAssistantComponentIdSetting => SettingsManager.instance.settings.mqttIntegration.homeAssistantComponentId;
+  bool get debugShowFpsCounter => SettingsManager.instance.settings.debug.showFpsCounter;
 
   double get outputResHeightExcl => resolutionMultiplier * 1000;
   double get outputResWidthExcl => outputResHeightExcl/collageAspectRatioSetting;

--- a/lib/views/share_screen/share_screen_view.dart
+++ b/lib/views/share_screen/share_screen_view.dart
@@ -22,6 +22,7 @@ class ShareScreenView extends ScreenViewBase<ShareScreenViewModel, ShareScreenCo
   @override
   Widget get body {
     return Stack(
+      clipBehavior: Clip.none,
       children: [
         Padding(
           padding: const EdgeInsets.all(30),

--- a/lib/views/start_screen/start_screen_view.dart
+++ b/lib/views/start_screen/start_screen_view.dart
@@ -20,6 +20,7 @@ class StartScreenView extends ScreenViewBase<StartScreenViewModel, StartScreenCo
     return LottieAnimationWrapper(
       animationSettings: viewModel.introScreenLottieAnimations,
       child: Stack(
+        clipBehavior: Clip.none,
         children: [
           GestureDetector(
             onTap: controller.onPressedContinue,

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -20,7 +20,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   AudioSessionPlugin.register(with: registry.registrar(forPlugin: "AudioSessionPlugin"))
   FileSelectorPlugin.register(with: registry.registrar(forPlugin: "FileSelectorPlugin"))
   JustAudioPlugin.register(with: registry.registrar(forPlugin: "JustAudioPlugin"))
-  FLTPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FLTPackageInfoPlusPlugin"))
+  FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   PrintingPlugin.register(with: registry.registrar(forPlugin: "PrintingPlugin"))
   ScreenRetrieverPlugin.register(with: registry.registrar(forPlugin: "ScreenRetrieverPlugin"))

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -1,7 +1,11 @@
 PODS:
+  - audio_session (0.0.1):
+    - FlutterMacOS
   - file_selector_macos (0.0.1):
     - FlutterMacOS
   - FlutterMacOS (1.0.0)
+  - just_audio (0.0.1):
+    - FlutterMacOS
   - package_info_plus (0.0.1):
     - FlutterMacOS
   - path_provider_foundation (0.0.1):
@@ -24,8 +28,10 @@ PODS:
     - FlutterMacOS
 
 DEPENDENCIES:
+  - audio_session (from `Flutter/ephemeral/.symlinks/plugins/audio_session/macos`)
   - file_selector_macos (from `Flutter/ephemeral/.symlinks/plugins/file_selector_macos/macos`)
   - FlutterMacOS (from `Flutter/ephemeral`)
+  - just_audio (from `Flutter/ephemeral/.symlinks/plugins/just_audio/macos`)
   - package_info_plus (from `Flutter/ephemeral/.symlinks/plugins/package_info_plus/macos`)
   - path_provider_foundation (from `Flutter/ephemeral/.symlinks/plugins/path_provider_foundation/darwin`)
   - printing (from `Flutter/ephemeral/.symlinks/plugins/printing/macos`)
@@ -40,10 +46,14 @@ SPEC REPOS:
     - SentryPrivate
 
 EXTERNAL SOURCES:
+  audio_session:
+    :path: Flutter/ephemeral/.symlinks/plugins/audio_session/macos
   file_selector_macos:
     :path: Flutter/ephemeral/.symlinks/plugins/file_selector_macos/macos
   FlutterMacOS:
     :path: Flutter/ephemeral
+  just_audio:
+    :path: Flutter/ephemeral/.symlinks/plugins/just_audio/macos
   package_info_plus:
     :path: Flutter/ephemeral/.symlinks/plugins/package_info_plus/macos
   path_provider_foundation:
@@ -60,8 +70,10 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/window_manager/macos
 
 SPEC CHECKSUMS:
+  audio_session: dea1f41890dbf1718f04a56f1d6150fd50039b72
   file_selector_macos: 468fb6b81fac7c0e88d71317f3eec34c3b008ff9
   FlutterMacOS: 8f6f14fa908a6fb3fba0cd85dbd81ec4b251fb24
+  just_audio: 9b67ca7b97c61cfc9784ea23cd8cc55eb226d489
   package_info_plus: 02d7a575e80f194102bef286361c6c326e4c29ce
   path_provider_foundation: 29f094ae23ebbca9d3d0cec13889cd9060c0e943
   printing: 1dd6a1fce2209ec240698e2439a4adbb9b427637

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -636,6 +636,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.2.0"
+  lemberfpsmonitor:
+    dependency: "direct main"
+    description:
+      name: lemberfpsmonitor
+      sha256: "2ffe1dc0e7902a8890639ce6a9e0088d62a7596708213ee11ccc047e6d437759"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.0.3+6"
   lints:
     dependency: transitive
     description:
@@ -760,10 +768,10 @@ packages:
     dependency: "direct main"
     description:
       name: package_info_plus
-      sha256: "6ff267fcd9d48cb61c8df74a82680e8b82e940231bb5f68356672fde0397334a"
+      sha256: "7e76fad405b3e4016cd39d08f455a4eb5199723cf594cd1b8916d47140d93017"
       url: "https://pub.dev"
     source: hosted
-    version: "4.1.0"
+    version: "4.2.0"
   package_info_plus_platform_interface:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -56,6 +56,7 @@ dependencies:
   path: 1.8.3
   window_manager: 0.3.7
   file_selector: 1.0.1
+  win32: 5.0.9
 
   # Log and error handling
   loggy: 2.0.3
@@ -72,10 +73,10 @@ dependencies:
   toml: 0.14.0
   synchronized: 3.1.0
   collection: 1.17.2
-  win32: 5.0.9
   mqtt5_client: 4.0.2
   dart_casing: 3.0.1
-  package_info_plus: 4.1.0
+  package_info_plus: 4.2.0
+  lemberfpsmonitor: 0.0.3+6
 
 dev_dependencies:
   flutter_test:

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -18,6 +18,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "ahash"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
+dependencies = [
+ "cfg-if 1.0.0",
+ "getrandom 0.2.10",
+ "once_cell",
+ "version_check 0.9.4",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1633,6 +1645,7 @@ dependencies = [
 name = "momento_booth_native_helpers"
 version = "0.1.0"
 dependencies = [
+ "ahash",
  "anyhow",
  "atom_table",
  "chrono",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -849,9 +849,9 @@ dependencies = [
 
 [[package]]
 name = "flutter_rust_bridge"
-version = "1.82.3"
+version = "1.82.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "898aef1ddc8d2d357c726a9e758f55935e62dacc946097455225414b3856eb60"
+checksum = "d5b3f423054f2fbc74e3dcef394ef3fd7a4f8309265a6b9a6ccf9c0fb07bb14b"
 dependencies = [
  "allo-isolate",
  "anyhow",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["lib", "staticlib", "cdylib"]
 anyhow = "1.0.75"
 derive_more = "0.99.17"
 atom_table = "1.1.0"
-flutter_rust_bridge = "1.82.1"
+flutter_rust_bridge = "=1.82.1"
 ffsend-api = "0.7.3"
 serde_json = "1.0.107"
 chrono = "0.4.31"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -28,6 +28,7 @@ turborand = "0.10.0"
 pathsep = "0.1.1"
 tokio = "1.32.0"
 gphoto2 = "3.2.3"
+ahash = "0.8.3"
 
 [profile.dev]
 opt-level = 3

--- a/rust/src/hardware_control/live_view/gphoto2.rs
+++ b/rust/src/hardware_control/live_view/gphoto2.rs
@@ -3,7 +3,7 @@ use std::{sync::{OnceLock, atomic::{AtomicBool, Ordering}, Arc}, any::Any, cell:
 use ahash::AHasher;
 use gphoto2::{Context, list::CameraDescriptor, widget::{TextWidget, RadioWidget}, Camera, Error, camera::CameraEvent};
 
-use tokio::sync::Mutex as AsyncMutex;
+use tokio::{sync::Mutex as AsyncMutex, time::sleep};
 use tokio::task::JoinHandle as AsyncJoinHandle;
 
 use crate::{utils::jpeg, dart_bridge::api::RawImage, log_debug};
@@ -78,6 +78,7 @@ pub async fn start_liveview<F, D>(camera_ref: Arc<AsyncMutex<GPhoto2Camera>>, fr
       if hash == last_hash.get() {
         // Frame is the same as the last one, skip
         duplicate_frame_callback();
+        sleep(Duration::from_millis(8)).await;
         continue;
       }
 

--- a/rust/src/hardware_control/live_view/white_noise.rs
+++ b/rust/src/hardware_control/live_view/white_noise.rs
@@ -1,10 +1,10 @@
 use std::{thread::{self, JoinHandle}, time, sync::{atomic::{AtomicBool, Ordering}, Arc}};
 use turborand::{rng::Rng, GenCore};
 
-use crate::{dart_bridge::api::RawImage};
+use crate::dart_bridge::api::RawImage;
 
 pub fn start_and_get_handle<F>(width: usize, height: usize, frame_callback: F) -> WhiteNoiseGeneratorHandle where F: Fn(RawImage) + Send + 'static {
-    let ten_millis = time::Duration::from_millis(10);
+    let frame_wait_time = time::Duration::from_millis(20);
 
     let should_stop = Arc::new(AtomicBool::new(false));
     let should_stop_clone = should_stop.clone();
@@ -15,7 +15,7 @@ pub fn start_and_get_handle<F>(width: usize, height: usize, frame_callback: F) -
             let frame = generate_frame(&rng, width, height);
             frame_callback(frame);
 
-            thread::sleep(ten_millis)
+            thread::sleep(frame_wait_time)
         }
     });
 


### PR DESCRIPTION
This PR:
- Disables clipping for all Stack widgets that don't need it anyway
- Adds an FPS counter (enable from Settings -> Debug tab)
- Cleansup and simplifies the LiveView widget
- Locks flutter_rust_bridge at Rust side to the correct version that's also used by Dart
- Updates macOS build files
- Updates packages
- Deduplicate gphoto2 frames by hash value + 8 ms delay every time a duplicate frame is detected