### PR TITLE
Bugfix/exif makernote read write

### DIFF
--- a/.github/workflows/pr-ci-app-linux-appimage-x64.yml
+++ b/.github/workflows/pr-ci-app-linux-appimage-x64.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Install apt packages
-      run: sudo apt update && sudo apt install build-essential git clang cmake ninja-build pkg-config libgtk-3-dev liblzma-dev llvm libfuse2 libgphoto2-dev libdigest-sha-perl libexiv2-dev
+      run: sudo apt update && sudo apt install build-essential git clang cmake ninja-build pkg-config libgtk-3-dev liblzma-dev llvm libfuse2 libgphoto2-dev libdigest-sha-perl libgexiv2-dev
 
     - name: Detect Flutter Version
       uses: kuhnroyal/flutter-fvm-config-action@v2

--- a/.github/workflows/pr-ci-app-linux-appimage-x64.yml
+++ b/.github/workflows/pr-ci-app-linux-appimage-x64.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Install apt packages
-      run: sudo apt update && sudo apt install build-essential git clang cmake ninja-build pkg-config libgtk-3-dev liblzma-dev llvm libfuse2 libgphoto2-dev libdigest-sha-perl
+      run: sudo apt update && sudo apt install build-essential git clang cmake ninja-build pkg-config libgtk-3-dev liblzma-dev llvm libfuse2 libgphoto2-dev libdigest-sha-perl libexiv2-dev
 
     - name: Detect Flutter Version
       uses: kuhnroyal/flutter-fvm-config-action@v2

--- a/.github/workflows/pr-ci-app-win-x64.yml
+++ b/.github/workflows/pr-ci-app-win-x64.yml
@@ -36,7 +36,7 @@ jobs:
       with:
         msystem: MINGW64
         update: true
-        install: mingw-w64-x86_64-libgphoto2 mingw-w64-x86_64-pkg-config mingw-w64-x86_64-gcc mingw-w64-x86_64-clang
+        install: mingw-w64-x86_64-libgphoto2 mingw-w64-x86_64-pkg-config mingw-w64-x86_64-gcc mingw-w64-x86_64-clang mingw-w64-x86_64-exiv2 mingw-w64-x86_64-curl-winssl
         path-type: inherit
         release: true
 

--- a/.github/workflows/pr-ci-app-win-x64.yml
+++ b/.github/workflows/pr-ci-app-win-x64.yml
@@ -36,7 +36,7 @@ jobs:
       with:
         msystem: MINGW64
         update: true
-        install: mingw-w64-x86_64-libgphoto2 mingw-w64-x86_64-pkg-config mingw-w64-x86_64-gcc mingw-w64-x86_64-clang mingw-w64-x86_64-exiv2 mingw-w64-x86_64-curl-winssl
+        install: mingw-w64-x86_64-libgphoto2 mingw-w64-x86_64-pkg-config mingw-w64-x86_64-gcc mingw-w64-x86_64-clang mingw-w64-x86_64-gexiv2 mingw-w64-x86_64-curl-winssl
         path-type: inherit
         release: true
 

--- a/.github/workflows/release-linux-appimage-x64.yml
+++ b/.github/workflows/release-linux-appimage-x64.yml
@@ -24,7 +24,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Install apt packages
-      run: sudo apt update && sudo apt install build-essential git clang cmake ninja-build pkg-config libgtk-3-dev liblzma-dev llvm libfuse2 libgphoto2-dev libdigest-sha-perl libexiv2-dev
+      run: sudo apt update && sudo apt install build-essential git clang cmake ninja-build pkg-config libgtk-3-dev liblzma-dev llvm libfuse2 libgphoto2-dev libdigest-sha-perl libgexiv2-dev
 
     - name: Detect Flutter Version
       uses: kuhnroyal/flutter-fvm-config-action@v2

--- a/.github/workflows/release-linux-appimage-x64.yml
+++ b/.github/workflows/release-linux-appimage-x64.yml
@@ -24,7 +24,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Install apt packages
-      run: sudo apt update && sudo apt install build-essential git clang cmake ninja-build pkg-config libgtk-3-dev liblzma-dev llvm libfuse2 libgphoto2-dev libdigest-sha-perl
+      run: sudo apt update && sudo apt install build-essential git clang cmake ninja-build pkg-config libgtk-3-dev liblzma-dev llvm libfuse2 libgphoto2-dev libdigest-sha-perl libexiv2-dev
 
     - name: Detect Flutter Version
       uses: kuhnroyal/flutter-fvm-config-action@v2

--- a/.github/workflows/release-win-x64.yml
+++ b/.github/workflows/release-win-x64.yml
@@ -39,7 +39,7 @@ jobs:
       with:
         msystem: MINGW64
         update: true
-        install: mingw-w64-x86_64-libgphoto2 mingw-w64-x86_64-pkg-config mingw-w64-x86_64-gcc mingw-w64-x86_64-clang mingw-w64-x86_64-exiv2 mingw-w64-x86_64-curl-winssl
+        install: mingw-w64-x86_64-libgphoto2 mingw-w64-x86_64-pkg-config mingw-w64-x86_64-gcc mingw-w64-x86_64-clang mingw-w64-x86_64-gexiv2 mingw-w64-x86_64-curl-winssl
         path-type: inherit
         release: true
 

--- a/.github/workflows/release-win-x64.yml
+++ b/.github/workflows/release-win-x64.yml
@@ -39,7 +39,7 @@ jobs:
       with:
         msystem: MINGW64
         update: true
