### PR TITLE
Replace EXIF reading with exiv2 by little_exif

### DIFF
--- a/.github/workflows/pr-ci-app-linux-appimage-x64.yml
+++ b/.github/workflows/pr-ci-app-linux-appimage-x64.yml
@@ -28,7 +28,7 @@ jobs:
         submodules: 'true'
 
     - name: Install apt packages
-      run: sudo apt update && sudo apt install build-essential git clang cmake ninja-build pkg-config libgtk-3-dev liblzma-dev llvm libfuse2 libgphoto2-dev libdigest-sha-perl libgexiv2-dev libsecret-1-dev libcurl4-openssl-dev libusb-1.0-0-dev libmimalloc-dev libmimalloc2.0 libasound2-dev
+      run: sudo apt update && sudo apt install build-essential git clang cmake ninja-build pkg-config libgtk-3-dev liblzma-dev llvm libfuse2 libgphoto2-dev libdigest-sha-perl libsecret-1-dev libcurl4-openssl-dev libusb-1.0-0-dev libmimalloc-dev libmimalloc2.0 libasound2-dev
 
     - name: Detect Flutter Version
       uses: kuhnroyal/flutter-fvm-config-action@v3

--- a/.github/workflows/pr-ci-app-macos-arm64.yml
+++ b/.github/workflows/pr-ci-app-macos-arm64.yml
@@ -108,7 +108,7 @@ jobs:
     - name: Download and unpack Homebrew libraries
       run: |
         mkdir ci_build && cd ci_build
-        ../macos/ci_download_deps.sh -a arm64_ventura,ventura libgphoto2 gexiv2
+        ../macos/ci_download_deps.sh -a arm64_ventura,ventura libgphoto2
         ../macos/ci_adapt_pkgconf_dirs.sh ventura/lib/pkgconfig
         ../macos/ci_adapt_pkgconf_dirs.sh arm64_ventura/lib/pkgconfig
 

--- a/.github/workflows/pr-ci-app-win-x64.yml
+++ b/.github/workflows/pr-ci-app-win-x64.yml
@@ -75,7 +75,7 @@ jobs:
       with:
         msystem: clang64
         path-type: inherit
-        pacboy: pkgconf:c gexiv2:c curl-winssl:c nghttp2:c nghttp3:c libusb:c gcc:c libgphoto2:c
+        pacboy: pkgconf:c curl-winssl:c nghttp2:c nghttp3:c libusb:c gcc:c libgphoto2:c
         install: git patch
         location: '${{ env.DEV_DRIVE }}/msys2'
 

--- a/.github/workflows/release-linux-appimage-x64.yml
+++ b/.github/workflows/release-linux-appimage-x64.yml
@@ -27,7 +27,7 @@ jobs:
         submodules: 'true'
 
     - name: Install apt packages
-      run: sudo apt update && sudo apt install build-essential git clang cmake ninja-build pkg-config libgtk-3-dev liblzma-dev llvm libfuse2 libgphoto2-dev libdigest-sha-perl libgexiv2-dev libsecret-1-dev libcurl4-openssl-dev libusb-1.0-0-dev libmimalloc-dev libmimalloc2.0 libasound2-dev
+      run: sudo apt update && sudo apt install build-essential git clang cmake ninja-build pkg-config libgtk-3-dev liblzma-dev llvm libfuse2 libgphoto2-dev libdigest-sha-perl libsecret-1-dev libcurl4-openssl-dev libusb-1.0-0-dev libmimalloc-dev libmimalloc2.0 libasound2-dev
 
     - name: Detect Flutter Version
       uses: kuhnroyal/flutter-fvm-config-action@v3

--- a/.github/workflows/release-macos-arm64.yml
+++ b/.github/workflows/release-macos-arm64.yml
@@ -102,7 +102,7 @@ jobs:
     - name: Download and unpack Homebrew libraries
       run: |
         mkdir ci_build && cd ci_build
-        ../macos/ci_download_deps.sh -a arm64_ventura,ventura libgphoto2 gexiv2
+        ../macos/ci_download_deps.sh -a arm64_ventura,ventura libgphoto2
         ../macos/ci_adapt_pkgconf_dirs.sh ventura/lib/pkgconfig
         ../macos/ci_adapt_pkgconf_dirs.sh arm64_ventura/lib/pkgconfig
 

--- a/.github/workflows/release-win-x64.yml
+++ b/.github/workflows/release-win-x64.yml
@@ -74,7 +74,7 @@ jobs:
       with:
         msystem: clang64
         path-type: inherit