-        install: mingw-w64-x86_64-libgphoto2 mingw-w64-x86_64-pkg-config mingw-w64-x86_64-gcc mingw-w64-x86_64-clang
+        install: mingw-w64-x86_64-libgphoto2 mingw-w64-x86_64-pkg-config mingw-w64-x86_64-gcc mingw-w64-x86_64-clang mingw-w64-x86_64-exiv2 mingw-w64-x86_64-curl-winssl
         path-type: inherit
         release: true
 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1692,6 +1692,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "kamadak-exif"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef4fc70d0ab7e5b6bafa30216a6b48705ea964cdfc29c050f2412295eba58077"
+dependencies = [
+ "mutate_once",
+]
+
+[[package]]
 name = "kernel32-sys"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1991,6 +2000,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "mutate_once"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16cf681a23b4d0a43fc35024c176437f9dcd818db34e0f42ab456a0ee5ad497b"
+
+[[package]]
 name = "nanorand"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2122,18 +2137,6 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
-]
-
-[[package]]
-name = "nom-exif"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4da85c96824dc1b583f55fd2c39e53b04482b4c199f25db27868db334bf06407"
-dependencies = [
- "chrono",
- "nom",
- "regex",
- "thiserror",
 ]
 
 [[package]]
@@ -2966,11 +2969,11 @@ dependencies = [
  "img-parts",
  "ipp",
  "jpeg-encoder",
+ "kamadak-exif",
  "lazy_static",
  "little_exif",
  "noise",
  "nokhwa",
- "nom-exif",
  "num",
  "num-derive",
  "num-traits",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1231,6 +1231,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "gexiv2-sys"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4edf7a47be383873c52eb34426723c7c9b040f9e58cf5088f2253cef149daf1"
+dependencies = [
+ "glib-sys",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "gif"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1245,6 +1256,16 @@ name = "gimli"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+
+[[package]]
+name = "glib-sys"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61a4f46316d06bfa33a7ac22df6f0524c8be58e3db2d9ca99ccb1f357b62a65"
+dependencies = [
+ "libc",
+ "system-deps",
+]
 
 [[package]]
 name = "glob"
@@ -1692,15 +1713,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "kamadak-exif"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef4fc70d0ab7e5b6bafa30216a6b48705ea964cdfc29c050f2412295eba58077"
-dependencies = [
- "mutate_once",
-]
-
-[[package]]
 name = "kernel32-sys"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1998,12 +2010,6 @@ dependencies = [
  "libc",
  "nasm-rs",
 ]
-
-[[package]]
-name = "mutate_once"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16cf681a23b4d0a43fc35024c176437f9dcd818db34e0f42ab456a0ee5ad497b"
 
 [[package]]
 name = "nanorand"
@@ -2913,6 +2919,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rexiv2"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ecb9dccad43fea1bf58ea7bb8e34614446bea8aa00f78add6624d7ee26fb87"
+dependencies = [
+ "gexiv2-sys",
+ "glib-sys",
+ "libc",
+ "num-rational",
+]
+
+[[package]]
 name = "rgb"
 version = "0.8.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2969,7 +2987,6 @@ dependencies = [
  "img-parts",
  "ipp",
  "jpeg-encoder",
- "kamadak-exif",
  "lazy_static",
  "little_exif",
  "noise",
@@ -2978,6 +2995,7 @@ dependencies = [
  "num-derive",
  "num-traits",
  "pathsep",
+ "rexiv2",
  "serde_json",
  "static_init",
  "tokio",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -35,7 +35,7 @@ url = "2.5.0"
 num = "0.4.1"
 num-traits = "0.2.18"
 num-derive = "0.4.2"
-kamadak-exif = "0.5.5"
+rexiv2 = { version = "0.10.0", features = ["raw-tag-access"] }
 
 [profile.dev]
 opt-level = 3

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -35,7 +35,7 @@ url = "2.5.0"
 num = "0.4.1"
 num-traits = "0.2.18"
 num-derive = "0.4.2"
-nom-exif = "1.2.0"
+kamadak-exif = "0.5.5"
 
 [profile.dev]
 opt-level = 3

--- a/rust/src/api/initialization.rs
+++ b/rust/src/api/initialization.rs
@@ -22,6 +22,7 @@ pub fn initialize_log(log_sink: StreamSink<LogEvent>) {
 }
 
 pub fn initialize_hardware(ready_sink: StreamSink<HardwareInitializationFinishedEvent>) {
+    rexiv2::initialize().expect("Unable to initialize rexiv2");
     if !HARDWARE_INITIALIZED.load(Ordering::SeqCst) {
         // Hardware has not been initialized yet
         helpers::initialize_hardware(ready_sink);

--- a/rust/src/models/images.rs
+++ b/rust/src/models/images.rs
@@ -1,4 +1,4 @@
-use chrono::{DateTime, Local};
+use chrono::NaiveDateTime;
 use num_derive::FromPrimitive;
 
 #[derive(Clone)]
@@ -28,7 +28,7 @@ pub enum RawImageFormat {
 pub enum MomentoBoothExifTag {
     ImageDescription(String),
     Software(String),
-    CreateDate(DateTime<Local>),
+    CreateDate(NaiveDateTime),
     Orientation(ExifOrientation),
     MakerNote(String),
 }


### PR DESCRIPTION
This PR:
- Changes writing MakerNote as type `UNDEFINED` (instead of type `STRING`)
- Replaces the EXIF reading implementation by exiv2 which seems to be more resilient to badly written EXIF data
- Adds installing the necessary libraries to the PR CI

Be sure to install `mingw-w64-x86_64-gexiv2` and `mingw-w64-x86_64-curl-winssl` (as normal libcurl seems to have an issue currently) on Windows.