-        pacboy: pkgconf:c gexiv2:c curl-winssl:c nghttp2:c nghttp3:c libusb:c gcc:c libgphoto2:c
+        pacboy: pkgconf:c curl-winssl:c nghttp2:c nghttp3:c libusb:c gcc:c libgphoto2:c
         install: git patch
         location: '${{ env.DEV_DRIVE }}/msys2'
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Check the online documentation at [https://momentobooth.github.io/momentobooth/]
 * **MSYS2**
   * Follow the instructions on the [MSYS2 website](https://www.msys2.org/)
   * Install the following packages:
-    `mingw-w64-clang-x86_64-pkgconf mingw-w64-clang-x86_64-libgphoto2 mingw-w64-clang-x86_64-gexiv2 mingw-w64-clang-x86_64-curl-winssl mingw-w64-clang-x86_64-nghttp2 mingw-w64-clang-x86_64-nghttp3`
+    `mingw-w64-clang-x86_64-pkgconf mingw-w64-clang-x86_64-libgphoto2 mingw-w64-clang-x86_64-curl-winssl mingw-w64-clang-x86_64-nghttp2 mingw-w64-clang-x86_64-nghttp3`
   * Make sure `{MSYS_INSTALL_PATH}\clang64\bin` is in your `PATH` (before other folders that also provide `pkg-config`/`pkgconf`)
 
 </details>
@@ -83,7 +83,7 @@ Check the online documentation at [https://momentobooth.github.io/momentobooth/]
   * Recommended installation via [`rustup`](https://rustup.rs/)
   * `rustup` is also available via [Homebrew](https://formulae.brew.sh/formula/rustup)
 * **Homebrew**
-  * Install: `pkgconf libgphoto2 gexiv2`
+  * Install: `pkgconf libgphoto2`
 
 </details>
 

--- a/lib/utils/environment_info.dart
+++ b/lib/utils/environment_info.dart
@@ -40,7 +40,6 @@ Future<void> initializeEnvironmentInfo() async {
     "Helper library Rust target": helperLibraryVersionInfo.rustTarget,
     "libgphoto2 version": helperLibraryVersionInfo.libgphoto2Version,
     "libusb version": helperLibraryVersionInfo.libusbVersion,
-    "libgexiv2 version": helperLibraryVersionInfo.libgexiv2Version,
   });
 }
 

--- a/lib/views/settings_overlay/pages/settings_overlay_view.about.dart
+++ b/lib/views/settings_overlay/pages/settings_overlay_view.about.dart
@@ -22,8 +22,6 @@ Widget get _aboutTab {
             const SizedBox(height: 8),
             Text('libusb version: ${helperLibraryVersionInfo.libusbVersion}'),
             Text('libgphoto2 version: ${helperLibraryVersionInfo.libgphoto2Version}${libgphoto2GitRev.isNotEmpty ? ' (git rev ${libgphoto2GitRev.substring(0, 7)})' : ''}'),
-            Text('libexiv2 version: ${helperLibraryVersionInfo.libexiv2Version}'),
-            Text('libgexiv2 version: ${helperLibraryVersionInfo.libgexiv2Version}'),
           ],
         ),
       ],

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1470,17 +1470,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gexiv2-sys"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4edf7a47be383873c52eb34426723c7c9b040f9e58cf5088f2253cef149daf1"
-dependencies = [
- "glib-sys",
- "libc",
- "pkg-config",
-]
-
-[[package]]
 name = "gif"
 version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1503,16 +1492,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e12d847aeb25f41be4c0ec9587d624e9cd631bc007a8fd7ce3f5851e064c6460"
 dependencies = [
  "mint",
-]
-
-[[package]]
-name = "glib-sys"
-version = "0.16.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61a4f46316d06bfa33a7ac22df6f0524c8be58e3db2d9ca99ccb1f357b62a65"
-dependencies = [
- "libc",
- "system-deps",
 ]
 
 [[package]]
@@ -3560,18 +3539,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rexiv2"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ecb9dccad43fea1bf58ea7bb8e34614446bea8aa00f78add6624d7ee26fb87"
-dependencies = [
- "gexiv2-sys",
- "glib-sys",
- "libc",
- "num-rational",
-]
-
-[[package]]
 name = "rgb"
 version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3627,7 +3594,6 @@ dependencies = [
  "ffsend-api",
  "flutter_rust_bridge",
  "futures 0.3.31",
- "gexiv2-sys",
  "gphoto2",
  "image",
  "img-parts",
@@ -3647,7 +3613,6 @@ dependencies = [
  "pathsep",
  "pkg-config",
  "regex",
- "rexiv2",
  "rustc_version_runtime",
  "serde_json",
  "snafu",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -29,8 +29,6 @@ url = "2.5.7"
 num = "0.4.3"
 num-traits = "0.2.19"
 num-derive = "0.4.2"
-rexiv2 = { version = "0.10.0", features = ["raw-tag-access"] }
-gexiv2-sys = "1.4.0"
 regex = "1.11.3"
 log = "0.4.28"
 nokhwa = { git = "https://github.com/l1npengtul/nokhwa.git", branch = "0.10", features = ["input-native", "output-threaded"] }

--- a/rust/build.rs
+++ b/rust/build.rs
@@ -1,11 +1,9 @@
 use std::env;
 use std::fs::File;
 use std::io::Write;
-use std::path::PathBuf;
 
 fn main() {
     insert_target_name();
-    generate_exiv2_bindings();
 }
 
 fn insert_target_name() {
@@ -19,24 +17,4 @@ fn insert_target_name() {
     // Write target name to file
     let target = env::var("TARGET").unwrap();
     file.write_all(target.as_bytes()).unwrap();
-}
-
-fn generate_exiv2_bindings() {
-    let pkg_config_result = pkg_config::Config::new().probe("exiv2").unwrap();
-
-    let mut builder = bindgen::Builder::default().clang_arg("-xc++").clang_arg("-std=c++11");
-    for path in pkg_config_result.include_paths {
-        builder = builder.clang_arg(format!("-I{}", path.to_str().unwrap()));
-
-        let header_path = path.join("exiv2").join("exiv2.hpp");
-        if header_path.exists() {
-            builder = builder.header(header_path.to_str().unwrap())
-        }
-    }
-    let bindings = builder.parse_callbacks(Box::new(bindgen::CargoCallbacks::new())).allowlist_function("Exiv2::version").generate().expect("Unable to generate bindings");
-
-    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
-    bindings
-        .write_to_file(out_path.join("exiv2_bindings.rs"))
-        .expect("Couldn't write bindings!");
 }

--- a/rust/src/api/initialization.rs
+++ b/rust/src/api/initialization.rs
@@ -1,14 +1,12 @@
 use crate::frb_generated::StreamSink;
 use crate::models::logging::LogEntry;
 use crate::models::version_info::VersionInfo;
-use std::ffi::CStr;
 use std::path::Path;
 use std::time;
 use crate::INITIALIZATION;
 use crate::LIBRARY_VERSION;
 use crate::RUST_TARGET;
 use crate::TOKIO_RUNTIME;
-use gexiv2_sys::gexiv2_get_version;
 pub use ipp::model::PrinterState;
 pub use ipp::model::JobState;
 use log::LevelFilter;
@@ -32,27 +30,6 @@ pub fn get_version_info() -> VersionInfo {
         library_version: LIBRARY_VERSION.to_owned(),
         libgphoto2_version: ::gphoto2::library_version().unwrap().to_owned(),
         libusb_version: get_libusb_version(),
-        libgexiv2_version: get_gexiv2_version(),
-        libexiv2_version: get_exiv2_version(),
-    }
-}
-
-fn get_gexiv2_version() -> String {
-    let raw_version = unsafe { gexiv2_get_version() };
-    println!("{:?}", raw_version);
-
-    // Extract the major, minor, and patch versions
-    let major = raw_version / 10000;
-    let minor = (raw_version / 100) % 100;
-    let patch = raw_version % 100;
-
-    format!("{}.{}.{}", major, minor, patch)
-}
-
-fn get_exiv2_version() -> String {
-    unsafe {
-        let c_str = crate::Exiv2_version();
-        CStr::from_ptr(c_str).to_string_lossy().into_owned()
     }
 }
 
@@ -127,8 +104,6 @@ pub fn initialize_library() {
         // TODO: test what happens when we panic
         TOKIO_RUNTIME.get_or_init(|| runtime::Builder::new_multi_thread().enable_all().build().unwrap());
         debug!("{}", "Tokio runtime initialized");
-        rexiv2::initialize().expect("Unable to initialize rexiv2");
-        debug!("{}", "Rexiv2 initialized");
     });
 
     while !NOISE_HANDLES.is_empty() {

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -10,8 +10,6 @@ mod frb_generated;
 mod hardware_control;
 mod utils;
 
-include!(concat!(env!("OUT_DIR"), "/exiv2_bindings.rs"));
-
 const RUST_TARGET: &str = include_str!(join_path!(env!("OUT_DIR"), "target_name.txt"));
 const LIBRARY_VERSION: &'static str = env!("CARGO_PKG_VERSION");
 

--- a/rust/src/models/version_info.rs
+++ b/rust/src/models/version_info.rs
@@ -5,6 +5,4 @@ pub struct VersionInfo {
     pub library_version: String,
     pub libgphoto2_version: String,
     pub libusb_version: String,
-    pub libgexiv2_version: String,
-    pub libexiv2_version: String,
 }

--- a/rust_builder/macos/rust_lib_momento_booth.podspec
+++ b/rust_builder/macos/rust_lib_momento_booth.podspec
@@ -26,7 +26,7 @@ A new Flutter FFI plugin project.
   s.swift_version = '5.0'
 
   s.frameworks = ["CoreMedia", "AVFoundation", "SystemConfiguration", "CoreAudio", "AudioToolbox"]
-  s.libraries = ["gphoto2", "gphoto2_port", "gexiv2", "glib-2.0", "exiv2", "usb-1.0"]
+  s.libraries = ["gphoto2", "gphoto2_port", "usb-1.0"]
 
   s.script_phase = {
     :name => 'Build Rust library',


### PR DESCRIPTION
Previously the `little-exif` crate didn't work for reading back EXIF data. Now it seems to work fine. As such we can remove exiv2 from our workflows now which should help with build times.