### PR TITLE
App control api through MQTT

### DIFF
--- a/documentation/src/SUMMARY.md
+++ b/documentation/src/SUMMARY.md
@@ -38,3 +38,6 @@
 
 # Misc
 - [Command Line Arguments](./cli.md)
+- [UX flow](./ux_flow.md)
+- [Home Assistant integration](./home_assistant.md)
+- [Control API](./control_API.md)

--- a/documentation/src/control_API.md
+++ b/documentation/src/control_API.md
@@ -1,0 +1,138 @@
+# Control API
+
+MomentoBooth provides a powerful **Control API** designed for hands-free operation and external automation. By exposing "actions" corresponding to UI elements (buttons, sliders, etc.) within the current "scope" shown in the app, the app can be controlled via external protocols.
+
+A "scope" represents a navigation view shown on screen. This can be a page or a pop-up dialog.
+
+The current implementation utilizes **MQTT** as the transport layer, allowing for deep integration with [smart home systems like Home Assistant](./home_assistant.md) or custom control modules, [such as voice control](#experimental-voice-control).
+
+## MQTT Interface
+
+All communication occurs relative to a `$base_topic` configured in the app settings.
+
+### Topics and Endpoints
+
+| Topic | Data Type | Description |
+| --- | --- | --- |
+| `actions/list` | `JSON Array` | Current available actions for the visible page/dialog. |
+| `actions/execute` | `JSON Object` | Publish here to trigger an action. Requires `tool` and `arguments`. |
+| `actions/execute/result` | `JSON Object` | Response from the last executed action. |
+| `actions/scopes` | `JSON Array` | The current navigation stack (e.g., `["Gallery", "Print Dialog"]`). |
+| `actions/listening` | `Boolean` | `true` if the app is currently accepting external commands. |
+| `actions/call_history` | `JSON Map` | Recently executed actions within the retention window. |
+| `notify` | `String` | Publish text here to display a toast notification on screen. |
+
+### Home Assistant Integration
+
+Home Assistant entities will be published to use the control API if the [Home Assistant integration](./home_assistant.md) is enabled. The following entities are registered:
+
+* **[MQTT Select Entity](https://www.home-assistant.io/integrations/select.mqtt/)**: Actions appear as a selectable list that updates live based on the app state.
+  > [!NOTE]
+  > Using the `select` action will only be successfull for actions that do not require arguments.
+* **[MQTT Notify Entity](https://www.home-assistant.io/integrations/notify.mqtt/)**: Allows automations to send toast messages directly to the booth display.
+
+## Logic and Interaction
+
+The idea is that an external application can trigger the actions that are available to the user at a specific moment. To provide some feedback to the user as to what is happening and why, toast notifications can be shown with a text provided by the external application.
+
+### The "Listening" State
+
+To prevent interference between physical users and remote controls, the `listening` flag automatically toggles to `false` when:
+
+* The current scope has no defined actions (e.g., Settings or Capture screens).
+* **Local Interaction**: A user touches or clicks the screen. Remote control is disabled for a configurable duration after the last touch.
+
+> [!NOTE]
+> Toast notifications via the `notify` topic are only displayed when `listening` is `true`. This prevents unwanted distractions when capturing photos or changing settings.
+
+## Data Models
+
+The data models used by the Control API can be found in the [models folder](https://github.com/momentobooth/momentobooth/tree/main/lib/models), but can also easily be understood by inspecting the MQTT output. The core model is `AppAction`, which extends the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/specification/2025-11-25/server/tools#tool) tool definition.
+
+### JSON Examples
+
+**An action definition (item in `actions/list`)**
+
+```json
+{
+    "name": "set_copies",
+    "title": "Set Copies",
+    "description": "Sets the number of copies to print.",
+    "examples": [
+        {
+            "phrase": "set copies to {copies:1}",
+            "arguments": {
+                "copies": 1
+            }
+        },
+        {
+            "phrase": "make {copies:three} copies",
+            "arguments": {
+                "copies": 3
+            }
+        },
+        {
+            "phrase": "change copies to {copies:four}",
+            "arguments": {
+                "copies": 4
+            }
+        },
+        {
+            "phrase": "set number of copies to {copies:2}",
+            "arguments": {
+                "copies": 2
+            }
+        }
+    ],
+    "inputSchema": {
+        "type": "object",
+        "properties": {
+            "copies": {
+                "type": "integer",
+                "description": "The number of copies to print",
+                "minimum": 1,
+                "maximum": 5
+            }
+        },
+        "required": [
+            "copies"
+        ],
+        "additionalProperties": false
+    },
+    "inputSchemaExample": "{ \"copies\": integer between 1 and 5 }"
+}
+```
+
+**Executing an action (`actions/execute`):**
+
+```json
+{
+  "tool": "set_copies",
+  "arguments": {
+    "copies": 3
+  }
+}
+
+```
+
+**Execution Result (`actions/execute/result`):**
+
+```json
+{
+  "success": true,
+  "message": "Copies set to 3"
+}
+
+```
+
+## Configuration
+
+The following settings are available in the MomentoBooth configuration:
+
+1. **Enable Control API**: Toggle the MQTT control functionality.
+2. **Control Disable Duration**: Seconds to ignore remote commands after a screen touch.
+3. **History Retention**: How long (in seconds) to keep executed actions in the `call_history` topic.
+
+## Experimental: Voice Control
+
+For an implementation example using the Control API for voice-activated photo booths, visit the [MomentoVoiceControl](https://github.com/momentobooth/MomentoVoiceControl) repository.

--- a/documentation/src/home_assistant.md
+++ b/documentation/src/home_assistant.md
@@ -1,0 +1,12 @@
+# Home Assistant integration
+
+When enabled, MomentoBoth can integrate with Home Assistant and install a device that exposes information that can be used in Home Assistant for tracking or automations. The integration provides the following:
+
+- Some general info like the software version (part of the "device")
+- Several sensors that mirror the software's statistics (number of captures, prints, etc.)
+- An automation trigger based on the capture state (`idle`, `countdown`, `capturing`)
+  - This is useful to sync lights with.
+
+This integration uses [Home Assistant's MQTT integration](https://www.home-assistant.io/integrations/mqtt/) and the device will automatically show up if MomentoBooth is connected to your Home Assistant's MQTT server and the integration is enabled.
+
+Additional control features can be used from Home Assistant when the [Control API](./control_API.md) is enabled.

--- a/documentation/src/ux_flow.md
+++ b/documentation/src/ux_flow.md
@@ -1,0 +1,83 @@
+# Screen Overview & Use
+
+This page outlines the navigational structure of MomentoBooth. First, the general navigational flow is specified. Then, each screen is listed with what it is for, and which interactions it offers.
+
+## High-Level User Flow
+
+1. **[Start Screen](#start-screen)** → **[Navigation Screen](#navigation-screen)**
+2. **[Navigation Screen](#navigation-screen)** → **[Capture Flow](#capture-flow-autonomous)** / **[Gallery](#gallery-screen)** / **Language Selection**
+3. **[Capture Flow](#capture-flow-autonomous)** → **[Create Collage](#create-collage-screen)** (if applicable) → **[Share Screen](#share-screen--photo-details-screen)**
+4. **[Share Screen](#share-screen--photo-details-screen)** → **[Start Screen](#start-screen)**
+
+## Screen Definitions
+
+### Start Screen
+
+The initial "attract" mode of the application.
+
+* **Visuals**: Displays a "Touch to Start" prompt.
+* **Interactions**:
+  * **Touch anywhere**: Transitions the user to the **Navigation Screen**.
+
+### Navigation Screen
+
+The central hub for all user activities.
+
+* **Interactions**:
+  * **Single Picture Button**: Initiates the autonomous capture flow for one photo.
+  * **Collage Button**: Initiates the autonomous multi-capture flow for a collage.
+  * **Gallery Button**: Navigates to the **Gallery Screen**.
+  * **Change Language Button**: Opens the **Language Selection Dialog**.
+
+### Capture Flow (Autonomous)
+
+A transitional state where the app takes control.
+
+* **Visuals**: Displays a countdown and live preview.
+* **Behavior**: Once triggered, this process is fully autonomous. Users cannot interfere until the photo(s) are captured.
+* **Transitions**:
+  * Leads to the **Share Screen** after a single capture.
+  * Leads to the **Create Collage Screen** after multiple captures.
+
+### Create Collage Screen
+
+The workspace for assembling a custom collage.
+
+* **Visuals**: Displays an overview of all recently captured images.
+* **Interactions**:
+  * **Image Selection**: Toggle which photos to include in the final output.
+  * **Continue Button**: Finalizes the selection and moves to the **Share Screen**.
+  * **Retake Button**: Opens the **Retake Dialog**.
+
+### Share Screen / Photo Details Screen
+
+These screens provide the same final output actions for respectively new captures or gallery items.
+
+* **Interactions**:
+  * **Get QR Code**: Opens a **QR Dialog** containing a download link.
+  * **Print**: Opens a **Print Dialog** to send the image to the configured printer.
+  * **Back/Finish**:
+    * From **Share Screen**: Returns the user to the **Start Screen**.
+    * From **Photo Details**: Returns the user to the **Gallery Screen**.
+
+
+### Gallery Screen
+
+An archive of previous creations.
+
+* **Visuals**: A grid overview of all saved collage outputs.
+* **Interactions**:
+  * **Select Image**: Opens the **Photo Details Screen** for the selected item.
+  * **Back Button**: Returns the user to the **Navigation Screen**.
+
+## Interactive Dialogs
+
+These overlay components appear across various screens and close automatically upon action. Some can be dismissed by clicking/touching outside of them.
+Here is a non-exhaustive overview.
+
+| Dialog | Triggered From | Action |
+| --- | --- | --- |
+| **Language Selection** | Navigation Screen | Updates the app locale and closes. |
+| **QR Dialog** | Share / Photo Details | Displays QR code; closes on dismissal. |
+| **Print Dialog** | Share / Photo Details | Confirms print job and closes. |
+| **Retake Dialog** | Share Screen | Asks whether the previous output file needs to be kept or deleted. |

--- a/lib/managers/_all.dart
+++ b/lib/managers/_all.dart
@@ -1,3 +1,4 @@
+export 'action_manager.dart';
 export 'app_init_manager.dart';
 export 'external_system_status_manager.dart';
 export 'live_view_manager.dart';

--- a/lib/managers/action_manager.dart
+++ b/lib/managers/action_manager.dart
@@ -1,5 +1,7 @@
 // import 'dart:async';
 
+import 'dart:async';
+
 import 'package:collection/collection.dart';
 import 'package:mobx/mobx.dart';
 import 'package:momento_booth/main.dart';
@@ -21,12 +23,20 @@ abstract class ActionManagerBase extends Subsystem with Store, Logger {
 
   @readonly
   ObservableList<_Entry> _stack = ObservableList();
-  ObservableMap<DateTime, AppActionCall> actionHistory = ObservableMap();
+  @readonly
+  ObservableMap<DateTime, AppActionCall> _actionHistory = ObservableMap();
+  @readonly
+  bool _blockWithPhysicalInteraction = false;
+  
+  /// Whether the system should currently be listening for actions based on whether there are any actions available and whether there has been recent physical interaction.
+  bool get listeningForActions => allowControl && !_blockWithPhysicalInteraction && current.isNotEmpty;
 
   List<AppAction> get current => _stack.isEmpty ? const [] : _stack.last.actions;
   List<String> get currentScopes => _stack.isEmpty ? const [] : _stack.map((e) => e.scopeName).toList();
 
   bool get allowControl => getIt<SettingsManager>().settings.control.enable;
+
+  Timer? _actionListeningTimer;
 
   // ////////////// //
   // Initialization //
@@ -41,16 +51,27 @@ abstract class ActionManagerBase extends Subsystem with Store, Logger {
   // Methods //
   // /////// //
 
+  /// Registers that a physical action has been performed, which will disable listening for new actions for a short period of time
+  /// to prevent the software from doing things the user doesn't want it to do while they are interacting with the photobooth.
+  /// This should be called whenever the user performs a physical action, such as tapping the screen or pressing a key.
+  void registerPhysicalAction() {
+    _blockWithPhysicalInteraction = true;
+    _actionListeningTimer?.cancel();
+    _actionListeningTimer = Timer(Duration(milliseconds: getIt<SettingsManager>().settings.control.controlDisableDurationMsAfterTouch), () {
+      _blockWithPhysicalInteraction = false;
+    });
+  }
+
   void registerActionCall(AppActionCall call, {bool overwriteSameName = false}) {
-    final lastEntry = actionHistory.entries.last;
-    if (lastEntry.value.tool == call.tool && overwriteSameName) {
+    final lastEntry = _actionHistory.entries.lastOrNull;
+    if (lastEntry != null && lastEntry.value.tool == call.tool && overwriteSameName) {
       logInfo("Overwriting previous action call for tool ${call.tool} with arguments ${lastEntry.value.arguments} by ${call.arguments}");
-      actionHistory.remove(lastEntry.key);
+      _actionHistory.remove(lastEntry.key);
     }
-    actionHistory[DateTime.now()] = call;
+    _actionHistory[DateTime.now()] = call;
     final retentionLength = getIt<SettingsManager>().settings.control.controlHistoryDurationSeconds;
-    actionHistory.removeWhere((key, value) => key.isBefore(DateTime.now().subtract(Duration(seconds: retentionLength))));
-    logInfo("Registered action call for tool ${call.tool} with arguments ${call.arguments}. Action history now contains ${actionHistory.length} entries.");
+    _actionHistory.removeWhere((key, value) => key.isBefore(DateTime.now().subtract(Duration(seconds: retentionLength))));
+    logInfo("Registered action call for tool ${call.tool} with arguments ${call.arguments}. Action history now contains ${_actionHistory.length} entries.");
   }
 
   void pushActions(List<AppAction> actions, String scopeName, Object token) {
@@ -75,6 +96,10 @@ abstract class ActionManagerBase extends Subsystem with Store, Logger {
   void callAction(String actionName, {Map<String, dynamic> parameters = const {}}) {
     if (!allowControl) {
       logWarning("Received request to call action $actionName, but control is disabled in settings");
+      return;
+    }
+    if (!listeningForActions) {
+      logWarning("Received request to call action $actionName, but currently not listening for actions due to recent physical interaction");
       return;
     }
     AppAction? action = current.firstWhereOrNull((a) => a.name == actionName);

--- a/lib/managers/action_manager.dart
+++ b/lib/managers/action_manager.dart
@@ -1,5 +1,6 @@
 // import 'dart:async';
 
+import 'package:collection/collection.dart';
 import 'package:mobx/mobx.dart';
 import 'package:momento_booth/main.dart';
 import 'package:momento_booth/managers/mqtt_manager.dart';
@@ -54,6 +55,16 @@ abstract class ActionManagerBase extends Subsystem with Store, Logger {
   void publish() {
     // Todo: Publish current action stack to MQTT
     logInfo("Stack of length ${_stack.length} contains ${current.length} actions: ${current.map((a) => a.name).join(", ")}");
+  }
+
+  void callAction(String actionName, {Map<String, dynamic> parameters = const {}}) {
+    AppAction? action = current.firstWhereOrNull((a) => a.name == actionName);
+    if (action != null) {
+      logInfo("Calling action $actionName ${parameters.isNotEmpty ? "with parameters $parameters" : "without parameters"}");
+      action.callback(parameters);
+    } else {
+      logWarning("Tried to call action $actionName, but it was not found in the current action stack");
+    }
   }
 
 }

--- a/lib/managers/action_manager.dart
+++ b/lib/managers/action_manager.dart
@@ -6,7 +6,6 @@ import 'package:momento_booth/main.dart';
 import 'package:momento_booth/managers/_all.dart';
 import 'package:momento_booth/models/app_action.dart';
 import 'package:momento_booth/models/app_action_call.dart';
-import 'package:momento_booth/models/settings.dart';
 import 'package:momento_booth/models/subsystem.dart';
 import 'package:momento_booth/utils/logger.dart';
 // import 'package:action_manager/action_manager.dart';
@@ -22,6 +21,7 @@ abstract class ActionManagerBase extends Subsystem with Store, Logger {
 
   @readonly
   ObservableList<_Entry> _stack = ObservableList();
+  ObservableMap<DateTime, AppActionCall> actionHistory = ObservableMap();
 
   List<AppAction> get current => _stack.isEmpty ? const [] : _stack.last.actions;
   List<String> get currentScopes => _stack.isEmpty ? const [] : _stack.map((e) => e.scopeName).toList();
@@ -40,6 +40,18 @@ abstract class ActionManagerBase extends Subsystem with Store, Logger {
   // /////// //
   // Methods //
   // /////// //
+
+  void registerActionCall(AppActionCall call, {bool overwriteSameName = false}) {
+    final lastEntry = actionHistory.entries.last;
+    if (lastEntry.value.tool == call.tool && overwriteSameName) {
+      logInfo("Overwriting previous action call for tool ${call.tool} with arguments ${lastEntry.value.arguments} by ${call.arguments}");
+      actionHistory.remove(lastEntry.key);
+    }
+    actionHistory[DateTime.now()] = call;
+    final retentionLength = getIt<SettingsManager>().settings.control.controlHistoryDurationSeconds;
+    actionHistory.removeWhere((key, value) => key.isBefore(DateTime.now().subtract(Duration(seconds: retentionLength))));
+    logInfo("Registered action call for tool ${call.tool} with arguments ${call.arguments}. Action history now contains ${actionHistory.length} entries.");
+  }
 
   void pushActions(List<AppAction> actions, String scopeName, Object token) {
     _stack.add(_Entry(token, scopeName, actions));

--- a/lib/managers/action_manager.dart
+++ b/lib/managers/action_manager.dart
@@ -3,8 +3,10 @@
 import 'package:collection/collection.dart';
 import 'package:mobx/mobx.dart';
 import 'package:momento_booth/main.dart';
-import 'package:momento_booth/managers/mqtt_manager.dart';
+import 'package:momento_booth/managers/_all.dart';
 import 'package:momento_booth/models/app_action.dart';
+import 'package:momento_booth/models/app_action_call.dart';
+import 'package:momento_booth/models/settings.dart';
 import 'package:momento_booth/models/subsystem.dart';
 import 'package:momento_booth/utils/logger.dart';
 // import 'package:action_manager/action_manager.dart';
@@ -22,8 +24,9 @@ abstract class ActionManagerBase extends Subsystem with Store, Logger {
   ObservableList<_Entry> _stack = ObservableList();
 
   List<AppAction> get current => _stack.isEmpty ? const [] : _stack.last.actions;
+  List<String> get currentScopes => _stack.isEmpty ? const [] : _stack.map((e) => e.scopeName).toList();
 
-  MqttManager get mqtt => getIt<MqttManager>();
+  bool get allowControl => getIt<SettingsManager>().settings.control.enable;
 
   // ////////////// //
   // Initialization //
@@ -38,8 +41,8 @@ abstract class ActionManagerBase extends Subsystem with Store, Logger {
   // Methods //
   // /////// //
 
-  void push(List<AppAction> actions, Object token) {
-    _stack.add(_Entry(token, actions));
+  void pushActions(List<AppAction> actions, String scopeName, Object token) {
+    _stack.add(_Entry(token, scopeName, actions));
     publish();
   }
 
@@ -58,6 +61,10 @@ abstract class ActionManagerBase extends Subsystem with Store, Logger {
   }
 
   void callAction(String actionName, {Map<String, dynamic> parameters = const {}}) {
+    if (!allowControl) {
+      logWarning("Received request to call action $actionName, but control is disabled in settings");
+      return;
+    }
     AppAction? action = current.firstWhereOrNull((a) => a.name == actionName);
     if (action != null) {
       logInfo("Calling action $actionName ${parameters.isNotEmpty ? "with parameters $parameters" : "without parameters"}");
@@ -71,7 +78,8 @@ abstract class ActionManagerBase extends Subsystem with Store, Logger {
 
 class _Entry {
   final Object token;
+  final String scopeName;
   final List<AppAction> actions;
 
-  _Entry(this.token, this.actions);
+  _Entry(this.token, this.scopeName, this.actions);
 }

--- a/lib/managers/action_manager.dart
+++ b/lib/managers/action_manager.dart
@@ -1,4 +1,4 @@
-import 'dart:async';
+// import 'dart:async';
 
 import 'package:mobx/mobx.dart';
 import 'package:momento_booth/main.dart';

--- a/lib/managers/action_manager.dart
+++ b/lib/managers/action_manager.dart
@@ -1,0 +1,66 @@
+import 'dart:async';
+
+import 'package:mobx/mobx.dart';
+import 'package:momento_booth/main.dart';
+import 'package:momento_booth/managers/mqtt_manager.dart';
+import 'package:momento_booth/models/app_action.dart';
+import 'package:momento_booth/models/subsystem.dart';
+import 'package:momento_booth/utils/logger.dart';
+// import 'package:action_manager/action_manager.dart';
+
+part 'action_manager.g.dart';
+
+class ActionManager = ActionManagerBase with _$ActionManager;
+
+abstract class ActionManagerBase extends Subsystem with Store, Logger {
+
+  @override
+  String subsystemName = "Action manager";
+
+  @readonly
+  ObservableList<_Entry> _stack = ObservableList();
+
+  List<AppAction> get current => _stack.isEmpty ? const [] : _stack.last.actions;
+
+  MqttManager get mqtt => getIt<MqttManager>();
+
+  // ////////////// //
+  // Initialization //
+  // ////////////// //
+
+  @override
+  void initialize() {
+    publish();
+  }
+
+  // /////// //
+  // Methods //
+  // /////// //
+
+  void push(List<AppAction> actions, Object token) {
+    _stack.add(_Entry(token, actions));
+    publish();
+  }
+
+  void pop(Object token) {
+    if (_stack.isNotEmpty) {
+      _stack.removeWhere((entry) => entry.token == token);
+      publish();
+    } else {
+      logWarning("Tried to pop from an empty action stack");
+    }
+  }
+
+  void publish() {
+    // Todo: Publish current action stack to MQTT
+    logInfo("Stack of length ${_stack.length} contains ${current.length} actions: ${current.map((a) => a.name).join(", ")}");
+  }
+
+}
+
+class _Entry {
+  final Object token;
+  final List<AppAction> actions;
+
+  _Entry(this.token, this.actions);
+}

--- a/lib/managers/action_manager.dart
+++ b/lib/managers/action_manager.dart
@@ -8,6 +8,7 @@ import 'package:momento_booth/main.dart';
 import 'package:momento_booth/managers/_all.dart';
 import 'package:momento_booth/models/app_action.dart';
 import 'package:momento_booth/models/app_action_call.dart';
+import 'package:momento_booth/models/app_action_response.dart';
 import 'package:momento_booth/models/subsystem.dart';
 import 'package:momento_booth/utils/logger.dart';
 // import 'package:action_manager/action_manager.dart';
@@ -27,6 +28,8 @@ abstract class ActionManagerBase extends Subsystem with Store, Logger {
   ObservableMap<DateTime, AppActionCall> _actionHistory = ObservableMap();
   @readonly
   bool _blockWithPhysicalInteraction = false;
+  @readonly
+  AppActionResponse? _lastResponse;
   
   /// Whether the system should currently be listening for actions based on whether there are any actions available and whether there has been recent physical interaction.
   bool get listeningForActions => allowControl && !_blockWithPhysicalInteraction && current.isNotEmpty;
@@ -89,8 +92,14 @@ abstract class ActionManagerBase extends Subsystem with Store, Logger {
   }
 
   void publish() {
-    // Todo: Publish current action stack to MQTT
+    // Publishing handled automatically by the MQTT manager.
     logInfo("Stack of length ${_stack.length} contains ${current.length} actions: ${current.map((a) => a.name).join(", ")}");
+  }
+
+  void setResponseForAction(bool success, String message) {
+    // Publishing handled automatically by the MQTT manager.
+    _lastResponse = AppActionResponse(success: success, message: message);
+    logInfo("Setting response for most recent action call to $_lastResponse");
   }
 
   void callAction(String actionName, {Map<String, dynamic> parameters = const {}}) {
@@ -105,7 +114,7 @@ abstract class ActionManagerBase extends Subsystem with Store, Logger {
     AppAction? action = current.firstWhereOrNull((a) => a.name == actionName);
     if (action != null) {
       logInfo("Calling action $actionName ${parameters.isNotEmpty ? "with parameters $parameters" : "without parameters"}");
-      action.callback(parameters);
+      action.callback(parameters, setResponseForAction);
     } else {
       logWarning("Tried to call action $actionName, but it was not found in the current action stack");
     }

--- a/lib/managers/action_manager.dart
+++ b/lib/managers/action_manager.dart
@@ -78,7 +78,9 @@ abstract class ActionManagerBase extends Subsystem with Store, Logger {
   }
 
   void pushActions(List<AppAction> actions, String scopeName, Object token) {
-    _stack.add(_Entry(token, scopeName, actions));
+    _stack
+      ..removeWhere((entry) => entry.token == token)
+      ..add(_Entry(token, scopeName, actions));
     publish();
   }
 

--- a/lib/managers/app_init_manager.dart
+++ b/lib/managers/app_init_manager.dart
@@ -62,6 +62,7 @@ abstract class AppInitManagerBase with Store {
         ..registerManager(WindowManager())
         ..registerManager(LiveViewManager())
         ..registerManager(MqttManager())
+        ..registerManager(ActionManager())
         ..registerManager(NotificationsManager())
         ..registerManager(PrintingManager())
         ..registerManager(PhotosManager())
@@ -109,6 +110,7 @@ abstract class AppInitManagerBase with Store {
       await _setStatusAndFireAndForget('Initializing window manager', getIt<WindowManager>().initializeSafe);
       await _setStatusAndFireAndForget('Initializing live view manager', getIt<LiveViewManager>().initializeSafe);
       await _setStatusAndFireAndForget('Initializing MQTT manager', getIt<MqttManager>().initializeSafe);
+      await _setStatusAndFireAndForget('Initializing action manager', getIt<ActionManager>().initializeSafe);
       await _setStatusAndFireAndForget('Initializing SFX manager', getIt<SfxManager>().initializeSafe);
       await _setStatusAndFireAndForget('Initializing printing manager', getIt<PrintingManager>().initializeSafe);
       await _setStatusAndFireAndForget('Initializing wakelock manager', getIt<WakelockManager>().initializeSafe);

--- a/lib/managers/mqtt_manager.dart
+++ b/lib/managers/mqtt_manager.dart
@@ -11,6 +11,7 @@ import 'package:momento_booth/managers/action_manager.dart';
 import 'package:momento_booth/managers/settings_manager.dart';
 import 'package:momento_booth/managers/stats_manager.dart';
 import 'package:momento_booth/models/app_action.dart';
+import 'package:momento_booth/models/app_action_call.dart';
 import 'package:momento_booth/models/capture_state.dart';
 import 'package:momento_booth/models/connection_state.dart';
 import 'package:momento_booth/models/home_assistant/home_assistant_discovery_payload.dart';
@@ -208,6 +209,7 @@ abstract class MqttManagerBase extends Subsystem with Store, Logger {
     _publish(
       "current_actions",
       jsonEncode(actions.map((a) => a.toJson()).toList()),
+      retain: true,
     );
     publishHomeAssistantSelectDiscoveryTopic(integrationName: "actions", options: actions.map((a) => a.name).toList(), stateTopic: "None", commandTopic: "$rootTopic/do_action");
   }
@@ -276,7 +278,16 @@ abstract class MqttManagerBase extends Subsystem with Store, Logger {
 
   void _onHomeAssistantActionMessage(String message) {
     logInfo("Received action command from Home Assistant by MQTT: $message");
-    getIt<ActionManager>().callAction(message);
+    try {
+      final dynamic decoded = jsonDecode(message);
+
+      if (decoded is Map<String, dynamic>) {
+        final call = AppActionCall.fromJson(decoded);
+        getIt<ActionManager>().callAction(call.tool, parameters: call.arguments);
+      }
+    } catch (e) {
+      getIt<ActionManager>().callAction(message);
+    }
   }
 
   // ////////////////////////// //

--- a/lib/managers/mqtt_manager.dart
+++ b/lib/managers/mqtt_manager.dart
@@ -8,6 +8,7 @@ import 'package:mobx/mobx.dart';
 import 'package:momento_booth/exceptions/mqtt_exception.dart';
 import 'package:momento_booth/main.dart';
 import 'package:momento_booth/managers/action_manager.dart';
+import 'package:momento_booth/managers/notifications_manager.dart';
 import 'package:momento_booth/managers/settings_manager.dart';
 import 'package:momento_booth/managers/stats_manager.dart';
 import 'package:momento_booth/models/_all.dart';
@@ -340,6 +341,7 @@ abstract class MqttManagerBase extends Subsystem with Store, Logger {
       notification = NotificationRequest(message: message);
     }
     logInfo("Received notification request: $notification");
+    getIt<NotificationsManager>().addNotificationRequest(notification);
   }
 
   // ////////////////////////// //

--- a/lib/managers/mqtt_manager.dart
+++ b/lib/managers/mqtt_manager.dart
@@ -7,8 +7,10 @@ import 'package:intl/intl.dart';
 import 'package:mobx/mobx.dart';
 import 'package:momento_booth/exceptions/mqtt_exception.dart';
 import 'package:momento_booth/main.dart';
+import 'package:momento_booth/managers/action_manager.dart';
 import 'package:momento_booth/managers/settings_manager.dart';
 import 'package:momento_booth/managers/stats_manager.dart';
+import 'package:momento_booth/models/app_action.dart';
 import 'package:momento_booth/models/capture_state.dart';
 import 'package:momento_booth/models/connection_state.dart';
 import 'package:momento_booth/models/home_assistant/home_assistant_discovery_payload.dart';
@@ -63,6 +65,12 @@ abstract class MqttManagerBase extends Subsystem with Store, Logger {
     autorun((_) {
       Stats stats = getIt<StatsManager>().stats;
       if (_client != null) _publishStats(stats);
+    });
+
+    // Publish actions
+    autorun((_) {
+        List<AppAction> actions = getIt<ActionManager>().current;
+      if (_client != null) _publishActions(actions);
     });
   }
 
@@ -153,6 +161,7 @@ abstract class MqttManagerBase extends Subsystem with Store, Logger {
 
   void _forcePublishAll() {
     _publishStats(getIt<StatsManager>().stats, true);
+    _publishActions(getIt<ActionManager>().current);
     publishScreen();
     publishCaptureState();
     publishSettings();
@@ -192,6 +201,13 @@ abstract class MqttManagerBase extends Subsystem with Store, Logger {
   void _publishAppVersion() {
     _publish("app_version", packageInfo.version);
     _publish("app_build", packageInfo.buildNumber);
+  }
+
+  void _publishActions(List<AppAction> actions) {
+    _publish(
+      "current_actions",
+      jsonEncode(actions.map((a) => a.toJson()).toList()),
+    );
   }
 
   void _clearTopic(String topic) {

--- a/lib/managers/mqtt_manager.dart
+++ b/lib/managers/mqtt_manager.dart
@@ -10,6 +10,7 @@ import 'package:momento_booth/main.dart';
 import 'package:momento_booth/managers/action_manager.dart';
 import 'package:momento_booth/managers/settings_manager.dart';
 import 'package:momento_booth/managers/stats_manager.dart';
+import 'package:momento_booth/models/_all.dart';
 import 'package:momento_booth/models/app_action.dart';
 import 'package:momento_booth/models/app_action_call.dart';
 import 'package:momento_booth/models/capture_state.dart';
@@ -274,6 +275,10 @@ abstract class MqttManagerBase extends Subsystem with Store, Logger {
             if (payload.length == 0) return;
             _clearTopic("actions/execute");
             _onHomeAssistantActionMessage(const Utf8Decoder().convert(payload.message!));
+          case MqttPublishMessage(:final variableHeader, :final payload) when variableHeader!.topicName == "$rootTopic/notify":
+            if (payload.length == 0) return;
+            _clearTopic("notify");
+            _onNotifyMessage(const Utf8Decoder().convert(payload.message!));
           default:
             logWarning("Received unknown published MQTT message: $message");
         }
@@ -283,6 +288,7 @@ abstract class MqttManagerBase extends Subsystem with Store, Logger {
     });
 
     _subscribeToTopic('update_settings');
+    _subscribeToTopic('notify');
     if (allowControl) {
       _subscribeToTopic('actions/execute');
     }
@@ -319,6 +325,21 @@ abstract class MqttManagerBase extends Subsystem with Store, Logger {
     } catch (e) {
       getIt<ActionManager>().callAction(message);
     }
+  }
+
+  void _onNotifyMessage(String message) {
+    logInfo("Received notify message from MQTT: $message");
+    late final NotificationRequest notification;
+    try {
+      final dynamic decoded = jsonDecode(message);
+
+      if (decoded is Map<String, dynamic>) {
+        notification = NotificationRequest.fromJson(decoded);
+      }
+    } catch (e) {
+      notification = NotificationRequest(message: message);
+    }
+    logInfo("Received notification request: $notification");
   }
 
   // ////////////////////////// //
@@ -374,6 +395,10 @@ abstract class MqttManagerBase extends Subsystem with Store, Logger {
       payload: CaptureState.capturing.mqttValue,
       stateTopic: "$rootTopic/capture_state",
     );
+    publishHomeAssistantNotifyDiscoveryTopic(
+      integrationName: "Show notification",
+      commandTopic: "$rootTopic/notify",
+    );
   }
 
   void publishHomeAssistantSensorDiscoveryTopic({required String integrationName, required String stateTopic}) {
@@ -425,6 +450,24 @@ abstract class MqttManagerBase extends Subsystem with Store, Logger {
               name: integrationName,
               options: options,
               stateTopic: stateTopic,
+              commandTopic: commandTopic,
+              device: homeAssistantDevice,
+              uniqueId: '${Casing.snakeCase(integrationName)}_$componentId',
+            ).toJson())))
+          .payload!,
+      retain: true,
+    );
+  }
+
+  void publishHomeAssistantNotifyDiscoveryTopic({required String integrationName, required String commandTopic}) {
+    if (!canDoHomeAssistantDiscovery) return;
+
+    _client!.publishMessage(
+      '$discoveryTopicPrefix/notify/$componentId/${Casing.snakeCase(integrationName)}/config',
+      MqttQos.atLeastOnce,
+      (MqttPayloadBuilder()
+            ..addString(jsonEncode(HomeAssistantDiscoveryPayload.notify(
+              name: integrationName,
               commandTopic: commandTopic,
               device: homeAssistantDevice,
               uniqueId: '${Casing.snakeCase(integrationName)}_$componentId',

--- a/lib/managers/mqtt_manager.dart
+++ b/lib/managers/mqtt_manager.dart
@@ -44,6 +44,7 @@ abstract class MqttManagerBase extends Subsystem with Store, Logger {
   String _lastPublishedRoute = "";
   CaptureState _lastPublishedCaptureState = CaptureState.idle;
   Settings get _settings => getIt<SettingsManager>().settings;
+  bool get allowControl => _settings.control.enable;
 
   String get rootTopic => getIt<SettingsManager>().settings.mqttIntegration.rootTopic;
 
@@ -72,8 +73,9 @@ abstract class MqttManagerBase extends Subsystem with Store, Logger {
 
     // Publish actions
     autorun((_) {
-        List<AppAction> actions = getIt<ActionManager>().current;
-      if (_client != null) _publishActions(actions);
+      List<AppAction> actions = getIt<ActionManager>().current;
+      List<String> scopes = getIt<ActionManager>().currentScopes;
+      if (_client != null) _publishActions(actions, scopes);
     });
   }
 
@@ -163,7 +165,7 @@ abstract class MqttManagerBase extends Subsystem with Store, Logger {
 
   void _forcePublishAll() {
     _publishStats(getIt<StatsManager>().stats, true);
-    _publishActions(getIt<ActionManager>().current);
+    _publishActions(getIt<ActionManager>().current, getIt<ActionManager>().currentScopes);
     publishScreen();
     publishCaptureState();
     publishSettings();
@@ -205,13 +207,28 @@ abstract class MqttManagerBase extends Subsystem with Store, Logger {
     _publish("app_build", packageInfo.buildNumber);
   }
 
-  void _publishActions(List<AppAction> actions) {
+  void _publishActions(List<AppAction> actions, List<String> scopes) {
+    if (!allowControl) return;
     _publish(
-      "current_actions",
+      "actions/list",
       jsonEncode(actions.map((a) => a.toJson()).toList()),
       retain: true,
     );
-    publishHomeAssistantSelectDiscoveryTopic(integrationName: "actions", options: actions.map((a) => a.name).toList(), stateTopic: "None", commandTopic: "$rootTopic/do_action");
+    publishHomeAssistantSelectDiscoveryTopic(integrationName: "actions", options: actions.map((a) => a.name).toList(), stateTopic: "None", commandTopic: "$rootTopic/actions/execute");
+    _publish(
+      "actions/scopes",
+      jsonEncode(scopes),
+      retain: true,
+    );
+  }
+
+  void _publishActionCallHistory(List<AppActionCall> actionCalls) {
+    if (!allowControl) return;
+    _publish(
+      "actions/call_history",
+      jsonEncode(actionCalls.map((a) => a.toJson()).toList()),
+      retain: true,
+    );
   }
 
   void _clearTopic(String topic) {
@@ -241,9 +258,9 @@ abstract class MqttManagerBase extends Subsystem with Store, Logger {
             if (payload.length == 0) return;
             _clearTopic("update_settings");
             _onSettingsMessage(const Utf8Decoder().convert(payload.message!));
-          case MqttPublishMessage(:final variableHeader, :final payload) when variableHeader!.topicName == "$rootTopic/do_action":
+          case MqttPublishMessage(:final variableHeader, :final payload) when variableHeader!.topicName == "$rootTopic/actions/execute":
             if (payload.length == 0) return;
-            _clearTopic("do_action");
+            _clearTopic("actions/execute");
             _onHomeAssistantActionMessage(const Utf8Decoder().convert(payload.message!));
           default:
             logWarning("Received unknown published MQTT message: $message");
@@ -254,7 +271,9 @@ abstract class MqttManagerBase extends Subsystem with Store, Logger {
     });
 
     _subscribeToTopic('update_settings');
-    _subscribeToTopic('do_action');
+    if (allowControl) {
+      _subscribeToTopic('actions/execute');
+    }
   }
 
   void _subscribeToTopic(String relativeTopic) {

--- a/lib/managers/mqtt_manager.dart
+++ b/lib/managers/mqtt_manager.dart
@@ -44,6 +44,8 @@ abstract class MqttManagerBase extends Subsystem with Store, Logger {
   CaptureState _lastPublishedCaptureState = CaptureState.idle;
   Settings get _settings => getIt<SettingsManager>().settings;
 
+  String get rootTopic => getIt<SettingsManager>().settings.mqttIntegration.rootTopic;
+
   @readonly
   ConnectionState _connectionState = ConnectionState.disconnected;
 
@@ -150,7 +152,6 @@ abstract class MqttManagerBase extends Subsystem with Store, Logger {
   void _publish(String topic, String message, {bool retain = false}) {
     if (_client == null) return;
 
-    String rootTopic = getIt<SettingsManager>().settings.mqttIntegration.rootTopic;
     _client!.publishMessage(
       '$rootTopic/$topic',
       MqttQos.atMostOnce,
@@ -208,12 +209,12 @@ abstract class MqttManagerBase extends Subsystem with Store, Logger {
       "current_actions",
       jsonEncode(actions.map((a) => a.toJson()).toList()),
     );
+    publishHomeAssistantSelectDiscoveryTopic(integrationName: "actions", options: actions.map((a) => a.name).toList(), stateTopic: "None", commandTopic: "$rootTopic/do_action");
   }
 
   void _clearTopic(String topic) {
     if (_client == null) return;
 
-    String rootTopic = getIt<SettingsManager>().settings.mqttIntegration.rootTopic;
     _client!.publishMessage(
       '$rootTopic/$topic',
       MqttQos.atMostOnce,
@@ -227,7 +228,6 @@ abstract class MqttManagerBase extends Subsystem with Store, Logger {
   // ///////////// //
 
   void _createSubscriptions() {
-    String rootTopic = getIt<SettingsManager>().settings.mqttIntegration.rootTopic;
     _client!.updates.listen((messageList) {
       MqttPublishMessage? message;
       try {
@@ -239,6 +239,10 @@ abstract class MqttManagerBase extends Subsystem with Store, Logger {
             if (payload.length == 0) return;
             _clearTopic("update_settings");
             _onSettingsMessage(const Utf8Decoder().convert(payload.message!));
+          case MqttPublishMessage(:final variableHeader, :final payload) when variableHeader!.topicName == "$rootTopic/do_action":
+            if (payload.length == 0) return;
+            _clearTopic("do_action");
+            _onHomeAssistantActionMessage(const Utf8Decoder().convert(payload.message!));
           default:
             logWarning("Received unknown published MQTT message: $message");
         }
@@ -248,6 +252,7 @@ abstract class MqttManagerBase extends Subsystem with Store, Logger {
     });
 
     _subscribeToTopic('update_settings');
+    _subscribeToTopic('do_action');
   }
 
   void _subscribeToTopic(String relativeTopic) {
@@ -269,9 +274,18 @@ abstract class MqttManagerBase extends Subsystem with Store, Logger {
     logInfo("Loaded settings data from MQTT");
   }
 
+  void _onHomeAssistantActionMessage(String message) {
+    logInfo("Received action command from Home Assistant by MQTT: $message");
+    getIt<ActionManager>().callAction(message);
+  }
+
   // ////////////////////////// //
   // Home Assistant integration //
   // ////////////////////////// //
+
+  bool get canDoHomeAssistantDiscovery => _client != null && getIt<SettingsManager>().settings.mqttIntegration.enableHomeAssistantDiscovery;
+  String get discoveryTopicPrefix => getIt<SettingsManager>().settings.mqttIntegration.homeAssistantDiscoveryTopicPrefix;
+  String get componentId => getIt<SettingsManager>().settings.mqttIntegration.homeAssistantComponentId;
 
   HomeAssistantDevice get homeAssistantDevice => HomeAssistantDevice(
       identifiers: [getIt<SettingsManager>().settings.mqttIntegration.homeAssistantComponentId],
@@ -282,9 +296,7 @@ abstract class MqttManagerBase extends Subsystem with Store, Logger {
     );
 
   void publishHomeAssistantDiscoveryTopics() {
-    if (_client == null || !getIt<SettingsManager>().settings.mqttIntegration.enableHomeAssistantDiscovery) return;
-
-    String rootTopic = getIt<SettingsManager>().settings.mqttIntegration.rootTopic;
+    if (!canDoHomeAssistantDiscovery) return;
 
     // Stats
     for (MapEntry<String, dynamic> statsEntry in _lastPublishedStats.entries) {
@@ -323,8 +335,7 @@ abstract class MqttManagerBase extends Subsystem with Store, Logger {
   }
 
   void publishHomeAssistantSensorDiscoveryTopic({required String integrationName, required String stateTopic}) {
-    final String discoveryTopicPrefix = getIt<SettingsManager>().settings.mqttIntegration.homeAssistantDiscoveryTopicPrefix;
-    final String componentId = getIt<SettingsManager>().settings.mqttIntegration.homeAssistantComponentId;
+    if (!canDoHomeAssistantDiscovery) return;
 
     _client!.publishMessage(
       '$discoveryTopicPrefix/sensor/$componentId/${Casing.snakeCase(integrationName)}/config',
@@ -340,8 +351,7 @@ abstract class MqttManagerBase extends Subsystem with Store, Logger {
   }
 
   void publishHomeAssistantDeviceTriggerDiscoveryTopic({required String integrationName, required String payload, required String stateTopic}) {
-    final String discoveryTopicPrefix = getIt<SettingsManager>().settings.mqttIntegration.homeAssistantDiscoveryTopicPrefix;
-    final String componentId = getIt<SettingsManager>().settings.mqttIntegration.homeAssistantComponentId;
+    if (!canDoHomeAssistantDiscovery) return;
 
     final String triggerType = Casing.snakeCase(integrationName);
     final String triggerSubType = Casing.snakeCase(payload);
@@ -356,6 +366,26 @@ abstract class MqttManagerBase extends Subsystem with Store, Logger {
               type: triggerType,
               subtype: triggerSubType,
               device: homeAssistantDevice,
+            ).toJson())))
+          .payload!,
+      retain: true,
+    );
+  }
+
+  void publishHomeAssistantSelectDiscoveryTopic({required String integrationName, required List<String> options, required String stateTopic, required String commandTopic}) {
+    if (!canDoHomeAssistantDiscovery) return;
+
+    _client!.publishMessage(
+      '$discoveryTopicPrefix/select/$componentId/${Casing.snakeCase(integrationName)}/config',
+      MqttQos.atLeastOnce,
+      (MqttPayloadBuilder()
+            ..addString(jsonEncode(HomeAssistantDiscoveryPayload.select(
+              name: integrationName,
+              options: options,
+              stateTopic: stateTopic,
+              commandTopic: commandTopic,
+              device: homeAssistantDevice,
+              uniqueId: '${Casing.snakeCase(integrationName)}_$componentId',
             ).toJson())))
           .payload!,
       retain: true,

--- a/lib/managers/mqtt_manager.dart
+++ b/lib/managers/mqtt_manager.dart
@@ -81,6 +81,10 @@ abstract class MqttManagerBase extends Subsystem with Store, Logger {
       List<AppActionCall> actionCalls = getIt<ActionManager>().actionHistory.values.toList();
       if (_client != null) _publishActionCallHistory(actionCalls);
     });
+    autorun((_) {
+      bool isListening = getIt<ActionManager>().listeningForActions;
+      if (_client != null) _publishListeningState(isListening);
+    });
   }
 
   void notifyPasswordChanged() {
@@ -233,6 +237,10 @@ abstract class MqttManagerBase extends Subsystem with Store, Logger {
       jsonEncode(actionCalls.map((a) => a.toJson()).toList()),
       retain: true,
     );
+  }
+
+  void _publishListeningState(bool isListening) {
+    _publish("actions/listening", isListening ? "true" : "false", retain: true);
   }
 
   void _clearTopic(String topic) {

--- a/lib/managers/mqtt_manager.dart
+++ b/lib/managers/mqtt_manager.dart
@@ -77,6 +77,10 @@ abstract class MqttManagerBase extends Subsystem with Store, Logger {
       List<String> scopes = getIt<ActionManager>().currentScopes;
       if (_client != null) _publishActions(actions, scopes);
     });
+    autorun((_) {
+      List<AppActionCall> actionCalls = getIt<ActionManager>().actionHistory.values.toList();
+      if (_client != null) _publishActionCallHistory(actionCalls);
+    });
   }
 
   void notifyPasswordChanged() {

--- a/lib/managers/mqtt_manager.dart
+++ b/lib/managers/mqtt_manager.dart
@@ -74,7 +74,7 @@ abstract class MqttManagerBase extends Subsystem with Store, Logger {
       if (_client != null) _publishActions(actions, scopes);
     });
     autorun((_) {
-      List<AppActionCall> actionCalls = getIt<ActionManager>().actionHistory.values.toList();
+      Map<DateTime, AppActionCall> actionCalls = getIt<ActionManager>().actionHistory;
       if (_client != null) _publishActionCallHistory(actionCalls);
     });
     autorun((_) {
@@ -230,11 +230,13 @@ abstract class MqttManagerBase extends Subsystem with Store, Logger {
     );
   }
 
-  void _publishActionCallHistory(List<AppActionCall> actionCalls) {
+  void _publishActionCallHistory(Map<DateTime, AppActionCall> actionCalls) {
     if (!allowControl) return;
+    var actionCallsMap = actionCalls.map((k, v) => MapEntry(k.toIso8601String(), v.toJson()));
+    var actionCallsJson = jsonEncode(actionCallsMap);
     _publish(
       "actions/call_history",
-      jsonEncode(actionCalls.map((a) => a.toJson()).toList()),
+      actionCallsJson,
       retain: true,
     );
   }

--- a/lib/managers/mqtt_manager.dart
+++ b/lib/managers/mqtt_manager.dart
@@ -12,13 +12,7 @@ import 'package:momento_booth/managers/notifications_manager.dart';
 import 'package:momento_booth/managers/settings_manager.dart';
 import 'package:momento_booth/managers/stats_manager.dart';
 import 'package:momento_booth/models/_all.dart';
-import 'package:momento_booth/models/app_action.dart';
-import 'package:momento_booth/models/app_action_call.dart';
-import 'package:momento_booth/models/capture_state.dart';
-import 'package:momento_booth/models/connection_state.dart';
 import 'package:momento_booth/models/home_assistant/home_assistant_discovery_payload.dart';
-import 'package:momento_booth/models/settings.dart';
-import 'package:momento_booth/models/stats.dart';
 import 'package:momento_booth/models/subsystem.dart';
 import 'package:momento_booth/repositories/secrets/secrets_repository.dart';
 import 'package:momento_booth/utils/environment_info.dart';
@@ -86,6 +80,10 @@ abstract class MqttManagerBase extends Subsystem with Store, Logger {
     autorun((_) {
       bool isListening = getIt<ActionManager>().listeningForActions;
       if (_client != null) _publishListeningState(isListening);
+    });
+    autorun((_) {
+      AppActionResponse? lastResponse = getIt<ActionManager>().lastResponse;
+      if (_client != null) _publishLastResponse(lastResponse);
     });
   }
 
@@ -243,6 +241,11 @@ abstract class MqttManagerBase extends Subsystem with Store, Logger {
 
   void _publishListeningState(bool isListening) {
     _publish("actions/listening", isListening ? "true" : "false", retain: true);
+  }
+
+  void _publishLastResponse(AppActionResponse? response) {
+    if (response == null) return;
+    _publish("actions/execute/result", jsonEncode(response.toJson()), retain: false);
   }
 
   void _clearTopic(String topic) {

--- a/lib/managers/notifications_manager.dart
+++ b/lib/managers/notifications_manager.dart
@@ -20,16 +20,35 @@ abstract class NotificationsManagerBase with Store {
   static const _printerStatusCheckPeriod = Duration(seconds: 5);
 
   @observable
-  ObservableList<InfoBar> notifications = ObservableList<InfoBar>();
+  ObservableList<InfoBar> statusNotifications = ObservableList();
+
+  @observable
+  String notification = "";
+
+  List<NotificationRequest> notificationRequests = [];
+  Timer? _notificationClearTimer;
 
   void initialize() {
     Timer.periodic(_printerStatusCheckPeriod, (_) => _statusCheck());
   }
 
+  void addNotificationRequest(NotificationRequest request) {
+    notificationRequests.add(request);
+
+    _notificationClearTimer?.cancel();
+    // Add 400 ms to the duration to account for the fade in animation.
+    _notificationClearTimer = Timer(Duration(milliseconds: request.duration + 400), () {
+      notificationRequests.remove(request);
+      notification = "";
+    });
+
+    notification = request.message;
+  }
+
   Future<void> _statusCheck() async {
     // The printer status check must be done before clearing as it is async and we don't want the notifications to blink.
     final printerNotifications = await _printerStatusCheck();
-    notifications
+    statusNotifications
       ..clear()
       ..addAll(printerNotifications)
       ..addAll(_subSystemStatusCheck())

--- a/lib/models/_all.dart
+++ b/lib/models/_all.dart
@@ -1,4 +1,5 @@
 export 'app_action.dart';
+export 'app_action_call.dart';
 export 'app_version_info.dart';
 export 'capture_state.dart';
 export 'connection_state.dart';

--- a/lib/models/_all.dart
+++ b/lib/models/_all.dart
@@ -9,6 +9,7 @@ export 'gallery_group.dart';
 export 'gallery_image.dart';
 export 'live_view_frame.dart';
 export 'maker_note_data.dart';
+export 'notification_request.dart';
 export 'photo_capture.dart';
 export 'print_queue_info.dart';
 export 'print_queue_task.dart';

--- a/lib/models/_all.dart
+++ b/lib/models/_all.dart
@@ -1,3 +1,4 @@
+export 'app_action.dart';
 export 'app_version_info.dart';
 export 'capture_state.dart';
 export 'connection_state.dart';

--- a/lib/models/_all.dart
+++ b/lib/models/_all.dart
@@ -1,5 +1,6 @@
 export 'app_action.dart';
 export 'app_action_call.dart';
+export 'app_action_response.dart';
 export 'app_version_info.dart';
 export 'capture_state.dart';
 export 'connection_state.dart';

--- a/lib/models/app_action.dart
+++ b/lib/models/app_action.dart
@@ -1,16 +1,16 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 part 'app_action.freezed.dart';
+part 'app_action.g.dart';
 
-@freezed
-class AppAction with _$AppAction {
-  @override
-  final String name;
-  @override
-  final Function(Map<String, dynamic>) callback;
+@Freezed(toJson: true)
+abstract class AppAction with _$AppAction {
 
-  AppAction({
-    required this.name,
-    required this.callback,
-  });
+  const AppAction._();
+
+  const factory AppAction({
+    required String name,
+    @JsonKey(includeToJson: false, includeFromJson: false)
+    required Function(Map<String, dynamic>) callback,
+  }) = _AppAction;
 }

--- a/lib/models/app_action.dart
+++ b/lib/models/app_action.dart
@@ -12,6 +12,7 @@ abstract class AppAction with _$AppAction {
     required String name,
     required String title,
     required String description,
+    @Default([]) List<String> examples,
     @Default('{ "type": "object", "additionalProperties": false }') String inputSchema,
     @JsonKey(includeToJson: false, includeFromJson: false)
     required Function(Map<String, dynamic>) callback,

--- a/lib/models/app_action.dart
+++ b/lib/models/app_action.dart
@@ -10,6 +10,9 @@ abstract class AppAction with _$AppAction {
 
   const factory AppAction({
     required String name,
+    required String title,
+    required String description,
+    @Default('{ "type": "object", "additionalProperties": false }') String inputSchema,
     @JsonKey(includeToJson: false, includeFromJson: false)
     required Function(Map<String, dynamic>) callback,
   }) = _AppAction;

--- a/lib/models/app_action.dart
+++ b/lib/models/app_action.dart
@@ -1,0 +1,16 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'app_action.freezed.dart';
+
+@freezed
+class AppAction with _$AppAction {
+  @override
+  final String name;
+  @override
+  final Function(Map<String, dynamic>) callback;
+
+  AppAction({
+    required this.name,
+    required this.callback,
+  });
+}

--- a/lib/models/app_action.dart
+++ b/lib/models/app_action.dart
@@ -15,6 +15,6 @@ abstract class AppAction with _$AppAction {
     @Default([]) List<String> examples,
     @Default('{ "type": "object", "additionalProperties": false }') String inputSchema,
     @JsonKey(includeToJson: false, includeFromJson: false)
-    required Function(Map<String, dynamic>) callback,
+    required Function(Map<String, dynamic>, Function(bool, String)) callback,
   }) = _AppAction;
 }

--- a/lib/models/app_action.dart
+++ b/lib/models/app_action.dart
@@ -1,4 +1,5 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:momento_booth/models/app_action_example.dart';
 
 part 'app_action.freezed.dart';
 part 'app_action.g.dart';
@@ -12,8 +13,8 @@ abstract class AppAction with _$AppAction {
     required String name,
     required String title,
     required String description,
-    @Default([]) List<String> examples,
-    @Default('{ "type": "object", "additionalProperties": false }') String inputSchema,
+    @Default([]) List<AppActionExample> examples,
+    @Default({ "type": "object", "additionalProperties": false }) Map<String, dynamic> inputSchema,
     @Default('{}') String inputSchemaExample,
     @JsonKey(includeToJson: false, includeFromJson: false)
     required Function(Map<String, dynamic>, Function(bool, String)) callback,

--- a/lib/models/app_action.dart
+++ b/lib/models/app_action.dart
@@ -14,6 +14,7 @@ abstract class AppAction with _$AppAction {
     required String description,
     @Default([]) List<String> examples,
     @Default('{ "type": "object", "additionalProperties": false }') String inputSchema,
+    @Default('{}') String inputSchemaExample,
     @JsonKey(includeToJson: false, includeFromJson: false)
     required Function(Map<String, dynamic>, Function(bool, String)) callback,
   }) = _AppAction;

--- a/lib/models/app_action_call.dart
+++ b/lib/models/app_action_call.dart
@@ -10,7 +10,7 @@ abstract class AppActionCall with _$AppActionCall {
 
   const factory AppActionCall({
     required String tool,
-    required Map<String, dynamic> arguments,
+    @Default({}) Map<String, dynamic> arguments,
   }) = _AppActionCall;
 
   factory AppActionCall.fromJson(Map<String, dynamic> json) => _$AppActionCallFromJson(json);

--- a/lib/models/app_action_call.dart
+++ b/lib/models/app_action_call.dart
@@ -1,0 +1,18 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'app_action_call.freezed.dart';
+part 'app_action_call.g.dart';
+
+@Freezed(toJson: true, fromJson: true)
+abstract class AppActionCall with _$AppActionCall {
+
+  const AppActionCall._();
+
+  const factory AppActionCall({
+    required String tool,
+    required Map<String, dynamic> arguments,
+  }) = _AppActionCall;
+
+  factory AppActionCall.fromJson(Map<String, dynamic> json) => _$AppActionCallFromJson(json);
+
+}

--- a/lib/models/app_action_example.dart
+++ b/lib/models/app_action_example.dart
@@ -1,0 +1,15 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'app_action_example.freezed.dart';
+part 'app_action_example.g.dart';
+
+@Freezed(toJson: true)
+abstract class AppActionExample with _$AppActionExample {
+
+  const AppActionExample._();
+
+  const factory AppActionExample({
+    required String phrase,
+    @Default({}) Map<String, dynamic> arguments,
+  }) = _AppActionExample;
+}

--- a/lib/models/app_action_response.dart
+++ b/lib/models/app_action_response.dart
@@ -1,0 +1,15 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'app_action_response.freezed.dart';
+part 'app_action_response.g.dart';
+
+@Freezed(toJson: true)
+abstract class AppActionResponse with _$AppActionResponse {
+
+  const AppActionResponse._();
+
+  const factory AppActionResponse({
+    required bool success,
+    required String message,
+  }) = _AppActionResponse;
+}

--- a/lib/models/home_assistant/home_assistant_discovery_payload.dart
+++ b/lib/models/home_assistant/home_assistant_discovery_payload.dart
@@ -39,6 +39,13 @@ sealed class HomeAssistantDiscoveryPayload with _$HomeAssistantDiscoveryPayload 
     @JsonKey(name: 'device') required HomeAssistantDevice device,
   }) = HomeAssistantSelectDiscoveryPayload;
 
+  const factory HomeAssistantDiscoveryPayload.notify({
+    @JsonKey(name: 'name') required String name,
+    @JsonKey(name: 'command_topic') required String commandTopic,
+    @JsonKey(name: 'unique_id') required String uniqueId,
+    @JsonKey(name: 'device') required HomeAssistantDevice device,
+  }) = HomeAssistantNotifyDiscoveryPayload;
+
 
 }
 

--- a/lib/models/home_assistant/home_assistant_discovery_payload.dart
+++ b/lib/models/home_assistant/home_assistant_discovery_payload.dart
@@ -30,6 +30,16 @@ sealed class HomeAssistantDiscoveryPayload with _$HomeAssistantDiscoveryPayload 
     @JsonKey(name: 'device') required HomeAssistantDevice device,
   }) = HomeAssistantDeviceTriggerDiscoveryPayload;
 
+  const factory HomeAssistantDiscoveryPayload.select({
+    @JsonKey(name: 'name') required String name,
+    @JsonKey(name: 'options') required List<String> options,
+    @JsonKey(name: 'state_topic') required String stateTopic,
+    @JsonKey(name: 'command_topic') required String commandTopic,
+    @JsonKey(name: 'unique_id') required String uniqueId,
+    @JsonKey(name: 'device') required HomeAssistantDevice device,
+  }) = HomeAssistantSelectDiscoveryPayload;
+
+
 }
 
 @Freezed(toJson: true)

--- a/lib/models/notification_request.dart
+++ b/lib/models/notification_request.dart
@@ -10,7 +10,7 @@ abstract class NotificationRequest with _$NotificationRequest {
 
   const factory NotificationRequest({
     required String message,
-    @Default(500) int duration,
+    @Default(1000) int duration,
   }) = _NotificationRequest;
 
   factory NotificationRequest.fromJson(Map<String, dynamic> json) => _$NotificationRequestFromJson(json);

--- a/lib/models/notification_request.dart
+++ b/lib/models/notification_request.dart
@@ -1,0 +1,18 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'notification_request.freezed.dart';
+part 'notification_request.g.dart';
+
+@Freezed(toJson: true, fromJson: true)
+abstract class NotificationRequest with _$NotificationRequest {
+
+  const NotificationRequest._();
+
+  const factory NotificationRequest({
+    required String message,
+    @Default(500) int duration,
+  }) = _NotificationRequest;
+
+  factory NotificationRequest.fromJson(Map<String, dynamic> json) => _$NotificationRequestFromJson(json);
+
+}

--- a/lib/models/settings.dart
+++ b/lib/models/settings.dart
@@ -38,6 +38,7 @@ sealed class Settings with _$Settings implements TomlEncodableValue {
     @JsonKey(defaultValue: HardwareSettings.withDefaults) required HardwareSettings hardware,
     @JsonKey(defaultValue: OutputSettings.withDefaults) required OutputSettings output,
     @JsonKey(defaultValue: UiSettings.withDefaults) required UiSettings ui,
+    @JsonKey(defaultValue: ControlSettings.withDefaults) required ControlSettings control,
     @JsonKey(defaultValue: MqttIntegrationSettings.withDefaults) required MqttIntegrationSettings mqttIntegration,
     @JsonKey(defaultValue: FaceRecognitionSettings.withDefaults) required FaceRecognitionSettings faceRecognition,
     @JsonKey(defaultValue: DebugSettings.withDefaults) required DebugSettings debug,
@@ -314,6 +315,25 @@ sealed class FaceRecognitionSettings with _$FaceRecognitionSettings implements T
   factory FaceRecognitionSettings.withDefaults() => FaceRecognitionSettings.fromJson({});
 
   factory FaceRecognitionSettings.fromJson(Map<String, Object?> json) => _$FaceRecognitionSettingsFromJson(json);
+
+  @override
+  Map<String, dynamic> toTomlValue() => toJson();
+
+}
+
+@Freezed(fromJson: true, toJson: true)
+sealed class ControlSettings with _$ControlSettings implements TomlEncodableValue {
+
+  const ControlSettings._();
+
+  const factory ControlSettings({
+    @Default(false) bool enable,
+    @Default(2000) int controlDisableDurationMsAfterTouch,
+  }) = _ControlSettings;
+
+  factory ControlSettings.withDefaults() => ControlSettings.fromJson({});
+
+  factory ControlSettings.fromJson(Map<String, Object?> json) => _$ControlSettingsFromJson(json);
 
   @override
   Map<String, dynamic> toTomlValue() => toJson();

--- a/lib/models/settings.dart
+++ b/lib/models/settings.dart
@@ -329,6 +329,7 @@ sealed class ControlSettings with _$ControlSettings implements TomlEncodableValu
   const factory ControlSettings({
     @Default(false) bool enable,
     @Default(2000) int controlDisableDurationMsAfterTouch,
+    @Default(30) int controlHistoryDurationSeconds,
   }) = _ControlSettings;
 
   factory ControlSettings.withDefaults() => ControlSettings.fromJson({});

--- a/lib/utils/speech_phrases.dart
+++ b/lib/utils/speech_phrases.dart
@@ -1,0 +1,49 @@
+const List<String> cancelPhrases = [
+  "cancel",
+  "stop",
+  "abort",
+  "never mind",
+  "forget it"
+];
+
+const List<String> continuePhrases = [
+  "continue",
+  "next",
+  "go on",
+  "proceed",
+  "keep going"
+];
+
+const List<String> backPhrases = [
+  "back",
+  "previous",
+  "go back",
+  "return",
+  "previous screen"
+];
+
+const List<String> confirmPhrases = [
+  "yes",
+  "confirm",
+  "that's right",
+  "correct",
+  "yep",
+  "do it",
+];
+
+const List<String> getQRPhrases = [
+  "get qr code",
+  "show qr code",
+  "generate qr code",
+  "share photo"
+];
+
+const List<String> printPhrases = [
+  "print",
+  "print it",
+  "print photo",
+  "print picture",
+  "i want a print",
+  "i want to print",
+  "let's print"
+];

--- a/lib/utils/speech_phrases.dart
+++ b/lib/utils/speech_phrases.dart
@@ -3,7 +3,10 @@ const List<String> cancelPhrases = [
   "stop",
   "abort",
   "never mind",
-  "forget it"
+  "forget it",
+  "close",
+  "dismiss",
+  "exit",
 ];
 
 const List<String> continuePhrases = [

--- a/lib/utils/speech_phrases.dart
+++ b/lib/utils/speech_phrases.dart
@@ -11,7 +11,9 @@ const List<String> continuePhrases = [
   "next",
   "go on",
   "proceed",
-  "keep going"
+  "keep going",
+  "done",
+  "finished"
 ];
 
 const List<String> backPhrases = [

--- a/lib/utils/speech_phrases.dart
+++ b/lib/utils/speech_phrases.dart
@@ -1,3 +1,5 @@
+import 'package:momento_booth/models/app_action_example.dart';
+
 const List<String> cancelPhrases = [
   "cancel",
   "stop",
@@ -9,6 +11,8 @@ const List<String> cancelPhrases = [
   "exit",
 ];
 
+List<AppActionExample> get cancelPhrasesExamples => cancelPhrases.map((phrase) => AppActionExample(phrase: phrase)).toList();
+
 const List<String> continuePhrases = [
   "continue",
   "next",
@@ -19,6 +23,8 @@ const List<String> continuePhrases = [
   "finished"
 ];
 
+List<AppActionExample> get continuePhrasesExamples => continuePhrases.map((phrase) => AppActionExample(phrase: phrase)).toList();
+
 const List<String> backPhrases = [
   "back",
   "previous",
@@ -26,6 +32,8 @@ const List<String> backPhrases = [
   "return",
   "previous screen"
 ];
+
+List<AppActionExample> get backPhrasesExamples => backPhrases.map((phrase) => AppActionExample(phrase: phrase)).toList();
 
 const List<String> confirmPhrases = [
   "yes",
@@ -36,12 +44,16 @@ const List<String> confirmPhrases = [
   "do it",
 ];
 
+List<AppActionExample> get confirmPhrasesExamples => confirmPhrases.map((phrase) => AppActionExample(phrase: phrase)).toList();
+
 const List<String> getQRPhrases = [
   "get qr code",
   "show qr code",
   "generate qr code",
   "share photo"
 ];
+
+List<AppActionExample> get getQRPhrasesExamples => getQRPhrases.map((phrase) => AppActionExample(phrase: phrase)).toList();
 
 const List<String> printPhrases = [
   "print",
@@ -52,3 +64,5 @@ const List<String> printPhrases = [
   "i want to print",
   "let's print"
 ];
+
+List<AppActionExample> get printPhrasesExamples => printPhrases.map((phrase) => AppActionExample(phrase: phrase)).toList();

--- a/lib/views/base/build_context_abstractor.dart
+++ b/lib/views/base/build_context_abstractor.dart
@@ -2,8 +2,13 @@ import 'package:fluent_ui/fluent_ui.dart';
 import 'package:go_router/go_router.dart';
 import 'package:momento_booth/app_localizations.dart';
 import 'package:momento_booth/extensions/build_context_extension.dart';
+import 'package:momento_booth/main.dart';
+import 'package:momento_booth/managers/action_manager.dart';
+import 'package:momento_booth/models/app_action.dart';
 import 'package:momento_booth/views/base/build_context_accessor.dart';
 import 'package:momento_booth/views/base/photo_booth_dialog_page.dart';
+import 'package:momento_booth/views/components/dialogs/dialog_actions_mixin.dart';
+import 'package:momento_booth/views/components/dialogs/photo_booth_dialog.dart';
 import 'package:momento_booth/views/photo_booth_screen/theme/photo_booth_theme.dart';
 
 /// This mixin makes several objects (that normally needs to be accessed using [BuildContext]) easier accessible from screen view models and controllers.
@@ -21,13 +26,24 @@ mixin BuildContextAbstractor {
   AppLocalizations get localizations => AppLocalizations.of(_context)!;
 
   Future<T?> showUserDialog<T extends Object?>({required Widget dialog, required bool barrierDismissible}) async {
-    return await navigator.push<T>(PhotoBoothDialogPage<T>(
+    // We acquire the actions from the dialog and push them to the ActionManager
+    final actionStackToken = Object();
+    final List<AppAction> dialogActions = switch (dialog) {
+      DialogActionsMixin photoBoothDialog => photoBoothDialog.actions,
+      _ => [],
+    };
+    getIt<ActionManager>().push(dialogActions, actionStackToken);
+    // We then show the dialog and wait for it to be dismissed, saving the `pop` result
+    final result = await navigator.push<T>(PhotoBoothDialogPage<T>(
       child: Padding(
         padding: const EdgeInsets.all(32),
         child: Center(child: dialog),
       ),
       barrierDismissible: barrierDismissible,
     ).createRoute());
+    // When the dialog is dismissed, we pop the actions from the ActionManager
+    getIt<ActionManager>().pop(actionStackToken);
+    return result;
   }
 
 }

--- a/lib/views/base/build_context_abstractor.dart
+++ b/lib/views/base/build_context_abstractor.dart
@@ -31,7 +31,7 @@ mixin BuildContextAbstractor {
       DialogActionsMixin photoBoothDialog => photoBoothDialog.actions,
       _ => [],
     };
-    getIt<ActionManager>().push(dialogActions, actionStackToken);
+    getIt<ActionManager>().pushActions(dialogActions, "User Dialog", actionStackToken);
     // We then show the dialog and wait for it to be dismissed, saving the `pop` result
     final result = await navigator.push<T>(PhotoBoothDialogPage<T>(
       child: Padding(

--- a/lib/views/base/build_context_abstractor.dart
+++ b/lib/views/base/build_context_abstractor.dart
@@ -8,7 +8,6 @@ import 'package:momento_booth/models/app_action.dart';
 import 'package:momento_booth/views/base/build_context_accessor.dart';
 import 'package:momento_booth/views/base/photo_booth_dialog_page.dart';
 import 'package:momento_booth/views/components/dialogs/dialog_actions_mixin.dart';
-import 'package:momento_booth/views/components/dialogs/photo_booth_dialog.dart';
 import 'package:momento_booth/views/photo_booth_screen/theme/photo_booth_theme.dart';
 
 /// This mixin makes several objects (that normally needs to be accessed using [BuildContext]) easier accessible from screen view models and controllers.

--- a/lib/views/base/build_context_abstractor.dart
+++ b/lib/views/base/build_context_abstractor.dart
@@ -41,19 +41,21 @@ mixin BuildContextAbstractor {
     if (publishActions) {
       getIt<ActionManager>().pushActions(dialogActions, dialogScopeName, usedActionStackToken);
     }
-    // We then show the dialog and wait for it to be dismissed, saving the `pop` result
-    final result = await navigator.push<T>(PhotoBoothDialogPage<T>(
-      child: Padding(
-        padding: const EdgeInsets.all(32),
-        child: Center(child: dialog),
-      ),
-      barrierDismissible: barrierDismissible,
-    ).createRoute());
-    // When the dialog is dismissed, we pop the actions from the ActionManager
-    if (publishActions) {
-      getIt<ActionManager>().pop(usedActionStackToken);
+    try {
+      // We then show the dialog and wait for it to be dismissed, saving the `pop` result
+      return await navigator.push<T>(PhotoBoothDialogPage<T>(
+        child: Padding(
+          padding: const EdgeInsets.all(32),
+          child: Center(child: dialog),
+        ),
+        barrierDismissible: barrierDismissible,
+      ).createRoute());
+    } finally {
+      // When the dialog is dismissed, we pop the actions from the ActionManager
+      if (publishActions) {
+        getIt<ActionManager>().pop(usedActionStackToken);
+      }
     }
-    return result;
   }
 
 }

--- a/lib/views/base/build_context_abstractor.dart
+++ b/lib/views/base/build_context_abstractor.dart
@@ -24,9 +24,12 @@ mixin BuildContextAbstractor {
 
   AppLocalizations get localizations => AppLocalizations.of(_context)!;
 
-  Future<T?> showUserDialog<T extends Object?>({required Widget dialog, required bool barrierDismissible, Object? actionStackToken}) async {
+  /// Launches the given dialog widget as a dialog, and returns the result by the route `pop`.
+  /// For stateless widgets implementing [DialogActionsMixin], use [publishActions] `true`, the dialog's actions will be published to the ActionManager for the duration of the dialog being open.
+  /// For stateful widgets where the state implements [HasActionsMixin], the dialog will manage pushing and popping its own actions, so [publishActions] should be `false` to avoid extra scopes in the ActionManager.
+  Future<T?> showUserDialog<T extends Object?>({required Widget dialog, required bool barrierDismissible, bool publishActions = true}) async {
     // We acquire the actions from the dialog and push them to the ActionManager
-    final usedActionStackToken = actionStackToken ?? Object();
+    final usedActionStackToken = Object();
     final List<AppAction> dialogActions = switch (dialog) {
       DialogActionsMixin photoBoothDialog => photoBoothDialog.actions,
       _ => [],
@@ -35,7 +38,9 @@ mixin BuildContextAbstractor {
       DialogActionsMixin photoBoothDialog => photoBoothDialog.scopeName,
       _ => "User Dialog",
     };
-    getIt<ActionManager>().pushActions(dialogActions, dialogScopeName, usedActionStackToken);
+    if (publishActions) {
+      getIt<ActionManager>().pushActions(dialogActions, dialogScopeName, usedActionStackToken);
+    }
     // We then show the dialog and wait for it to be dismissed, saving the `pop` result
     final result = await navigator.push<T>(PhotoBoothDialogPage<T>(
       child: Padding(
@@ -45,7 +50,9 @@ mixin BuildContextAbstractor {
       barrierDismissible: barrierDismissible,
     ).createRoute());
     // When the dialog is dismissed, we pop the actions from the ActionManager
-    getIt<ActionManager>().pop(usedActionStackToken);
+    if (publishActions) {
+      getIt<ActionManager>().pop(usedActionStackToken);
+    }
     return result;
   }
 

--- a/lib/views/base/build_context_abstractor.dart
+++ b/lib/views/base/build_context_abstractor.dart
@@ -24,14 +24,18 @@ mixin BuildContextAbstractor {
 
   AppLocalizations get localizations => AppLocalizations.of(_context)!;
 
-  Future<T?> showUserDialog<T extends Object?>({required Widget dialog, required bool barrierDismissible}) async {
+  Future<T?> showUserDialog<T extends Object?>({required Widget dialog, required bool barrierDismissible, Object? actionStackToken}) async {
     // We acquire the actions from the dialog and push them to the ActionManager
-    final actionStackToken = Object();
+    final usedActionStackToken = actionStackToken ?? Object();
     final List<AppAction> dialogActions = switch (dialog) {
       DialogActionsMixin photoBoothDialog => photoBoothDialog.actions,
       _ => [],
     };
-    getIt<ActionManager>().pushActions(dialogActions, "User Dialog", actionStackToken);
+    final String dialogScopeName = switch (dialog) {
+      DialogActionsMixin photoBoothDialog => photoBoothDialog.scopeName,
+      _ => "User Dialog",
+    };
+    getIt<ActionManager>().pushActions(dialogActions, dialogScopeName, usedActionStackToken);
     // We then show the dialog and wait for it to be dismissed, saving the `pop` result
     final result = await navigator.push<T>(PhotoBoothDialogPage<T>(
       child: Padding(
@@ -41,7 +45,7 @@ mixin BuildContextAbstractor {
       barrierDismissible: barrierDismissible,
     ).createRoute());
     // When the dialog is dismissed, we pop the actions from the ActionManager
-    getIt<ActionManager>().pop(actionStackToken);
+    getIt<ActionManager>().pop(usedActionStackToken);
     return result;
   }
 

--- a/lib/views/base/has_actions_mixin.dart
+++ b/lib/views/base/has_actions_mixin.dart
@@ -1,6 +1,7 @@
 import 'package:momento_booth/main.dart';
 import 'package:momento_booth/managers/action_manager.dart';
 import 'package:momento_booth/models/app_action.dart';
+import 'package:momento_booth/models/app_action_call.dart';
 
 mixin HasActionsMixin {
   final Object _actionStackToken = Object();
@@ -13,5 +14,9 @@ mixin HasActionsMixin {
 
   void popActions() {
     getIt<ActionManager>().pop(_actionStackToken);
+  }
+
+  void registerActionCall(AppActionCall call, {bool overwriteSameName = false}) {
+    getIt<ActionManager>().registerActionCall(call, overwriteSameName: overwriteSameName);
   }
 }

--- a/lib/views/base/has_actions_mixin.dart
+++ b/lib/views/base/has_actions_mixin.dart
@@ -1,0 +1,16 @@
+import 'package:momento_booth/main.dart';
+import 'package:momento_booth/managers/action_manager.dart';
+import 'package:momento_booth/models/app_action.dart';
+
+mixin HasActionsMixin {
+  final Object _actionStackToken = Object();
+  List<AppAction> get actions => [];
+
+  void pushActions() {
+    getIt<ActionManager>().push(actions, _actionStackToken);
+  }
+
+  void popActions() {
+    getIt<ActionManager>().pop(_actionStackToken);
+  }
+}

--- a/lib/views/base/has_actions_mixin.dart
+++ b/lib/views/base/has_actions_mixin.dart
@@ -5,9 +5,10 @@ import 'package:momento_booth/models/app_action.dart';
 mixin HasActionsMixin {
   final Object _actionStackToken = Object();
   List<AppAction> get actions => [];
+  String get scopeName => "Unknown";
 
   void pushActions() {
-    getIt<ActionManager>().push(actions, _actionStackToken);
+    getIt<ActionManager>().pushActions(actions, scopeName, _actionStackToken);
   }
 
   void popActions() {

--- a/lib/views/base/photo_booth_dialog_page.dart
+++ b/lib/views/base/photo_booth_dialog_page.dart
@@ -4,8 +4,11 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:momento_booth/main.dart';
 import 'package:momento_booth/managers/settings_manager.dart';
+import 'package:momento_booth/models/app_action.dart';
+import 'package:momento_booth/views/base/has_actions_mixin.dart';
+import 'package:momento_booth/views/components/dialogs/photo_booth_dialog.dart';
 
-final class PhotoBoothDialogPage<T> extends CustomTransitionPage<T> {
+final class PhotoBoothDialogPage<T> extends CustomTransitionPage<T> with HasActionsMixin {
 
   static const defaultTransitionDuration = Duration(milliseconds: 800);
   static const defaultTransitionOutDuration = Duration(milliseconds: 400);
@@ -25,6 +28,13 @@ final class PhotoBoothDialogPage<T> extends CustomTransitionPage<T> {
       reverseCurve: Curves.easeInExpo,
     );
   }
+
+  /// Extract the app actions from the dialog if the child is a [PhotoBoothDialog].
+  @override
+  List<AppAction> get actions => switch (super.child) {
+    PhotoBoothDialog dialog => dialog.appActions,
+    _ => [],
+  };
 
   PhotoBoothDialogPage({
     required super.child,
@@ -48,7 +58,9 @@ final class PhotoBoothDialogPage<T> extends CustomTransitionPage<T> {
               ),
             );
           },
-        );
+        ) {
+    pushActions();
+  }
 
   @override
   Route<T> createRoute([BuildContext? _]) => PhotoBoothDialogRoute<T>(
@@ -61,6 +73,10 @@ final class PhotoBoothDialogPage<T> extends CustomTransitionPage<T> {
         transitionDuration: transitionDuration,
         reverseTransitionDuration: reverseTransitionDuration,
       );
+
+  void dispose() {
+    popActions();
+  }
 
 }
 

--- a/lib/views/base/photo_booth_dialog_page.dart
+++ b/lib/views/base/photo_booth_dialog_page.dart
@@ -4,11 +4,8 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:momento_booth/main.dart';
 import 'package:momento_booth/managers/settings_manager.dart';
-import 'package:momento_booth/models/app_action.dart';
-import 'package:momento_booth/views/base/has_actions_mixin.dart';
-import 'package:momento_booth/views/components/dialogs/photo_booth_dialog.dart';
 
-final class PhotoBoothDialogPage<T> extends CustomTransitionPage<T> with HasActionsMixin {
+final class PhotoBoothDialogPage<T> extends CustomTransitionPage<T> {
 
   static const defaultTransitionDuration = Duration(milliseconds: 800);
   static const defaultTransitionOutDuration = Duration(milliseconds: 400);
@@ -28,13 +25,6 @@ final class PhotoBoothDialogPage<T> extends CustomTransitionPage<T> with HasActi
       reverseCurve: Curves.easeInExpo,
     );
   }
-
-  /// Extract the app actions from the dialog if the child is a [PhotoBoothDialog].
-  @override
-  List<AppAction> get actions => switch (super.child) {
-    PhotoBoothDialog dialog => dialog.appActions,
-    _ => [],
-  };
 
   PhotoBoothDialogPage({
     required super.child,
@@ -58,9 +48,7 @@ final class PhotoBoothDialogPage<T> extends CustomTransitionPage<T> with HasActi
               ),
             );
           },
-        ) {
-    pushActions();
-  }
+        );
 
   @override
   Route<T> createRoute([BuildContext? _]) => PhotoBoothDialogRoute<T>(
@@ -73,10 +61,6 @@ final class PhotoBoothDialogPage<T> extends CustomTransitionPage<T> with HasActi
         transitionDuration: transitionDuration,
         reverseTransitionDuration: reverseTransitionDuration,
       );
-
-  void dispose() {
-    popActions();
-  }
 
 }
 

--- a/lib/views/base/screen_controller_base.dart
+++ b/lib/views/base/screen_controller_base.dart
@@ -1,13 +1,11 @@
 import 'package:meta/meta.dart';
-import 'package:momento_booth/main.dart';
-import 'package:momento_booth/managers/_all.dart';
-import 'package:momento_booth/models/app_action.dart';
 import 'package:momento_booth/utils/logger.dart';
 import 'package:momento_booth/views/base/build_context_abstractor.dart';
 import 'package:momento_booth/views/base/build_context_accessor.dart';
+import 'package:momento_booth/views/base/has_actions_mixin.dart';
 import 'package:momento_booth/views/base/screen_view_model_base.dart';
 
-abstract class ScreenControllerBase<T extends ScreenViewModelBase> with BuildContextAbstractor, Logger {
+abstract class ScreenControllerBase<T extends ScreenViewModelBase> with BuildContextAbstractor, Logger, HasActionsMixin {
 
   final T viewModel;
 
@@ -18,15 +16,12 @@ abstract class ScreenControllerBase<T extends ScreenViewModelBase> with BuildCon
     required this.viewModel,
     required this.contextAccessor,
   }) {
-    getIt<ActionManager>().push(actions, _actionStackToken);
+    pushActions();
   }
 
   @mustCallSuper
   void dispose() {
-    getIt<ActionManager>().pop(_actionStackToken);
+    popActions();
   }
-
-  final Object _actionStackToken = Object();
-  List<AppAction> get actions => [];
 
 }

--- a/lib/views/base/screen_controller_base.dart
+++ b/lib/views/base/screen_controller_base.dart
@@ -1,4 +1,7 @@
 import 'package:meta/meta.dart';
+import 'package:momento_booth/main.dart';
+import 'package:momento_booth/managers/_all.dart';
+import 'package:momento_booth/models/app_action.dart';
 import 'package:momento_booth/utils/logger.dart';
 import 'package:momento_booth/views/base/build_context_abstractor.dart';
 import 'package:momento_booth/views/base/build_context_accessor.dart';
@@ -14,10 +17,16 @@ abstract class ScreenControllerBase<T extends ScreenViewModelBase> with BuildCon
   ScreenControllerBase({
     required this.viewModel,
     required this.contextAccessor,
-  });
+  }) {
+    getIt<ActionManager>().push(actions, _actionStackToken);
+  }
 
   @mustCallSuper
   void dispose() {
+    getIt<ActionManager>().pop(_actionStackToken);
   }
+
+  final Object _actionStackToken = Object();
+  List<AppAction> get actions => [];
 
 }

--- a/lib/views/base/screen_controller_base.dart
+++ b/lib/views/base/screen_controller_base.dart
@@ -6,6 +6,9 @@ import 'package:momento_booth/views/base/has_actions_mixin.dart';
 import 'package:momento_booth/views/base/screen_view_model_base.dart';
 
 abstract class ScreenControllerBase<T extends ScreenViewModelBase> with BuildContextAbstractor, Logger, HasActionsMixin {
+  
+  @override
+  String get scopeName => "Unknown screen";
 
   final T viewModel;
 

--- a/lib/views/components/buttons/photo_booth_filled_button.dart
+++ b/lib/views/components/buttons/photo_booth_filled_button.dart
@@ -1,17 +1,14 @@
 import 'package:fluent_ui/fluent_ui.dart';
 import 'package:momento_booth/extensions/build_context_extension.dart';
+import 'package:momento_booth/views/components/buttons/stateless_photo_booth_button.dart';
 
-class PhotoBoothFilledButton extends StatelessWidget {
-
-  final String title;
-  final IconData? icon;
-  final VoidCallback? onPressed;
+class PhotoBoothFilledButton extends StatelessPhotoBoothButton {
 
   const PhotoBoothFilledButton({
-    super.key,
-    required this.title,
-    this.icon,
-    this.onPressed,
+    super.key, 
+    required super.title,
+    super.icon,
+    super.onPressed
   });
 
   @override

--- a/lib/views/components/buttons/photo_booth_outlined_button.dart
+++ b/lib/views/components/buttons/photo_booth_outlined_button.dart
@@ -1,17 +1,14 @@
 import 'package:fluent_ui/fluent_ui.dart';
 import 'package:momento_booth/extensions/build_context_extension.dart';
+import 'package:momento_booth/views/components/buttons/stateless_photo_booth_button.dart';
 
-class PhotoBoothOutlinedButton extends StatelessWidget {
-
-  final String title;
-  final IconData? icon;
-  final VoidCallback? onPressed;
+class PhotoBoothOutlinedButton extends StatelessPhotoBoothButton {
 
   const PhotoBoothOutlinedButton({
     super.key,
-    required this.title,
-    this.icon,
-    this.onPressed,
+    required super.title,
+    super.icon,
+    super.onPressed,
   });
 
   @override

--- a/lib/views/components/buttons/stateless_photo_booth_button.dart
+++ b/lib/views/components/buttons/stateless_photo_booth_button.dart
@@ -1,0 +1,16 @@
+import 'package:fluent_ui/fluent_ui.dart';
+
+abstract class StatelessPhotoBoothButton extends StatelessWidget {
+
+  final String title;
+  final IconData? icon;
+  final VoidCallback? onPressed;
+
+  const StatelessPhotoBoothButton({
+    super.key,
+    required this.title,
+    this.icon,
+    this.onPressed,
+  }) : super();
+
+}

--- a/lib/views/components/dialogs/dialog_actions_mixin.dart
+++ b/lib/views/components/dialogs/dialog_actions_mixin.dart
@@ -1,0 +1,7 @@
+import 'package:meta/meta.dart';
+import 'package:momento_booth/models/app_action.dart';
+
+mixin DialogActionsMixin {
+  @mustBeOverridden
+  List<AppAction> get actions => [];
+}

--- a/lib/views/components/dialogs/dialog_actions_mixin.dart
+++ b/lib/views/components/dialogs/dialog_actions_mixin.dart
@@ -4,4 +4,5 @@ import 'package:momento_booth/models/app_action.dart';
 mixin DialogActionsMixin {
   @mustBeOverridden
   List<AppAction> get actions => [];
+  String get scopeName => "User Dialog";
 }

--- a/lib/views/components/dialogs/language_choice_dialog.dart
+++ b/lib/views/components/dialogs/language_choice_dialog.dart
@@ -4,10 +4,12 @@ import 'package:flutter_svg/svg.dart';
 import 'package:momento_booth/app_localizations.dart';
 import 'package:momento_booth/main.dart';
 import 'package:momento_booth/managers/project_manager.dart';
+import 'package:momento_booth/models/app_action.dart';
 import 'package:momento_booth/models/settings.dart';
+import 'package:momento_booth/views/components/dialogs/dialog_actions_mixin.dart';
 import 'package:momento_booth/views/components/dialogs/modal_dialog.dart';
 
-class LanguageChoiceDialog extends StatelessWidget {
+class LanguageChoiceDialog extends StatelessWidget with DialogActionsMixin {
 
   final Function(Language) onChosen;
 
@@ -74,4 +76,18 @@ class LanguageChoiceDialog extends StatelessWidget {
     );
   }
 
+  @override
+  List<AppAction> get actions => [
+    AppAction(name: "set_language", callback: setLanguageAPI),
+    // Todo: is there a way to pop the route from here?
+    // AppAction(name: "dismiss", callback: (_) {  }),
+  ];
+
+  void setLanguageAPI(Map<String, dynamic> args) {
+    final String languageCode = args["language_code"] ?? "--";
+    final Language language = Language.definedValues.firstWhere((lang) => lang.code == languageCode, orElse: () => Language.noLanguage);
+    if (language != Language.noLanguage){
+      onChosen(language);
+    }
+  }
 }

--- a/lib/views/components/dialogs/language_choice_dialog.dart
+++ b/lib/views/components/dialogs/language_choice_dialog.dart
@@ -78,7 +78,13 @@ class LanguageChoiceDialog extends StatelessWidget with DialogActionsMixin {
 
   @override
   List<AppAction> get actions => [
-    AppAction(name: "set_language", callback: setLanguageAPI),
+    AppAction(
+      name: "set_language",
+      callback: setLanguageAPI,
+      title: 'Set Language',
+      description: 'Change the application language to the chosen one for this session.',
+      inputSchema: '{ "type": "object", "properties": { "language_code": { "type": "string", "description": "The ISO 639-1 code for the language to set" } }, "required": ["language_code"], "additionalProperties": false }'
+    ),
     // Todo: is there a way to pop the route from here?
     // AppAction(name: "dismiss", callback: (_) {  }),
   ];

--- a/lib/views/components/dialogs/language_choice_dialog.dart
+++ b/lib/views/components/dialogs/language_choice_dialog.dart
@@ -5,6 +5,7 @@ import 'package:momento_booth/app_localizations.dart';
 import 'package:momento_booth/main.dart';
 import 'package:momento_booth/managers/project_manager.dart';
 import 'package:momento_booth/models/app_action.dart';
+import 'package:momento_booth/models/app_action_example.dart';
 import 'package:momento_booth/models/settings.dart';
 import 'package:momento_booth/utils/speech_phrases.dart';
 import 'package:momento_booth/views/components/dialogs/dialog_actions_mixin.dart';
@@ -27,7 +28,6 @@ class LanguageChoiceDialog extends StatelessWidget with DialogActionsMixin {
 
   List<Language> get projectAvailableLanguages => getIt<ProjectManager>().settings.availableLanguages;
   List<Language> get languages => projectAvailableLanguages.isNotEmpty? projectAvailableLanguages : Language.definedValues;
-  List<String> get languageCodes => languages.map((lang) => '"${lang.code}"').toList();
 
   @override
   Widget build(BuildContext context) {
@@ -85,15 +85,23 @@ class LanguageChoiceDialog extends StatelessWidget with DialogActionsMixin {
       callback: setLanguageAPI,
       title: 'Set Language',
       description: 'Change the application language to the chosen one for this session.',
-      inputSchema: '{ "type": "object", "properties": { "language_code": { "enum": [${languageCodes.join(", ")}], "description": "The ISO 639-1 code for the language to set" } }, "required": ["language_code"], "additionalProperties": false }',
-      inputSchemaExample: '{ "language_code": one of ${languageCodes.join(", ")} }',
+      inputSchema: { "type": "object", "properties": { "language_code": { "enum": languages.map((lang) => lang.code).toList(), "description": "The ISO 639-1 code for the language to set" } }, "required": ["language_code"], "additionalProperties": false },
+      inputSchemaExample: '{ "language_code": one of ${languages.map((lang) => '"${lang.code}"').join(", ")} }',
+      examples: languages.expand((lang) => [
+        AppActionExample(phrase: "select ${lang.nameNative}", arguments: { "language_code": lang.code }),
+        AppActionExample(phrase: "use ${lang.nameNative}", arguments: { "language_code": lang.code }),
+        AppActionExample(phrase: "set language to ${lang.nameNative}", arguments: { "language_code": lang.code }),
+        AppActionExample(phrase: "change language to ${lang.nameNative}", arguments: { "language_code": lang.code }),
+        AppActionExample(phrase: "switch language to ${lang.nameNative}", arguments: { "language_code": lang.code }),
+        AppActionExample(phrase: "i want to use ${lang.nameNative}", arguments: { "language_code": lang.code }),
+      ]).toList(),
     ),
     // Todo: is there a way to pop the route from here?
     AppAction(
       name: "dismiss",
       callback: (_, response) { onCancel(); response(true, "Dialog dismissed"); },
       title: "Dismiss", description: "Close the language selection dialog without changing the language.",
-      examples: cancelPhrases
+      examples: cancelPhrasesExamples
     ),
   ];
 

--- a/lib/views/components/dialogs/language_choice_dialog.dart
+++ b/lib/views/components/dialogs/language_choice_dialog.dart
@@ -6,16 +6,19 @@ import 'package:momento_booth/main.dart';
 import 'package:momento_booth/managers/project_manager.dart';
 import 'package:momento_booth/models/app_action.dart';
 import 'package:momento_booth/models/settings.dart';
+import 'package:momento_booth/utils/speech_phrases.dart';
 import 'package:momento_booth/views/components/dialogs/dialog_actions_mixin.dart';
 import 'package:momento_booth/views/components/dialogs/modal_dialog.dart';
 
 class LanguageChoiceDialog extends StatelessWidget with DialogActionsMixin {
 
   final Function(Language) onChosen;
+  final VoidCallback onCancel;
 
   const LanguageChoiceDialog({
     super.key,
     required this.onChosen,
+    required this.onCancel,
   });
 
   String getFlagAsset(String countryCode) {
@@ -86,7 +89,12 @@ class LanguageChoiceDialog extends StatelessWidget with DialogActionsMixin {
       inputSchema: '{ "type": "object", "properties": { "language_code": { "type": "string", "description": "The ISO 639-1 code for the language to set" } }, "required": ["language_code"], "additionalProperties": false }'
     ),
     // Todo: is there a way to pop the route from here?
-    // AppAction(name: "dismiss", callback: (_) {  }),
+    AppAction(
+      name: "dismiss",
+      callback: (_, response) { onCancel(); response(true, "Dialog dismissed"); },
+      title: "Dismiss", description: "Close the language selection dialog without changing the language.",
+      examples: cancelPhrases
+    ),
   ];
 
   @override

--- a/lib/views/components/dialogs/language_choice_dialog.dart
+++ b/lib/views/components/dialogs/language_choice_dialog.dart
@@ -89,6 +89,9 @@ class LanguageChoiceDialog extends StatelessWidget with DialogActionsMixin {
     // AppAction(name: "dismiss", callback: (_) {  }),
   ];
 
+  @override
+  String get scopeName => "Language Choice Dialog";
+
   void setLanguageAPI(Map<String, dynamic> args, Function(bool, String) response) {
     final String languageCode = args["language_code"] ?? "--";
     final Language language = Language.definedValues.firstWhere((lang) => lang.code == languageCode, orElse: () => Language.noLanguage);

--- a/lib/views/components/dialogs/language_choice_dialog.dart
+++ b/lib/views/components/dialogs/language_choice_dialog.dart
@@ -25,14 +25,13 @@ class LanguageChoiceDialog extends StatelessWidget with DialogActionsMixin {
     return 'assets/svg/flags/$countryCode.svg';
   }
 
+  List<Language> get projectAvailableLanguages => getIt<ProjectManager>().settings.availableLanguages;
+  List<Language> get languages => projectAvailableLanguages.isNotEmpty? projectAvailableLanguages : Language.definedValues;
+  List<String> get languageCodes => languages.map((lang) => '"${lang.code}"').toList();
+
   @override
   Widget build(BuildContext context) {
     AppLocalizations localizations = AppLocalizations.of(context)!;
-
-    final projectAvailableLanguages = getIt<ProjectManager>().settings.availableLanguages;
-    final languages = projectAvailableLanguages.isNotEmpty
-      ? projectAvailableLanguages
-      : Language.definedValues;
 
     final TextStyle textStyle = FluentTheme.of(context).typography.bodyLarge!.copyWith(
       fontSize: 30,
@@ -86,7 +85,8 @@ class LanguageChoiceDialog extends StatelessWidget with DialogActionsMixin {
       callback: setLanguageAPI,
       title: 'Set Language',
       description: 'Change the application language to the chosen one for this session.',
-      inputSchema: '{ "type": "object", "properties": { "language_code": { "type": "string", "description": "The ISO 639-1 code for the language to set" } }, "required": ["language_code"], "additionalProperties": false }'
+      inputSchema: '{ "type": "object", "properties": { "language_code": { "enum": [${languageCodes.join(", ")}], "description": "The ISO 639-1 code for the language to set" } }, "required": ["language_code"], "additionalProperties": false }',
+      inputSchemaExample: '{ "language_code": one of ${languageCodes.join(", ")} }',
     ),
     // Todo: is there a way to pop the route from here?
     AppAction(

--- a/lib/views/components/dialogs/language_choice_dialog.dart
+++ b/lib/views/components/dialogs/language_choice_dialog.dart
@@ -89,11 +89,14 @@ class LanguageChoiceDialog extends StatelessWidget with DialogActionsMixin {
     // AppAction(name: "dismiss", callback: (_) {  }),
   ];
 
-  void setLanguageAPI(Map<String, dynamic> args) {
+  void setLanguageAPI(Map<String, dynamic> args, Function(bool, String) response) {
     final String languageCode = args["language_code"] ?? "--";
     final Language language = Language.definedValues.firstWhere((lang) => lang.code == languageCode, orElse: () => Language.noLanguage);
     if (language != Language.noLanguage){
       onChosen(language);
+      response(true, "Language set to ${language.nameNative} (${language.code})");
+    } else {
+      response(false, "Invalid language code: $languageCode");
     }
   }
 }

--- a/lib/views/components/dialogs/modal_dialog.dart
+++ b/lib/views/components/dialogs/modal_dialog.dart
@@ -4,6 +4,7 @@ import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:momento_booth/app_localizations.dart';
 import 'package:momento_booth/main.dart';
 import 'package:momento_booth/managers/project_manager.dart';
+import 'package:momento_booth/models/app_action.dart';
 import 'package:momento_booth/views/components/buttons/photo_booth_filled_button.dart';
 import 'package:momento_booth/views/components/dialogs/photo_booth_dialog.dart';
 import 'package:widgetbook/widgetbook.dart';
@@ -17,6 +18,7 @@ class ModalDialog extends StatelessWidget {
   final ModalDialogType? dialogType;
   final Widget body;
   final List<Widget>? actions;
+  final List<AppAction>? appActionsOverride;
   final VoidCallback? onDismiss;
 
   const ModalDialog({
@@ -27,6 +29,7 @@ class ModalDialog extends StatelessWidget {
     this.dialogType = ModalDialogType.info,
     required this.body,
     this.actions,
+    this.appActionsOverride,
     this.onDismiss,
   });
 
@@ -51,6 +54,7 @@ class ModalDialog extends StatelessWidget {
                   onPressed: onDismiss ?? () => Navigator.of(context).maybePop(),
                 ),
               ],
+          appActionsOverride: appActionsOverride,
         ),
       ),
     );

--- a/lib/views/components/dialogs/photo_booth_dialog.dart
+++ b/lib/views/components/dialogs/photo_booth_dialog.dart
@@ -17,7 +17,12 @@ class PhotoBoothDialog extends StatelessWidget {
   List<AppAction> get appActions {
     if (appActionsOverride != null) return appActionsOverride!;
     var buttons = actions.whereType<StatelessPhotoBoothButton>();
-    return buttons.map((button) => AppAction(name: button.title.toLowerCase().replaceAll(" ", "_"), callback: (_) { button.onPressed?.call(); })).toList();
+    return buttons.map((button) => AppAction(
+      name: button.title.toLowerCase().replaceAll(" ", "_"),
+      callback: (_) { button.onPressed?.call(); },
+      title: button.title,
+      description: 'Presses the "${button.title}" button in the ${title ?? "photo booth"} dialog.',
+    )).toList();
   }
 
   const PhotoBoothDialog({

--- a/lib/views/components/dialogs/photo_booth_dialog.dart
+++ b/lib/views/components/dialogs/photo_booth_dialog.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:momento_booth/extensions/build_context_extension.dart';
+import 'package:momento_booth/models/app_action.dart';
+import 'package:momento_booth/views/components/buttons/stateless_photo_booth_button.dart';
 
 class PhotoBoothDialog extends StatelessWidget {
 
@@ -10,6 +12,13 @@ class PhotoBoothDialog extends StatelessWidget {
   final Widget body;
   final EdgeInsets bodyPadding;
   final List<Widget> actions;
+  final List<AppAction>? appActionsOverride;
+
+  List<AppAction> get appActions {
+    if (appActionsOverride != null) return appActionsOverride!;
+    var buttons = actions.whereType<StatelessPhotoBoothButton>();
+    return buttons.map((button) => AppAction(name: button.title.toLowerCase().replaceAll(" ", "_"), callback: (_) { button.onPressed?.call(); })).toList();
+  }
 
   const PhotoBoothDialog({
     super.key,
@@ -20,6 +29,7 @@ class PhotoBoothDialog extends StatelessWidget {
     this.indicator,
     this.bodyPadding = const EdgeInsets.symmetric(horizontal: 4.0, vertical: 16.0),
     this.actions = const [],
+    this.appActionsOverride,
   });
 
   @override

--- a/lib/views/components/dialogs/photo_booth_dialog.dart
+++ b/lib/views/components/dialogs/photo_booth_dialog.dart
@@ -19,7 +19,7 @@ class PhotoBoothDialog extends StatelessWidget {
     var buttons = actions.whereType<StatelessPhotoBoothButton>();
     return buttons.map((button) => AppAction(
       name: button.title.toLowerCase().replaceAll(" ", "_"),
-      callback: (_) { button.onPressed?.call(); },
+      callback: (_, response) { button.onPressed?.call(); response(true, "Pressed ${button.title} button"); },
       title: button.title,
       description: 'Presses the "${button.title}" button in the ${title ?? "photo booth"} dialog.',
     )).toList();

--- a/lib/views/components/dialogs/print_dialog.dart
+++ b/lib/views/components/dialogs/print_dialog.dart
@@ -6,6 +6,7 @@ import 'package:momento_booth/main.dart';
 import 'package:momento_booth/managers/settings_manager.dart';
 import 'package:momento_booth/models/app_action.dart';
 import 'package:momento_booth/models/settings.dart';
+import 'package:momento_booth/utils/speech_phrases.dart';
 import 'package:momento_booth/views/components/buttons/photo_booth_filled_button.dart';
 import 'package:momento_booth/views/components/buttons/photo_booth_outlined_button.dart';
 import 'package:momento_booth/views/components/dialogs/dialog_actions_mixin.dart';
@@ -33,14 +34,16 @@ class PrintDialog extends StatefulWidget with DialogActionsMixin {
       name: "cancel",
       callback: (_) { onCancel(); },
       title: 'Cancel',
-      description: 'Presses the cancel button in the print dialog.'
+      description: 'Presses the cancel button in the print dialog.',
+      examples: cancelPhrases
     ),
     // Todo add arguments
     AppAction(
       name: "print",
       callback: (_) { onPrintPressed(PrintSize.normal, 1); },
       title: 'Print',
-      description: 'Presses the print button in the print dialog.'
+      description: 'Presses the print button in the print dialog.',
+      examples: printPhrases
     ),
   ];
 

--- a/lib/views/components/dialogs/print_dialog.dart
+++ b/lib/views/components/dialogs/print_dialog.dart
@@ -4,12 +4,14 @@ import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:momento_booth/app_localizations.dart';
 import 'package:momento_booth/main.dart';
 import 'package:momento_booth/managers/settings_manager.dart';
+import 'package:momento_booth/models/app_action.dart';
 import 'package:momento_booth/models/settings.dart';
 import 'package:momento_booth/views/components/buttons/photo_booth_filled_button.dart';
 import 'package:momento_booth/views/components/buttons/photo_booth_outlined_button.dart';
+import 'package:momento_booth/views/components/dialogs/dialog_actions_mixin.dart';
 import 'package:momento_booth/views/components/dialogs/modal_dialog.dart';
 
-class PrintDialog extends StatefulWidget {
+class PrintDialog extends StatefulWidget with DialogActionsMixin {
 
   final VoidCallback onCancel;
   final void Function(PrintSize size, int copies) onPrintPressed;
@@ -24,6 +26,13 @@ class PrintDialog extends StatefulWidget {
 
   @override
   State<PrintDialog> createState() => _PrintDialogState();
+
+  @override
+  List<AppAction> get actions => [
+    AppAction(name: "cancel", callback: (_) { onCancel(); }),
+    // Todo add arguments
+    AppAction(name: "print", callback: (_) { onPrintPressed(PrintSize.normal, 1); }),
+  ];
 
 }
 

--- a/lib/views/components/dialogs/print_dialog.dart
+++ b/lib/views/components/dialogs/print_dialog.dart
@@ -29,9 +29,19 @@ class PrintDialog extends StatefulWidget with DialogActionsMixin {
 
   @override
   List<AppAction> get actions => [
-    AppAction(name: "cancel", callback: (_) { onCancel(); }),
+    AppAction(
+      name: "cancel",
+      callback: (_) { onCancel(); },
+      title: 'Cancel',
+      description: 'Presses the cancel button in the print dialog.'
+    ),
     // Todo add arguments
-    AppAction(name: "print", callback: (_) { onPrintPressed(PrintSize.normal, 1); }),
+    AppAction(
+      name: "print",
+      callback: (_) { onPrintPressed(PrintSize.normal, 1); },
+      title: 'Print',
+      description: 'Presses the print button in the print dialog.'
+    ),
   ];
 
 }

--- a/lib/views/components/dialogs/print_dialog.dart
+++ b/lib/views/components/dialogs/print_dialog.dart
@@ -47,6 +47,9 @@ class PrintDialog extends StatefulWidget with DialogActionsMixin {
     ),
   ];
 
+  @override
+  String get scopeName => "Print Dialog";
+
 }
 
 class _PrintDialogState extends State<PrintDialog> {

--- a/lib/views/components/dialogs/print_dialog.dart
+++ b/lib/views/components/dialogs/print_dialog.dart
@@ -5,6 +5,7 @@ import 'package:momento_booth/app_localizations.dart';
 import 'package:momento_booth/main.dart';
 import 'package:momento_booth/managers/settings_manager.dart';
 import 'package:momento_booth/models/app_action.dart';
+import 'package:momento_booth/models/app_action_example.dart';
 import 'package:momento_booth/models/settings.dart';
 import 'package:momento_booth/utils/speech_phrases.dart';
 import 'package:momento_booth/views/base/has_actions_mixin.dart';
@@ -35,7 +36,7 @@ class _PrintDialogState extends State<PrintDialog> with HasActionsMixin {
   int numPrints = 1;
   PrintSize printSize = PrintSize.normal;
 
-  String get sizeEnumOptions => PrintSize.values.where((e) => e != PrintSize.split).map((e) => '"${e.name}"').join(", ");
+  List<String> get sizeEnumOptions => PrintSize.values.where((e) => e != PrintSize.split).map((e) => e.name).toList();
 
   @override
   List<AppAction> get actions => [
@@ -44,20 +45,20 @@ class _PrintDialogState extends State<PrintDialog> with HasActionsMixin {
       callback: (_, response) { widget.onCancel(); response(true, "Cancel button pressed"); },
       title: 'Cancel',
       description: 'Presses the cancel button in the print dialog.',
-      examples: cancelPhrases
+      examples: cancelPhrasesExamples
     ),
     AppAction(
       name: "set_copies",
       callback: setCopiesAPI,
       title: 'Set Copies',
       description: 'Sets the number of copies to print.',
-      inputSchema: '{ "type": "object", "properties": { "copies": { "type": "integer", "description": "The number of copies to print", "minimum": 1, "maximum": ${widget.maxPrints} } }, "required": ["copies"], "additionalProperties": false }',
+      inputSchema: { "type": "object", "properties": { "copies": { "type": "integer", "description": "The number of copies to print", "minimum": 1, "maximum": widget.maxPrints } }, "required": ["copies"], "additionalProperties": false },
       inputSchemaExample: '{ "copies": integer between 1 and ${widget.maxPrints} }',
       examples: [
-        "set copies to {copies}",
-        "make {copies} copies",
-        "change copies to {copies}",
-        "set number of copies to {copies}",
+        AppActionExample(phrase: "set copies to {copies:1}", arguments: { "copies": 1 }),
+        AppActionExample(phrase: "make {copies:three} copies", arguments: { "copies": 3 }),
+        AppActionExample(phrase: "change copies to {copies:four}", arguments: { "copies": 4 }),
+        AppActionExample(phrase: "set number of copies to {copies:2}", arguments: { "copies": 2 }),
       ],
     ),
     AppAction(
@@ -65,13 +66,13 @@ class _PrintDialogState extends State<PrintDialog> with HasActionsMixin {
       callback: setSizeAPI,
       title: 'Set Size',
       description: 'Sets the print size.',
-      inputSchema: '{ "type": "object", "properties": { "size": { "enum": [$sizeEnumOptions], "description": "The print size to set" } }, "required": ["size"], "additionalProperties": false }',
-      inputSchemaExample: '{ "size": one of [$sizeEnumOptions] }',
+      inputSchema: { "type": "object", "properties": { "size": { "enum": sizeEnumOptions, "description": "The print size to set" } }, "required": ["size"], "additionalProperties": false },
+      inputSchemaExample: '{ "size": one of ${sizeEnumOptions.map((e) => '"$e"').join(", ")} }',
       examples: [
-        "set print size to {size}",
-        "change print size to {size}",
-        "set size to {size}",
-        "change size to {size}",
+        AppActionExample(phrase: "set print size to {size:${PrintSize.normal.name}}", arguments: { "size": PrintSize.normal.name }),
+        AppActionExample(phrase: "change print size to {size:${PrintSize.small.name}}", arguments: { "size": PrintSize.small.name }),
+        AppActionExample(phrase: "set size to {size:${PrintSize.normal.name}}", arguments: { "size": PrintSize.normal.name }),
+        AppActionExample(phrase: "change size to {size:${PrintSize.tiny.name}}", arguments: { "size": PrintSize.tiny.name }),
       ],
     ),
     AppAction(
@@ -79,7 +80,7 @@ class _PrintDialogState extends State<PrintDialog> with HasActionsMixin {
       callback: (_, response) { widget.onPrintPressed(printSize, numPrints); response(true, "Print button pressed, printing $numPrints copies of $printSize size"); },
       title: 'Print',
       description: 'Presses the print button in the print dialog.',
-      examples: printPhrases
+      examples: printPhrasesExamples
     ),
   ];
 

--- a/lib/views/components/dialogs/print_dialog.dart
+++ b/lib/views/components/dialogs/print_dialog.dart
@@ -51,14 +51,28 @@ class _PrintDialogState extends State<PrintDialog> with HasActionsMixin {
       callback: setCopiesAPI,
       title: 'Set Copies',
       description: 'Sets the number of copies to print.',
-      inputSchema: '{ "type": "object", "properties": { "copies": { "type": "integer", "description": "The number of copies to print", "minimum": 1, "maximum": ${widget.maxPrints} } }, "required": ["copies"], "additionalProperties": false }'
+      inputSchema: '{ "type": "object", "properties": { "copies": { "type": "integer", "description": "The number of copies to print", "minimum": 1, "maximum": ${widget.maxPrints} } }, "required": ["copies"], "additionalProperties": false }',
+      inputSchemaExample: '{ "copies": integer between 1 and ${widget.maxPrints} }',
+      examples: [
+        "set copies to {copies}",
+        "make {copies} copies",
+        "change copies to {copies}",
+        "set number of copies to {copies}",
+      ],
     ),
     AppAction(
       name: "set_size",
       callback: setSizeAPI,
       title: 'Set Size',
       description: 'Sets the print size.',
-      inputSchema: '{ "type": "object", "properties": { "size": { "enum": [$sizeEnumOptions], "description": "The print size to set" } }, "required": ["size"], "additionalProperties": false }'
+      inputSchema: '{ "type": "object", "properties": { "size": { "enum": [$sizeEnumOptions], "description": "The print size to set" } }, "required": ["size"], "additionalProperties": false }',
+      inputSchemaExample: '{ "size": one of [$sizeEnumOptions] }',
+      examples: [
+        "set print size to {size}",
+        "change print size to {size}",
+        "set size to {size}",
+        "change size to {size}",
+      ],
     ),
     AppAction(
       name: "print",

--- a/lib/views/components/dialogs/print_dialog.dart
+++ b/lib/views/components/dialogs/print_dialog.dart
@@ -7,12 +7,12 @@ import 'package:momento_booth/managers/settings_manager.dart';
 import 'package:momento_booth/models/app_action.dart';
 import 'package:momento_booth/models/settings.dart';
 import 'package:momento_booth/utils/speech_phrases.dart';
+import 'package:momento_booth/views/base/has_actions_mixin.dart';
 import 'package:momento_booth/views/components/buttons/photo_booth_filled_button.dart';
 import 'package:momento_booth/views/components/buttons/photo_booth_outlined_button.dart';
-import 'package:momento_booth/views/components/dialogs/dialog_actions_mixin.dart';
 import 'package:momento_booth/views/components/dialogs/modal_dialog.dart';
 
-class PrintDialog extends StatefulWidget with DialogActionsMixin {
+class PrintDialog extends StatefulWidget {
 
   final VoidCallback onCancel;
   final void Function(PrintSize size, int copies) onPrintPressed;
@@ -28,34 +28,91 @@ class PrintDialog extends StatefulWidget with DialogActionsMixin {
   @override
   State<PrintDialog> createState() => _PrintDialogState();
 
+}
+
+class _PrintDialogState extends State<PrintDialog> with HasActionsMixin {
+
+  int numPrints = 1;
+  PrintSize printSize = PrintSize.normal;
+
+  String get sizeEnumOptions => PrintSize.values.where((e) => e != PrintSize.split).map((e) => '"${e.name}"').join(", ");
+
   @override
   List<AppAction> get actions => [
     AppAction(
       name: "cancel",
-      callback: (_, response) { onCancel(); response(true, "Cancel button pressed"); },
+      callback: (_, response) { widget.onCancel(); response(true, "Cancel button pressed"); },
       title: 'Cancel',
       description: 'Presses the cancel button in the print dialog.',
       examples: cancelPhrases
     ),
-    // Todo add arguments
+    AppAction(
+      name: "set_copies",
+      callback: setCopiesAPI,
+      title: 'Set Copies',
+      description: 'Sets the number of copies to print.',
+      inputSchema: '{ "type": "object", "properties": { "copies": { "type": "integer", "description": "The number of copies to print", "minimum": 1, "maximum": ${widget.maxPrints} } }, "required": ["copies"], "additionalProperties": false }'
+    ),
+    AppAction(
+      name: "set_size",
+      callback: setSizeAPI,
+      title: 'Set Size',
+      description: 'Sets the print size.',
+      inputSchema: '{ "type": "object", "properties": { "size": { "enum": [$sizeEnumOptions], "description": "The print size to set" } }, "required": ["size"], "additionalProperties": false }'
+    ),
     AppAction(
       name: "print",
-      callback: (_, response) { onPrintPressed(PrintSize.normal, 1); response(true, "Print button pressed"); },
+      callback: (_, response) { widget.onPrintPressed(printSize, numPrints); response(true, "Print button pressed, printing $numPrints copies of $printSize size"); },
       title: 'Print',
       description: 'Presses the print button in the print dialog.',
       examples: printPhrases
     ),
   ];
 
+  void setSizeAPI(Map<String, dynamic> params, Function(bool, String) response) {
+    final sizeStr = params["size"];
+    if (sizeStr == null) {
+      response(false, "Missing 'size' parameter");
+      return;
+    }
+    if (sizeStr is! String) {
+      response(false, "Invalid 'size' parameter: must be a string");
+      return;
+    }
+    final size = PrintSize.values.firstWhere((e) => e.name == sizeStr, orElse: () => PrintSize.normal);
+    setState(() => printSize = size);
+    response(true, "Print size set to $sizeStr");
+  }
+
+  void setCopiesAPI(Map<String, dynamic> params, Function(bool, String) response) {
+    final copiesParam = params["copies"];
+    if (copiesParam == null) {
+      response(false, "Missing 'copies' parameter");
+      return;
+    }
+    if (copiesParam is! int) {
+      response(false, "Invalid 'copies' parameter: must be an integer");
+      return;
+    }
+    final copies = copiesParam.clamp(1, widget.maxPrints);
+    setState(() => numPrints = copies);
+    response(true, "Number of copies set to $copies");
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    pushActions();
+  }
+
+  @override
+  void dispose() {
+    popActions();
+    super.dispose();
+  }
+
   @override
   String get scopeName => "Print Dialog";
-
-}
-
-class _PrintDialogState extends State<PrintDialog> {
-
-  int numPrints = 1;
-  PrintSize printSize = PrintSize.normal;
 
   int get gridX => switch (printSize) {
     PrintSize.small => getIt<SettingsManager>().settings.hardware.printLayoutSettings.gridSmall.x,

--- a/lib/views/components/dialogs/print_dialog.dart
+++ b/lib/views/components/dialogs/print_dialog.dart
@@ -32,7 +32,7 @@ class PrintDialog extends StatefulWidget with DialogActionsMixin {
   List<AppAction> get actions => [
     AppAction(
       name: "cancel",
-      callback: (_) { onCancel(); },
+      callback: (_, response) { onCancel(); response(true, "Cancel button pressed"); },
       title: 'Cancel',
       description: 'Presses the cancel button in the print dialog.',
       examples: cancelPhrases
@@ -40,7 +40,7 @@ class PrintDialog extends StatefulWidget with DialogActionsMixin {
     // Todo add arguments
     AppAction(
       name: "print",
-      callback: (_) { onPrintPressed(PrintSize.normal, 1); },
+      callback: (_, response) { onPrintPressed(PrintSize.normal, 1); response(true, "Print button pressed"); },
       title: 'Print',
       description: 'Presses the print button in the print dialog.',
       examples: printPhrases

--- a/lib/views/components/dialogs/qr_share_dialog.dart
+++ b/lib/views/components/dialogs/qr_share_dialog.dart
@@ -2,14 +2,16 @@ import 'package:fluent_ui/fluent_ui.dart';
 import 'package:lottie/lottie.dart';
 import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:momento_booth/app_localizations.dart';
+import 'package:momento_booth/models/app_action.dart';
 import 'package:momento_booth/views/components/buttons/photo_booth_filled_button.dart';
 import 'package:momento_booth/views/components/buttons/photo_booth_outlined_button.dart';
+import 'package:momento_booth/views/components/dialogs/dialog_actions_mixin.dart';
 import 'package:momento_booth/views/components/dialogs/modal_dialog.dart';
 import 'package:momento_booth/views/components/qr_code.dart';
 import 'package:widgetbook/widgetbook.dart';
 import 'package:widgetbook_annotation/widgetbook_annotation.dart';
 
-class QrShareDialog extends StatelessWidget {
+class QrShareDialog extends StatelessWidget with DialogActionsMixin {
 
   final ShareDialogState state;
   final double? uploadProgress;
@@ -157,6 +159,20 @@ class QrShareDialog extends StatelessWidget {
       ),
     );
   }
+
+  @override
+  List<AppAction> get actions => switch (state) {
+    // These are actually the same actions, but with different names
+    ShareDialogState.uploaded => [
+        AppAction(name: "redo_upload", callback: (_) { onRedoUpload(); }),
+        AppAction(name: "close", callback: (_) { onDismiss(); }),
+      ],
+    ShareDialogState.error => [
+        AppAction(name: "cancel", callback: (_) { onDismiss(); }),
+        AppAction(name: "retry_upload", callback: (_) { onRedoUpload(); }),
+      ],
+    _ => [],
+  };
 
 }
 

--- a/lib/views/components/dialogs/qr_share_dialog.dart
+++ b/lib/views/components/dialogs/qr_share_dialog.dart
@@ -164,12 +164,32 @@ class QrShareDialog extends StatelessWidget with DialogActionsMixin {
   List<AppAction> get actions => switch (state) {
     // These are actually the same actions, but with different names
     ShareDialogState.uploaded => [
-        AppAction(name: "redo_upload", callback: (_) { onRedoUpload(); }),
-        AppAction(name: "close", callback: (_) { onDismiss(); }),
+        AppAction(
+          name: "redo_upload",
+          callback: (_) { onRedoUpload(); },
+          title: "Redo Upload",
+          description: "Start the upload process again to get a new QR code",
+        ),
+        AppAction(
+          name: "close",
+          callback: (_) { onDismiss(); },
+          title: "Close",
+          description: "Close the QR sharing dialog.",
+        ),
       ],
     ShareDialogState.error => [
-        AppAction(name: "cancel", callback: (_) { onDismiss(); }),
-        AppAction(name: "retry_upload", callback: (_) { onRedoUpload(); }),
+        AppAction(
+          name: "cancel",
+          callback: (_) { onDismiss(); },
+          title: "Cancel",
+          description: "Cancel the upload process.",
+        ),
+        AppAction(
+          name: "retry_upload",
+          callback: (_) { onRedoUpload(); },
+          title: "Retry Upload",
+          description: "After an error has occurred, this will try uploading the photo again.",
+        ),
       ],
     _ => [],
   };

--- a/lib/views/components/dialogs/qr_share_dialog.dart
+++ b/lib/views/components/dialogs/qr_share_dialog.dart
@@ -5,23 +5,22 @@ import 'package:lottie/lottie.dart';
 import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:momento_booth/app_localizations.dart';
 import 'package:momento_booth/main.dart';
-import 'package:momento_booth/managers/action_manager.dart';
 import 'package:momento_booth/managers/settings_manager.dart';
 import 'package:momento_booth/managers/stats_manager.dart';
 import 'package:momento_booth/models/app_action.dart';
 import 'package:momento_booth/src/rust/api/ffsend.dart';
 import 'package:momento_booth/src/rust/utils/ffsend_client.dart';
 import 'package:momento_booth/utils/logger.dart';
+import 'package:momento_booth/views/base/has_actions_mixin.dart';
 import 'package:momento_booth/views/components/buttons/photo_booth_filled_button.dart';
 import 'package:momento_booth/views/components/buttons/photo_booth_outlined_button.dart';
-import 'package:momento_booth/views/components/dialogs/dialog_actions_mixin.dart';
 import 'package:momento_booth/views/components/dialogs/modal_dialog.dart';
 import 'package:momento_booth/views/components/qr_code.dart';
 import 'package:path/path.dart' as path;
 // import 'package:widgetbook/widgetbook.dart';
 // import 'package:widgetbook_annotation/widgetbook_annotation.dart';
 
-class QrShareDialog extends StatefulWidget with DialogActionsMixin {
+class QrShareDialog extends StatefulWidget {
 
   final File file;
   final VoidCallback onDismiss;
@@ -36,16 +35,9 @@ class QrShareDialog extends StatefulWidget with DialogActionsMixin {
 
   @override
   State<QrShareDialog> createState() => _QrShareDialogState();
-  
-  @override
-  // This list is empty because the state manages the actions itself, based on the current state of the upload process
-  List<AppAction> get actions => [];
-
-  @override
-  String get scopeName => "QR Share Dialog";
 }
 
-class _QrShareDialogState extends State<QrShareDialog> with Logger {
+class _QrShareDialogState extends State<QrShareDialog> with Logger, HasActionsMixin {
   ShareDialogState _state = ShareDialogState.uploading;
   double? uploadProgress;
   String? qrText;
@@ -56,6 +48,9 @@ class _QrShareDialogState extends State<QrShareDialog> with Logger {
   }
 
   ShareDialogState get state => _state;
+
+  @override
+  String get scopeName => "QR Share Dialog";
 
   @override
   void initState() {
@@ -236,10 +231,7 @@ class _QrShareDialogState extends State<QrShareDialog> with Logger {
     });
   }
 
-  void pushActions() {
-    getIt<ActionManager>().pushActions(actions, "QRShareDialog", widget.actionsToken);
-  }
-
+  @override
   List<AppAction> get actions => switch (state) {
     // These are actually the same actions, but with different names
     ShareDialogState.uploaded => [

--- a/lib/views/components/dialogs/qr_share_dialog.dart
+++ b/lib/views/components/dialogs/qr_share_dialog.dart
@@ -1,32 +1,67 @@
+import 'dart:io';
+
 import 'package:fluent_ui/fluent_ui.dart';
 import 'package:lottie/lottie.dart';
 import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:momento_booth/app_localizations.dart';
+import 'package:momento_booth/main.dart';
+import 'package:momento_booth/managers/action_manager.dart';
+import 'package:momento_booth/managers/settings_manager.dart';
+import 'package:momento_booth/managers/stats_manager.dart';
 import 'package:momento_booth/models/app_action.dart';
+import 'package:momento_booth/src/rust/api/ffsend.dart';
+import 'package:momento_booth/src/rust/utils/ffsend_client.dart';
+import 'package:momento_booth/utils/logger.dart';
 import 'package:momento_booth/views/components/buttons/photo_booth_filled_button.dart';
 import 'package:momento_booth/views/components/buttons/photo_booth_outlined_button.dart';
 import 'package:momento_booth/views/components/dialogs/dialog_actions_mixin.dart';
 import 'package:momento_booth/views/components/dialogs/modal_dialog.dart';
 import 'package:momento_booth/views/components/qr_code.dart';
-import 'package:widgetbook/widgetbook.dart';
-import 'package:widgetbook_annotation/widgetbook_annotation.dart';
+import 'package:path/path.dart' as path;
+// import 'package:widgetbook/widgetbook.dart';
+// import 'package:widgetbook_annotation/widgetbook_annotation.dart';
 
-class QrShareDialog extends StatelessWidget with DialogActionsMixin {
+class QrShareDialog extends StatefulWidget with DialogActionsMixin {
 
-  final ShareDialogState state;
-  final double? uploadProgress;
-  final String? qrText;
-  final VoidCallback onRedoUpload;
+  final File file;
   final VoidCallback onDismiss;
+  final Object actionsToken;
 
   const QrShareDialog({
     super.key,
-    required this.state,
-    this.uploadProgress,
-    this.qrText,
-    required this.onRedoUpload,
+    required this.file,
     required this.onDismiss,
+    required this.actionsToken,
   });
+
+  @override
+  State<QrShareDialog> createState() => _QrShareDialogState();
+  
+  @override
+  // This list is empty because the state manages the actions itself, based on the current state of the upload process
+  List<AppAction> get actions => [];
+
+  @override
+  String get scopeName => "QR Share Dialog";
+}
+
+class _QrShareDialogState extends State<QrShareDialog> with Logger {
+  ShareDialogState _state = ShareDialogState.uploading;
+  double? uploadProgress;
+  String? qrText;
+
+  set state(ShareDialogState newState) {
+    _state = newState;
+    pushActions();
+  }
+
+  ShareDialogState get state => _state;
+
+  @override
+  void initState() {
+    super.initState();
+    uploadPhotoToSend();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -50,23 +85,23 @@ class QrShareDialog extends StatelessWidget with DialogActionsMixin {
             PhotoBoothOutlinedButton(
               title: localizations.qrDialogExtraDownloadButton,
               icon: LucideIcons.repeat,
-              onPressed: onRedoUpload,
+              onPressed: uploadPhotoToSend,
             ),
             PhotoBoothFilledButton(
               title: localizations.genericCloseButton,
               icon: LucideIcons.check,
-              onPressed: onDismiss,
+              onPressed: widget.onDismiss,
             ),
           ],
         ShareDialogState.error => [
             PhotoBoothOutlinedButton(
               title: localizations.genericCancelButton,
-              onPressed: onDismiss,
+              onPressed: widget.onDismiss,
             ),
             PhotoBoothFilledButton(
               title: localizations.genericRetryButton,
               icon: LucideIcons.check,
-              onPressed: onRedoUpload,
+              onPressed: uploadPhotoToSend,
             ),
           ],
         _ => const [],
@@ -160,19 +195,63 @@ class QrShareDialog extends StatelessWidget with DialogActionsMixin {
     );
   }
 
-  @override
+  Future<void> uploadPhotoToSend() async {
+    logDebug("Uploading ${widget.file.path}");
+    setState(() {
+      state = ShareDialogState.uploading;
+      uploadProgress = 0.0;
+    });
+    String ffSendUrl = getIt<SettingsManager>().settings.output.firefoxSendServerUrl;
+
+    String basename = path.basename(widget.file.path);
+    Stream<FfSendTransferProgress> stream = ffsendUploadFile(
+      filePath: widget.file.path,
+      hostUrl: ffSendUrl,
+      downloadFilename: basename,
+      controlCommandTimeout: getIt<SettingsManager>().settings.output.firefoxSendControlCommandTimeout,
+      transferTimeout: getIt<SettingsManager>().settings.output.firefoxSendTransferTimeout,
+    );
+
+    uploadProgress = 0.0;
+
+    stream.listen((event) async {
+      if (event.isFinished) {
+        logDebug("Upload complete: ${event.downloadUrl}");
+
+        await Future.delayed(const Duration(milliseconds: 500));
+        qrText = event.downloadUrl;
+        uploadProgress = null;
+
+        getIt<StatsManager>().addUploadedPhoto();
+        setState(() => state = ShareDialogState.uploaded);
+      } else {
+        logDebug("Uploading: ${event.transferredBytes}/${event.totalBytes} bytes");
+        setState(() => uploadProgress = event.transferredBytes / (event.totalBytes ?? 0));
+      }
+    }).onError((x) async {
+      logError("Upload failed, file path: ${widget.file.path}", x);
+      await Future.delayed(const Duration(seconds: 1));
+      setState(() => uploadProgress = null);
+      setState(() => state = ShareDialogState.error);
+    });
+  }
+
+  void pushActions() {
+    getIt<ActionManager>().pushActions(actions, "QRShareDialog", widget.actionsToken);
+  }
+
   List<AppAction> get actions => switch (state) {
     // These are actually the same actions, but with different names
     ShareDialogState.uploaded => [
         AppAction(
           name: "redo_upload",
-          callback: (_, response) { onRedoUpload(); response(true, "Redo upload button pressed"); },
+          callback: (_, response) { uploadPhotoToSend(); response(true, "Redo upload button pressed"); },
           title: "Redo Upload",
           description: "Start the upload process again to get a new QR code",
         ),
         AppAction(
           name: "close",
-          callback: (_, response) { onDismiss(); response(true, "Close button pressed"); },
+          callback: (_, response) { widget.onDismiss(); response(true, "Close button pressed"); },
           title: "Close",
           description: "Close the QR sharing dialog.",
         ),
@@ -180,20 +259,19 @@ class QrShareDialog extends StatelessWidget with DialogActionsMixin {
     ShareDialogState.error => [
         AppAction(
           name: "cancel",
-          callback: (_, response) { onDismiss(); response(true, "Cancel button pressed"); },
+          callback: (_, response) { widget.onDismiss(); response(true, "Cancel button pressed"); },
           title: "Cancel",
           description: "Cancel the upload process.",
         ),
         AppAction(
           name: "retry_upload",
-          callback: (_, response) { onRedoUpload(); response(true, "Retry upload button pressed"); },
+          callback: (_, response) { uploadPhotoToSend(); response(true, "Retry upload button pressed"); },
           title: "Retry Upload",
           description: "After an error has occurred, this will try uploading the photo again.",
         ),
       ],
     _ => [],
   };
-
 }
 
 enum ShareDialogState {
@@ -202,7 +280,8 @@ enum ShareDialogState {
   error,
 }
 
-@UseCase(name: 'QR Share Dialog', type: QrShareDialog)
+// Todo: figure out how to re-enable this now that the widget is stateful.
+/*@UseCase(name: 'QR Share Dialog', type: QrShareDialog)
 Widget qrShareDialog(BuildContext context) {
   return QrShareDialog(
     state: context.knobs.object.dropdown(label: 'State', initialOption: ShareDialogState.uploading, options: ShareDialogState.values),
@@ -211,4 +290,4 @@ Widget qrShareDialog(BuildContext context) {
     onRedoUpload: () {},
     onDismiss: () {},
   );
-}
+}*/

--- a/lib/views/components/dialogs/qr_share_dialog.dart
+++ b/lib/views/components/dialogs/qr_share_dialog.dart
@@ -11,6 +11,7 @@ import 'package:momento_booth/models/app_action.dart';
 import 'package:momento_booth/src/rust/api/ffsend.dart';
 import 'package:momento_booth/src/rust/utils/ffsend_client.dart';
 import 'package:momento_booth/utils/logger.dart';
+import 'package:momento_booth/utils/speech_phrases.dart';
 import 'package:momento_booth/views/base/has_actions_mixin.dart';
 import 'package:momento_booth/views/components/buttons/photo_booth_filled_button.dart';
 import 'package:momento_booth/views/components/buttons/photo_booth_outlined_button.dart';
@@ -240,12 +241,19 @@ class _QrShareDialogState extends State<QrShareDialog> with Logger, HasActionsMi
           callback: (_, response) { uploadPhotoToSend(); response(true, "Redo upload button pressed"); },
           title: "Redo Upload",
           description: "Start the upload process again to get a new QR code",
+          examples: [
+            "redo upload",
+            "upload again",
+            "upload another one",
+            "get me a new QR code",
+          ],
         ),
         AppAction(
           name: "close",
           callback: (_, response) { widget.onDismiss(); response(true, "Close button pressed"); },
           title: "Close",
           description: "Close the QR sharing dialog.",
+          examples: cancelPhrases
         ),
       ],
     ShareDialogState.error => [
@@ -254,12 +262,18 @@ class _QrShareDialogState extends State<QrShareDialog> with Logger, HasActionsMi
           callback: (_, response) { widget.onDismiss(); response(true, "Cancel button pressed"); },
           title: "Cancel",
           description: "Cancel the upload process.",
+          examples: cancelPhrases
         ),
         AppAction(
           name: "retry_upload",
           callback: (_, response) { uploadPhotoToSend(); response(true, "Retry upload button pressed"); },
           title: "Retry Upload",
           description: "After an error has occurred, this will try uploading the photo again.",
+          examples: [
+            "try again",
+            "retry upload",
+            "try uploading again",
+          ],
         ),
       ],
     _ => [],

--- a/lib/views/components/dialogs/qr_share_dialog.dart
+++ b/lib/views/components/dialogs/qr_share_dialog.dart
@@ -166,13 +166,13 @@ class QrShareDialog extends StatelessWidget with DialogActionsMixin {
     ShareDialogState.uploaded => [
         AppAction(
           name: "redo_upload",
-          callback: (_) { onRedoUpload(); },
+          callback: (_, response) { onRedoUpload(); response(true, "Redo upload button pressed"); },
           title: "Redo Upload",
           description: "Start the upload process again to get a new QR code",
         ),
         AppAction(
           name: "close",
-          callback: (_) { onDismiss(); },
+          callback: (_, response) { onDismiss(); response(true, "Close button pressed"); },
           title: "Close",
           description: "Close the QR sharing dialog.",
         ),
@@ -180,13 +180,13 @@ class QrShareDialog extends StatelessWidget with DialogActionsMixin {
     ShareDialogState.error => [
         AppAction(
           name: "cancel",
-          callback: (_) { onDismiss(); },
+          callback: (_, response) { onDismiss(); response(true, "Cancel button pressed"); },
           title: "Cancel",
           description: "Cancel the upload process.",
         ),
         AppAction(
           name: "retry_upload",
-          callback: (_) { onRedoUpload(); },
+          callback: (_, response) { onRedoUpload(); response(true, "Retry upload button pressed"); },
           title: "Retry Upload",
           description: "After an error has occurred, this will try uploading the photo again.",
         ),

--- a/lib/views/components/dialogs/qr_share_dialog.dart
+++ b/lib/views/components/dialogs/qr_share_dialog.dart
@@ -8,6 +8,7 @@ import 'package:momento_booth/main.dart';
 import 'package:momento_booth/managers/settings_manager.dart';
 import 'package:momento_booth/managers/stats_manager.dart';
 import 'package:momento_booth/models/app_action.dart';
+import 'package:momento_booth/models/app_action_example.dart';
 import 'package:momento_booth/src/rust/api/ffsend.dart';
 import 'package:momento_booth/src/rust/utils/ffsend_client.dart';
 import 'package:momento_booth/utils/logger.dart';
@@ -246,14 +247,14 @@ class _QrShareDialogState extends State<QrShareDialog> with Logger, HasActionsMi
             "upload again",
             "upload another one",
             "get me a new QR code",
-          ],
+          ].map((phrase) => AppActionExample(phrase: phrase)).toList(),
         ),
         AppAction(
           name: "close",
           callback: (_, response) { widget.onDismiss(); response(true, "Close button pressed"); },
           title: "Close",
           description: "Close the QR sharing dialog.",
-          examples: cancelPhrases
+          examples: cancelPhrasesExamples
         ),
       ],
     ShareDialogState.error => [
@@ -262,7 +263,7 @@ class _QrShareDialogState extends State<QrShareDialog> with Logger, HasActionsMi
           callback: (_, response) { widget.onDismiss(); response(true, "Cancel button pressed"); },
           title: "Cancel",
           description: "Cancel the upload process.",
-          examples: cancelPhrases
+          examples: cancelPhrasesExamples
         ),
         AppAction(
           name: "retry_upload",
@@ -273,7 +274,7 @@ class _QrShareDialogState extends State<QrShareDialog> with Logger, HasActionsMi
             "try again",
             "retry upload",
             "try uploading again",
-          ],
+          ].map((phrase) => AppActionExample(phrase: phrase)).toList(),
         ),
       ],
     _ => [],

--- a/lib/views/components/dialogs/qr_share_dialog.dart
+++ b/lib/views/components/dialogs/qr_share_dialog.dart
@@ -26,13 +26,11 @@ class QrShareDialog extends StatefulWidget {
 
   final File file;
   final VoidCallback onDismiss;
-  final Object actionsToken;
 
   const QrShareDialog({
     super.key,
     required this.file,
     required this.onDismiss,
-    required this.actionsToken,
   });
 
   @override

--- a/lib/views/components/dialogs/retake_dialog.dart
+++ b/lib/views/components/dialogs/retake_dialog.dart
@@ -1,11 +1,13 @@
 import 'package:fluent_ui/fluent_ui.dart';
 import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:momento_booth/app_localizations.dart';
+import 'package:momento_booth/models/app_action.dart';
 import 'package:momento_booth/views/components/buttons/photo_booth_filled_button.dart';
 import 'package:momento_booth/views/components/buttons/photo_booth_outlined_button.dart';
+import 'package:momento_booth/views/components/dialogs/dialog_actions_mixin.dart';
 import 'package:momento_booth/views/components/dialogs/modal_dialog.dart';
 
-class RetakeDialog extends StatelessWidget {
+class RetakeDialog extends StatelessWidget with DialogActionsMixin {
 
   final VoidCallback onDelete;
   final VoidCallback onKeep;
@@ -44,5 +46,12 @@ class RetakeDialog extends StatelessWidget {
       ],
     );
   }
+
+  @override
+  List<AppAction> get actions => [
+    AppAction(name: "cancel", callback: (_) { onCancel(); }),
+    AppAction(name: "keep", callback: (_) { onKeep(); }),
+    AppAction(name: "delete", callback: (_) { onDelete(); }),
+  ];
 
 }

--- a/lib/views/components/dialogs/retake_dialog.dart
+++ b/lib/views/components/dialogs/retake_dialog.dart
@@ -2,6 +2,7 @@ import 'package:fluent_ui/fluent_ui.dart';
 import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:momento_booth/app_localizations.dart';
 import 'package:momento_booth/models/app_action.dart';
+import 'package:momento_booth/utils/speech_phrases.dart';
 import 'package:momento_booth/views/components/buttons/photo_booth_filled_button.dart';
 import 'package:momento_booth/views/components/buttons/photo_booth_outlined_button.dart';
 import 'package:momento_booth/views/components/dialogs/dialog_actions_mixin.dart';
@@ -54,18 +55,21 @@ class RetakeDialog extends StatelessWidget with DialogActionsMixin {
       callback: (_) { onCancel(); },
       title: 'Cancel',
       description: 'Close the dialog and keep the current photo.',
+      examples: cancelPhrases,
     ),
     AppAction(
       name: "keep",
       callback: (_) { onKeep(); },
       title: 'Keep',
       description: 'Keep the current photo and start a new capture.',
+      examples: const ["keep", "save", "keep photo", "keep picture", "don't delete", "don't delete photo", "don't delete picture"],
     ),
     AppAction(
       name: "delete",
       callback: (_) { onDelete(); },
       title: 'Delete',
       description: 'Delete the current photo and start a new capture.',
+      examples: const ["delete", "trash", "delete photo", "delete picture", "retake", "take again", "take new photo"],
     ),
   ];
 

--- a/lib/views/components/dialogs/retake_dialog.dart
+++ b/lib/views/components/dialogs/retake_dialog.dart
@@ -49,9 +49,24 @@ class RetakeDialog extends StatelessWidget with DialogActionsMixin {
 
   @override
   List<AppAction> get actions => [
-    AppAction(name: "cancel", callback: (_) { onCancel(); }),
-    AppAction(name: "keep", callback: (_) { onKeep(); }),
-    AppAction(name: "delete", callback: (_) { onDelete(); }),
+    AppAction(
+      name: "cancel",
+      callback: (_) { onCancel(); },
+      title: 'Cancel',
+      description: 'Close the dialog and keep the current photo.',
+    ),
+    AppAction(
+      name: "keep",
+      callback: (_) { onKeep(); },
+      title: 'Keep',
+      description: 'Keep the current photo and start a new capture.',
+    ),
+    AppAction(
+      name: "delete",
+      callback: (_) { onDelete(); },
+      title: 'Delete',
+      description: 'Delete the current photo and start a new capture.',
+    ),
   ];
 
 }

--- a/lib/views/components/dialogs/retake_dialog.dart
+++ b/lib/views/components/dialogs/retake_dialog.dart
@@ -52,21 +52,21 @@ class RetakeDialog extends StatelessWidget with DialogActionsMixin {
   List<AppAction> get actions => [
     AppAction(
       name: "cancel",
-      callback: (_) { onCancel(); },
+      callback: (_, response) { onCancel(); response(true, "Cancel button pressed"); },
       title: 'Cancel',
       description: 'Close the dialog and keep the current photo.',
       examples: cancelPhrases,
     ),
     AppAction(
       name: "keep",
-      callback: (_) { onKeep(); },
+      callback: (_, response) { onKeep(); response(true, "Keep button pressed"); },
       title: 'Keep',
       description: 'Keep the current photo and start a new capture.',
       examples: const ["keep", "save", "keep photo", "keep picture", "don't delete", "don't delete photo", "don't delete picture"],
     ),
     AppAction(
       name: "delete",
-      callback: (_) { onDelete(); },
+      callback: (_, response) { onDelete(); response(true, "Delete button pressed"); },
       title: 'Delete',
       description: 'Delete the current photo and start a new capture.',
       examples: const ["delete", "trash", "delete photo", "delete picture", "retake", "take again", "take new photo"],

--- a/lib/views/components/dialogs/retake_dialog.dart
+++ b/lib/views/components/dialogs/retake_dialog.dart
@@ -2,6 +2,7 @@ import 'package:fluent_ui/fluent_ui.dart';
 import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:momento_booth/app_localizations.dart';
 import 'package:momento_booth/models/app_action.dart';
+import 'package:momento_booth/models/app_action_example.dart';
 import 'package:momento_booth/utils/speech_phrases.dart';
 import 'package:momento_booth/views/components/buttons/photo_booth_filled_button.dart';
 import 'package:momento_booth/views/components/buttons/photo_booth_outlined_button.dart';
@@ -55,21 +56,21 @@ class RetakeDialog extends StatelessWidget with DialogActionsMixin {
       callback: (_, response) { onCancel(); response(true, "Cancel button pressed"); },
       title: 'Cancel',
       description: 'Close the dialog and keep the current photo.',
-      examples: cancelPhrases,
+      examples: cancelPhrasesExamples,
     ),
     AppAction(
       name: "keep",
       callback: (_, response) { onKeep(); response(true, "Keep button pressed"); },
       title: 'Keep',
       description: 'Keep the current photo and start a new capture.',
-      examples: const ["keep", "save", "keep photo", "keep picture", "don't delete", "don't delete photo", "don't delete picture"],
+      examples: const ["keep", "save", "keep photo", "keep picture", "don't delete", "don't delete photo", "don't delete picture"].map((phrase) => AppActionExample(phrase: phrase)).toList(),
     ),
     AppAction(
       name: "delete",
       callback: (_, response) { onDelete(); response(true, "Delete button pressed"); },
       title: 'Delete',
       description: 'Delete the current photo and start a new capture.',
-      examples: const ["delete", "trash", "delete photo", "delete picture", "retake", "take again", "take new photo"],
+      examples: const ["delete", "trash", "delete photo", "delete picture", "retake", "take again", "take new photo"].map((phrase) => AppActionExample(phrase: phrase)).toList(),
     ),
   ];
 

--- a/lib/views/components/dialogs/retake_dialog.dart
+++ b/lib/views/components/dialogs/retake_dialog.dart
@@ -73,4 +73,7 @@ class RetakeDialog extends StatelessWidget with DialogActionsMixin {
     ),
   ];
 
+  @override
+  String get scopeName => "Retake Dialog";
+
 }

--- a/lib/views/components/imaging/live_view_background.dart
+++ b/lib/views/components/imaging/live_view_background.dart
@@ -9,6 +9,7 @@ import 'package:momento_booth/managers/_all.dart';
 import 'package:momento_booth/models/settings.dart';
 import 'package:momento_booth/models/subsystem_status.dart';
 import 'package:momento_booth/views/components/imaging/live_view.dart';
+import 'package:momento_booth/views/components/indicators/pill_container.dart';
 import 'package:momento_booth/views/photo_booth_screen/screens/gallery_screen/gallery_screen.dart';
 import 'package:momento_booth/views/photo_booth_screen/screens/manual_collage_screen/manual_collage_screen.dart';
 import 'package:momento_booth/views/photo_booth_screen/screens/photo_details_screen/photo_details_screen.dart';
@@ -58,6 +59,7 @@ class _LiveViewBackgroundState extends State<LiveViewBackground> {
         _viewState,
         widget.child,
         _statusOverlay,
+        _notificationOverlay,
       ],
     );
   }
@@ -70,13 +72,28 @@ class _LiveViewBackgroundState extends State<LiveViewBackground> {
           mainAxisAlignment: MainAxisAlignment.start,
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            for (InfoBar notification in getIt<NotificationsManager>().notifications) ...[
+            for (InfoBar notification in getIt<NotificationsManager>().statusNotifications) ...[
               notification,
               const SizedBox(height: 8),
             ],
           ],
         ),
       ),
+    );
+  }
+
+  Widget get _notificationOverlay {
+    return Padding(
+      padding: const EdgeInsets.all(30),
+      child: Align(
+        alignment: Alignment.bottomCenter,
+        child: Observer(
+          builder: (context) => PillContainer(
+              text: getIt<NotificationsManager>().notification,
+              visible: getIt<NotificationsManager>().notification.isNotEmpty,
+            ),
+          ),
+        ),
     );
   }
 

--- a/lib/views/components/indicators/pill_container.dart
+++ b/lib/views/components/indicators/pill_container.dart
@@ -1,0 +1,74 @@
+import 'dart:ui';
+import 'package:flutter/material.dart';
+import 'package:momento_booth/extensions/build_context_extension.dart';
+
+/// A pill-shaped animated overlay with a frosted glass effect.
+class PillContainer extends StatelessWidget {
+  /// The text to display inside the pill.
+  final String text;
+  /// Whether the pill is currently visible.
+  final bool visible;
+
+  const PillContainer({
+    super.key,
+    required this.text,
+    required this.visible,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    const brightness = 1.2;
+    const blurSigma = 10.0;
+    const borderRadius = 40.0;
+
+    return Align(
+      alignment: Alignment.bottomCenter,
+      child: AnimatedSwitcher(
+        duration: const Duration(milliseconds: 400),
+        transitionBuilder: (child, animation) {
+          return ScaleTransition(
+            scale: CurvedAnimation(parent: animation, curve: Curves.easeOutBack),
+            child: FadeTransition(opacity: animation, child: child),
+          );
+        },
+        child: visible
+            ? ClipRRect(
+              borderRadius: BorderRadius.circular(borderRadius),
+              child: BackdropFilter(
+                filter: ImageFilter.compose(
+                  outer: ImageFilter.blur(sigmaX: blurSigma, sigmaY: blurSigma),
+                  inner: ColorFilter.matrix([
+                    // Increases brightness slightly to mimic the vibrancy effect
+                    brightness, 0, 0, 0, 10,
+                    0, brightness, 0, 0, 10,
+                    0, 0, brightness, 0, 10,
+                    0, 0, 0, 1, 0,
+                  ]),
+                ),
+                child: Container(
+                  padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
+                  decoration: BoxDecoration(
+                    color: Colors.white.withValues(alpha: 0.5),
+                    borderRadius: BorderRadius.circular(borderRadius),
+                    border: Border.all(color: Colors.white.withValues(alpha: 0.3)),
+                    boxShadow: [
+                      BoxShadow(
+                        color: Colors.black.withValues(alpha: 0.1),
+                        blurRadius: 10,
+                        offset: const Offset(0, 4),
+                        spreadRadius: 2,
+                      ),
+                    ],
+                  ),
+                  child: Text(
+                    text,
+                    style: context.theme.subtitleTheme.style.copyWith(color: Colors.black, fontSize: 40, height: 1, shadows: []),
+                  ),
+                ),
+              ),
+            )
+            : const SizedBox.shrink(),
+      ),
+    );
+  }
+}

--- a/lib/views/photo_booth_screen/components/activity_monitor.dart
+++ b/lib/views/photo_booth_screen/components/activity_monitor.dart
@@ -121,6 +121,7 @@ class _ActivityMonitorState extends State<ActivityMonitor> with Logger {
       getIt<StatsManager>().addTap();
       getIt<SfxManager>().playClickSound();
     }
+    getIt<ActionManager>().registerPhysicalAction();
     _resetTimer();
   }
 

--- a/lib/views/photo_booth_screen/screens/collage_maker_screen/collage_maker_screen_controller.dart
+++ b/lib/views/photo_booth_screen/screens/collage_maker_screen/collage_maker_screen_controller.dart
@@ -25,7 +25,7 @@ class CollageMakerScreenController extends ScreenControllerBase<CollageMakerScre
       callback: selectPicturesAPI,
       title: "Select Pictures",
       description: "Choose pictures to include in the collage.",
-      inputSchema: '{ "type": "object", "properties": { "selected": { "type": "array", "items": { "type": "integer", "minimum": 0, "maximum": 3 } }, "minItems": 0, "maxItems": 4 }, "description": "The indices of the selected pictures, 0-indexed" }, "required": ["selected"], "additionalProperties": false }'
+      inputSchema: '{ "type": "object", "properties": { "selected": { "type": "array", "items": { "type": "integer", "minimum": 0, "maximum": 3 }, "minItems": 0, "maxItems": 4 }}, "description": "The indices of the selected pictures, 0-indexed", "required": ["selected"], "additionalProperties": false }'
     ),
     AppAction(
       name: "continue",

--- a/lib/views/photo_booth_screen/screens/collage_maker_screen/collage_maker_screen_controller.dart
+++ b/lib/views/photo_booth_screen/screens/collage_maker_screen/collage_maker_screen_controller.dart
@@ -3,6 +3,7 @@ import 'package:flutter/widgets.dart';
 import 'package:momento_booth/main.dart';
 import 'package:momento_booth/managers/photos_manager.dart';
 import 'package:momento_booth/models/app_action.dart';
+import 'package:momento_booth/utils/speech_phrases.dart';
 import 'package:momento_booth/views/base/screen_controller_base.dart';
 import 'package:momento_booth/views/components/imaging/photo_collage.dart';
 import 'package:momento_booth/views/photo_booth_screen/notifications/activity_timeout_callback.dart';
@@ -25,24 +26,41 @@ class CollageMakerScreenController extends ScreenControllerBase<CollageMakerScre
       callback: selectPicturesAPI,
       title: "Select Pictures",
       description: "Choose pictures to include in the collage.",
-      inputSchema: '{ "type": "object", "properties": { "selected": { "type": "array", "items": { "type": "integer", "minimum": 0, "maximum": 3 }, "minItems": 0, "maxItems": 4 }}, "description": "The indices of the selected pictures, 0-indexed", "required": ["selected"], "additionalProperties": false }'
+      inputSchema: '{ "type": "object", "properties": { "selected": { "type": "array", "items": { "type": "integer", "minimum": 1, "maximum": 4 }, "minItems": 0, "maxItems": 4 }}, "description": "The indices of the selected pictures, 1-indexed", "required": ["selected"], "additionalProperties": false }',
+      examples: const [
+        "select picture {selected}, {selected} and {selected}",
+        "select picture {selected} and {second}",
+        "select picture {selected}",
+        "select the {selected} picture",
+        "select the {selected} and {selected} picture",
+        "select the {selected}, {selected}, and {selected} picture",
+      ],
     ),
     AppAction(
       name: "continue",
       callback: (_) { onContinueTap(); },
       title: "Continue",
-      description: "Proceed to the share screen."
+      description: "Proceed to the share screen.",
+      examples: continuePhrases,
     ),
     AppAction(
-      name: "select_all_pictures_and_continue",
+      name: "select_all_pictures",
       callback: (_) {
         getIt<PhotosManager>().chosen
           ..clear()
           ..addAll([0, 1, 2, 3]);
-        onContinueTap();
       },
-      title: "Select All Pictures and Continue",
-      description: "Select all captured pictures, create the collage, and proceed to the share screen."
+      title: "Select All Pictures",
+      description: "Select all captured pictures",
+      examples: const [
+        "select all pictures",
+        "select all photos",
+        "select all images",
+        "select all",
+        "all of them",
+        "all pictures",
+        "use all pictures",
+      ],
     ),
   ];
 
@@ -88,7 +106,7 @@ class CollageMakerScreenController extends ScreenControllerBase<CollageMakerScre
   /// This is called from the native side when the select_pictures action is called from the actions API.
   /// The selected picture indices are passed in the `selected` field of the params.
   void selectPicturesAPI(Map<String, dynamic> params) {
-    List<int> selected = List<int>.from(params["selected"] ?? []);
+    List<int> selected = List<int>.from(params["selected"] ?? []).map((index) => index - 1).where((index) => index >= 0 && index < 4).toList();
     getIt<PhotosManager>().chosen
       ..clear()
       ..addAll(selected);

--- a/lib/views/photo_booth_screen/screens/collage_maker_screen/collage_maker_screen_controller.dart
+++ b/lib/views/photo_booth_screen/screens/collage_maker_screen/collage_maker_screen_controller.dart
@@ -20,6 +20,9 @@ class CollageMakerScreenController extends ScreenControllerBase<CollageMakerScre
   final GlobalKey<PhotoCollageState> collageKey = GlobalKey<PhotoCollageState>();
 
   @override
+  String get scopeName => "Collage Maker Screen";
+
+  @override
   List<AppAction> get actions => [
     AppAction(
       name: "select_pictures",
@@ -106,7 +109,10 @@ class CollageMakerScreenController extends ScreenControllerBase<CollageMakerScre
   /// This is called from the native side when the select_pictures action is called from the actions API.
   /// The selected picture indices are passed in the `selected` field of the params.
   void selectPicturesAPI(Map<String, dynamic> params) {
-    List<int> selected = List<int>.from(params["selected"] ?? []).map((index) => index - 1).where((index) => index >= 0 && index < 4).toList();
+    List<int> selected = List<int>.from(params["selected"] ?? [])
+      .map((index) => index - 1)                    // Convert from 1-indexed to 0-indexed
+      .where((index) => index >= 0 && index < 4)    // Ensure indices are within bounds
+      .toSet().toList();                            // Remove duplicates
     getIt<PhotosManager>().chosen
       ..clear()
       ..addAll(selected);

--- a/lib/views/photo_booth_screen/screens/collage_maker_screen/collage_maker_screen_controller.dart
+++ b/lib/views/photo_booth_screen/screens/collage_maker_screen/collage_maker_screen_controller.dart
@@ -3,6 +3,7 @@ import 'package:flutter/widgets.dart';
 import 'package:momento_booth/main.dart';
 import 'package:momento_booth/managers/photos_manager.dart';
 import 'package:momento_booth/models/app_action.dart';
+import 'package:momento_booth/models/app_action_call.dart';
 import 'package:momento_booth/utils/speech_phrases.dart';
 import 'package:momento_booth/views/base/screen_controller_base.dart';
 import 'package:momento_booth/views/components/imaging/photo_collage.dart';
@@ -91,6 +92,9 @@ class CollageMakerScreenController extends ScreenControllerBase<CollageMakerScre
     } else {
       getIt<PhotosManager>().chosen.add(image);
     }
+    // Log the action call with the selected pictures as arguments, converting from 0-indexed to 1-indexed.
+    // Overwrite any previous select_pictures action to avoid cluttering the action history with multiple select_pictures calls when the user is toggling pictures multiple times.
+    registerActionCall(AppActionCall(tool: "select_pictures", arguments: {"selected": getIt<PhotosManager>().chosen.map((index) => index + 1).toList()}), overwriteSameName: true);
   }
 
   Future<void> onTimeout() async {
@@ -101,6 +105,7 @@ class CollageMakerScreenController extends ScreenControllerBase<CollageMakerScre
 
   Future<void> onContinueTap() async {
     if (getIt<PhotosManager>().chosen.isNotEmpty) {
+      registerActionCall(const AppActionCall(tool: "continue"));
       await viewModel.generateCollage(collageKey: collageKey);
       router.go(ShareScreen.defaultRoute);
     }
@@ -116,6 +121,8 @@ class CollageMakerScreenController extends ScreenControllerBase<CollageMakerScre
     getIt<PhotosManager>().chosen
       ..clear()
       ..addAll(selected);
+    // Log the action call with the selected pictures as arguments
+    registerActionCall(AppActionCall(tool: "select_pictures", arguments: {"selected": selected.map((index) => index + 1).toList()}));
   }
 
   // ////// //

--- a/lib/views/photo_booth_screen/screens/collage_maker_screen/collage_maker_screen_controller.dart
+++ b/lib/views/photo_booth_screen/screens/collage_maker_screen/collage_maker_screen_controller.dart
@@ -2,6 +2,7 @@
 import 'package:flutter/widgets.dart';
 import 'package:momento_booth/main.dart';
 import 'package:momento_booth/managers/photos_manager.dart';
+import 'package:momento_booth/models/app_action.dart';
 import 'package:momento_booth/views/base/screen_controller_base.dart';
 import 'package:momento_booth/views/components/imaging/photo_collage.dart';
 import 'package:momento_booth/views/photo_booth_screen/notifications/activity_timeout_callback.dart';
@@ -16,6 +17,18 @@ class CollageMakerScreenController extends ScreenControllerBase<CollageMakerScre
 
   /// Global key to create a snapshot of the [PhotoCollage] widget.
   final GlobalKey<PhotoCollageState> collageKey = GlobalKey<PhotoCollageState>();
+
+  @override
+  List<AppAction> get actions => [
+    AppAction(name: "select_pictures", callback: selectPicturesAPI),
+    AppAction(name: "continue", callback: (_) { onContinueTap(); }),
+    AppAction(name: "select_all_pictures_and_continue", callback: (_) {
+      getIt<PhotosManager>().chosen
+        ..clear()
+        ..addAll([0, 1, 2, 3]);
+      onContinueTap();
+    }),
+  ];
 
   // //// //
   // Init //
@@ -54,6 +67,15 @@ class CollageMakerScreenController extends ScreenControllerBase<CollageMakerScre
       await viewModel.generateCollage(collageKey: collageKey);
       router.go(ShareScreen.defaultRoute);
     }
+  }
+
+  /// This is called from the native side when the select_pictures action is called from the actions API.
+  /// The selected picture indices are passed in the `selected` field of the params.
+  void selectPicturesAPI(Map<String, dynamic> params) {
+    List<int> selected = List<int>.from(params["selected"] ?? []);
+    getIt<PhotosManager>().chosen
+      ..clear()
+      ..addAll(selected);
   }
 
   // ////// //

--- a/lib/views/photo_booth_screen/screens/collage_maker_screen/collage_maker_screen_controller.dart
+++ b/lib/views/photo_booth_screen/screens/collage_maker_screen/collage_maker_screen_controller.dart
@@ -20,14 +20,30 @@ class CollageMakerScreenController extends ScreenControllerBase<CollageMakerScre
 
   @override
   List<AppAction> get actions => [
-    AppAction(name: "select_pictures", callback: selectPicturesAPI),
-    AppAction(name: "continue", callback: (_) { onContinueTap(); }),
-    AppAction(name: "select_all_pictures_and_continue", callback: (_) {
-      getIt<PhotosManager>().chosen
-        ..clear()
-        ..addAll([0, 1, 2, 3]);
-      onContinueTap();
-    }),
+    AppAction(
+      name: "select_pictures",
+      callback: selectPicturesAPI,
+      title: "Select Pictures",
+      description: "Choose pictures to include in the collage.",
+      inputSchema: '{ "type": "object", "properties": { "selected": { "type": "array", "items": { "type": "integer", "minimum": 0, "maximum": 3 } }, "minItems": 0, "maxItems": 4 }, "description": "The indices of the selected pictures, 0-indexed" }, "required": ["selected"], "additionalProperties": false }'
+    ),
+    AppAction(
+      name: "continue",
+      callback: (_) { onContinueTap(); },
+      title: "Continue",
+      description: "Proceed to the share screen."
+    ),
+    AppAction(
+      name: "select_all_pictures_and_continue",
+      callback: (_) {
+        getIt<PhotosManager>().chosen
+          ..clear()
+          ..addAll([0, 1, 2, 3]);
+        onContinueTap();
+      },
+      title: "Select All Pictures and Continue",
+      description: "Select all captured pictures, create the collage, and proceed to the share screen."
+    ),
   ];
 
   // //// //

--- a/lib/views/photo_booth_screen/screens/collage_maker_screen/collage_maker_screen_controller.dart
+++ b/lib/views/photo_booth_screen/screens/collage_maker_screen/collage_maker_screen_controller.dart
@@ -42,17 +42,18 @@ class CollageMakerScreenController extends ScreenControllerBase<CollageMakerScre
     ),
     AppAction(
       name: "continue",
-      callback: (_) { onContinueTap(); },
+      callback: (_, response) { onContinueTap(); response(true, "Continue button pressed"); },
       title: "Continue",
       description: "Proceed to the share screen.",
       examples: continuePhrases,
     ),
     AppAction(
       name: "select_all_pictures",
-      callback: (_) {
+      callback: (_, response) {
         getIt<PhotosManager>().chosen
           ..clear()
           ..addAll([0, 1, 2, 3]);
+        response(true, "All pictures selected");
       },
       title: "Select All Pictures",
       description: "Select all captured pictures",
@@ -113,7 +114,7 @@ class CollageMakerScreenController extends ScreenControllerBase<CollageMakerScre
 
   /// This is called from the native side when the select_pictures action is called from the actions API.
   /// The selected picture indices are passed in the `selected` field of the params.
-  void selectPicturesAPI(Map<String, dynamic> params) {
+  void selectPicturesAPI(Map<String, dynamic> params, Function(bool, String) response) {
     List<int> selected = List<int>.from(params["selected"] ?? [])
       .map((index) => index - 1)                    // Convert from 1-indexed to 0-indexed
       .where((index) => index >= 0 && index < 4)    // Ensure indices are within bounds
@@ -123,6 +124,7 @@ class CollageMakerScreenController extends ScreenControllerBase<CollageMakerScre
       ..addAll(selected);
     // Log the action call with the selected pictures as arguments
     registerActionCall(AppActionCall(tool: "select_pictures", arguments: {"selected": selected.map((index) => index + 1).toList()}));
+    response(true, "Pictures ${selected.map((index) => index + 1).toList()} selected");
   }
 
   // ////// //

--- a/lib/views/photo_booth_screen/screens/collage_maker_screen/collage_maker_screen_controller.dart
+++ b/lib/views/photo_booth_screen/screens/collage_maker_screen/collage_maker_screen_controller.dart
@@ -31,6 +31,7 @@ class CollageMakerScreenController extends ScreenControllerBase<CollageMakerScre
       title: "Select Pictures",
       description: "Choose pictures to include in the collage.",
       inputSchema: '{ "type": "object", "properties": { "selected": { "type": "array", "items": { "type": "integer", "minimum": 1, "maximum": 4 }, "minItems": 0, "maxItems": 4 }}, "description": "The indices of the selected pictures, 1-indexed", "required": ["selected"], "additionalProperties": false }',
+      inputSchemaExample: '{ "selected": array of 1-indexed integers between 1 and 4, e.g., [1, 2, 4] }',
       examples: const [
         "select picture {selected}, {selected} and {selected}",
         "select picture {selected} and {second}",

--- a/lib/views/photo_booth_screen/screens/collage_maker_screen/collage_maker_screen_controller.dart
+++ b/lib/views/photo_booth_screen/screens/collage_maker_screen/collage_maker_screen_controller.dart
@@ -4,6 +4,7 @@ import 'package:momento_booth/main.dart';
 import 'package:momento_booth/managers/photos_manager.dart';
 import 'package:momento_booth/models/app_action.dart';
 import 'package:momento_booth/models/app_action_call.dart';
+import 'package:momento_booth/models/app_action_example.dart';
 import 'package:momento_booth/utils/speech_phrases.dart';
 import 'package:momento_booth/views/base/screen_controller_base.dart';
 import 'package:momento_booth/views/components/imaging/photo_collage.dart';
@@ -30,15 +31,15 @@ class CollageMakerScreenController extends ScreenControllerBase<CollageMakerScre
       callback: selectPicturesAPI,
       title: "Select Pictures",
       description: "Choose pictures to include in the collage.",
-      inputSchema: '{ "type": "object", "properties": { "selected": { "type": "array", "items": { "type": "integer", "minimum": 1, "maximum": 4 }, "minItems": 0, "maxItems": 4 }}, "description": "The indices of the selected pictures, 1-indexed", "required": ["selected"], "additionalProperties": false }',
+      inputSchema: { "type": "object", "properties": { "selected": { "type": "array", "items": { "type": "integer", "minimum": 1, "maximum": 4 }, "minItems": 0, "maxItems": 4 }}, "description": "The indices of the selected pictures, 1-indexed", "required": ["selected"], "additionalProperties": false },
       inputSchemaExample: '{ "selected": array of 1-indexed integers between 1 and 4, e.g., [1, 2, 4] }',
       examples: const [
-        "select picture {selected}, {selected} and {selected}",
-        "select picture {selected} and {second}",
-        "select picture {selected}",
-        "select the {selected} picture",
-        "select the {selected} and {selected} picture",
-        "select the {selected}, {selected}, and {selected} picture",
+        AppActionExample(phrase: "select picture {selected:1}, {selected:2} and {selected:4}", arguments: { "selected": [1, 2, 4] }),
+        AppActionExample(phrase: "select picture {selected:one} and {second:two}", arguments: { "selected": [1, 2] }),
+        AppActionExample(phrase: "select picture {selected:one}", arguments: { "selected": [1] }),
+        AppActionExample(phrase: "select the {selected:first} picture", arguments: { "selected": [1] }),
+        AppActionExample(phrase: "select the {selected:second} and {selected:third} picture", arguments: { "selected": [2, 3] }),
+        AppActionExample(phrase: "select the {selected:third}, {selected:second}, and {selected:first} picture", arguments: { "selected": [3, 2, 1] }),
       ],
     ),
     AppAction(
@@ -46,7 +47,7 @@ class CollageMakerScreenController extends ScreenControllerBase<CollageMakerScre
       callback: (_, response) { onContinueTap(); response(true, "Continue button pressed"); },
       title: "Continue",
       description: "Proceed to the share screen.",
-      examples: continuePhrases,
+      examples: continuePhrasesExamples,
     ),
     AppAction(
       name: "select_all_pictures",
@@ -66,7 +67,7 @@ class CollageMakerScreenController extends ScreenControllerBase<CollageMakerScre
         "all of them",
         "all pictures",
         "use all pictures",
-      ],
+      ].map((phrase) => AppActionExample(phrase: phrase)).toList(),
     ),
   ];
 

--- a/lib/views/photo_booth_screen/screens/gallery_screen/gallery_screen_controller.dart
+++ b/lib/views/photo_booth_screen/screens/gallery_screen/gallery_screen_controller.dart
@@ -6,6 +6,7 @@ import 'package:http/http.dart' as http;
 import 'package:momento_booth/main.dart';
 import 'package:momento_booth/managers/settings_manager.dart';
 import 'package:momento_booth/models/app_action.dart';
+import 'package:momento_booth/models/app_action_call.dart';
 import 'package:momento_booth/utils/speech_phrases.dart';
 import 'package:momento_booth/views/base/screen_controller_base.dart';
 import 'package:momento_booth/views/components/dialogs/find_face_dialog.dart';
@@ -48,6 +49,7 @@ class GalleryScreenController extends ScreenControllerBase<GalleryScreenViewMode
   void openPhoto(File file) {
     final String filename = basename(file.path);
     logDebug("Opening photo $filename");
+    registerActionCall(AppActionCall(tool: "open_photo", arguments: {"filename": filename}));
     router.push("${PhotoDetailsScreen.defaultRoute}/$filename");
   }
 
@@ -64,6 +66,7 @@ class GalleryScreenController extends ScreenControllerBase<GalleryScreenViewMode
   }
 
   void onPressedBack() {
+    registerActionCall(const AppActionCall(tool: "back"));
     if (router.canPop()) {
       router.pop();
     } else {

--- a/lib/views/photo_booth_screen/screens/gallery_screen/gallery_screen_controller.dart
+++ b/lib/views/photo_booth_screen/screens/gallery_screen/gallery_screen_controller.dart
@@ -5,6 +5,7 @@ import 'package:flutter_mobx/flutter_mobx.dart';
 import 'package:http/http.dart' as http;
 import 'package:momento_booth/main.dart';
 import 'package:momento_booth/managers/settings_manager.dart';
+import 'package:momento_booth/models/app_action.dart';
 import 'package:momento_booth/views/base/screen_controller_base.dart';
 import 'package:momento_booth/views/components/dialogs/find_face_dialog.dart';
 import 'package:momento_booth/views/photo_booth_screen/screens/gallery_screen/gallery_screen_view_model.dart';
@@ -14,6 +15,12 @@ import 'package:path/path.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 
 class GalleryScreenController extends ScreenControllerBase<GalleryScreenViewModel> {
+
+  @override
+  List<AppAction> get actions => [
+    AppAction(name: "open_last_picture", callback: (_) { openLastPhoto(); }),
+    AppAction(name: "back", callback: (_) { onPressedBack(); }),
+  ];
 
   // Initialization/Deinitialization
 
@@ -26,6 +33,18 @@ class GalleryScreenController extends ScreenControllerBase<GalleryScreenViewMode
     final String filename = basename(file.path);
     logDebug("Opening photo $filename");
     router.push("${PhotoDetailsScreen.defaultRoute}/$filename");
+  }
+
+  void openLastPhoto() {
+    final lastGroup = viewModel.imageGroups?.lastOrNull;
+    if (lastGroup != null) {
+      final lastPhoto = lastGroup.images.lastOrNull;
+      if (lastPhoto != null) {
+        openPhoto(lastPhoto.file);
+      } else {
+        logDebug("No photos found in the last group");
+      }
+    }
   }
 
   void onPressedBack() {

--- a/lib/views/photo_booth_screen/screens/gallery_screen/gallery_screen_controller.dart
+++ b/lib/views/photo_booth_screen/screens/gallery_screen/gallery_screen_controller.dart
@@ -18,8 +18,18 @@ class GalleryScreenController extends ScreenControllerBase<GalleryScreenViewMode
 
   @override
   List<AppAction> get actions => [
-    AppAction(name: "open_last_picture", callback: (_) { openLastPhoto(); }),
-    AppAction(name: "back", callback: (_) { onPressedBack(); }),
+    AppAction(
+      name: "open_latest_picture",
+      callback: (_) { openLatestPhoto(); },
+      title: "Open Latest Picture",
+      description: "View the most recently captured picture."
+    ),
+    AppAction(
+      name: "back",
+      callback: (_) { onPressedBack(); },
+      title: "Back",
+      description: "Return to the previous screen."
+    ),
   ];
 
   // Initialization/Deinitialization
@@ -35,12 +45,12 @@ class GalleryScreenController extends ScreenControllerBase<GalleryScreenViewMode
     router.push("${PhotoDetailsScreen.defaultRoute}/$filename");
   }
 
-  void openLastPhoto() {
-    final lastGroup = viewModel.imageGroups?.lastOrNull;
-    if (lastGroup != null) {
-      final lastPhoto = lastGroup.images.lastOrNull;
-      if (lastPhoto != null) {
-        openPhoto(lastPhoto.file);
+  void openLatestPhoto() {
+    final latestGroup = viewModel.imageGroups?.firstOrNull;
+    if (latestGroup != null) {
+      final latestPhoto = latestGroup.images.firstOrNull;
+      if (latestPhoto != null) {
+        openPhoto(latestPhoto.file);
       } else {
         logDebug("No photos found in the last group");
       }

--- a/lib/views/photo_booth_screen/screens/gallery_screen/gallery_screen_controller.dart
+++ b/lib/views/photo_booth_screen/screens/gallery_screen/gallery_screen_controller.dart
@@ -18,6 +18,9 @@ import 'package:sentry_flutter/sentry_flutter.dart';
 class GalleryScreenController extends ScreenControllerBase<GalleryScreenViewModel> {
 
   @override
+  String get scopeName => "Gallery Screen";
+
+  @override
   List<AppAction> get actions => [
     AppAction(
       name: "open_latest_picture",

--- a/lib/views/photo_booth_screen/screens/gallery_screen/gallery_screen_controller.dart
+++ b/lib/views/photo_booth_screen/screens/gallery_screen/gallery_screen_controller.dart
@@ -6,6 +6,7 @@ import 'package:http/http.dart' as http;
 import 'package:momento_booth/main.dart';
 import 'package:momento_booth/managers/settings_manager.dart';
 import 'package:momento_booth/models/app_action.dart';
+import 'package:momento_booth/utils/speech_phrases.dart';
 import 'package:momento_booth/views/base/screen_controller_base.dart';
 import 'package:momento_booth/views/components/dialogs/find_face_dialog.dart';
 import 'package:momento_booth/views/photo_booth_screen/screens/gallery_screen/gallery_screen_view_model.dart';
@@ -22,13 +23,15 @@ class GalleryScreenController extends ScreenControllerBase<GalleryScreenViewMode
       name: "open_latest_picture",
       callback: (_) { openLatestPhoto(); },
       title: "Open Latest Picture",
-      description: "View the most recently captured picture."
+      description: "View the most recently captured picture.",
+      examples: const ["latest", "most recent", "last photo", "last picture", "open latest"],
     ),
     AppAction(
       name: "back",
       callback: (_) { onPressedBack(); },
       title: "Back",
-      description: "Return to the previous screen."
+      description: "Return to the previous screen.",
+      examples: backPhrases,
     ),
   ];
 

--- a/lib/views/photo_booth_screen/screens/gallery_screen/gallery_screen_controller.dart
+++ b/lib/views/photo_booth_screen/screens/gallery_screen/gallery_screen_controller.dart
@@ -7,6 +7,7 @@ import 'package:momento_booth/main.dart';
 import 'package:momento_booth/managers/settings_manager.dart';
 import 'package:momento_booth/models/app_action.dart';
 import 'package:momento_booth/models/app_action_call.dart';
+import 'package:momento_booth/models/app_action_example.dart';
 import 'package:momento_booth/utils/speech_phrases.dart';
 import 'package:momento_booth/views/base/screen_controller_base.dart';
 import 'package:momento_booth/views/components/dialogs/find_face_dialog.dart';
@@ -28,14 +29,14 @@ class GalleryScreenController extends ScreenControllerBase<GalleryScreenViewMode
       callback: (_, response) { openLatestPhoto(); response(true, "Opened latest picture for viewing"); },
       title: "Open Latest Picture",
       description: "View the most recently captured picture.",
-      examples: const ["latest", "most recent", "last photo", "last picture", "open latest"],
+      examples: const ["latest", "most recent", "last photo", "last picture", "open latest"].map((phrase) => AppActionExample(phrase: phrase)).toList(),
     ),
     AppAction(
       name: "back",
       callback: (_, response) { onPressedBack(); response(true, "Back button pressed"); },
       title: "Back",
       description: "Return to the previous screen.",
-      examples: backPhrases,
+      examples: backPhrasesExamples,
     ),
   ];
 

--- a/lib/views/photo_booth_screen/screens/gallery_screen/gallery_screen_controller.dart
+++ b/lib/views/photo_booth_screen/screens/gallery_screen/gallery_screen_controller.dart
@@ -25,14 +25,14 @@ class GalleryScreenController extends ScreenControllerBase<GalleryScreenViewMode
   List<AppAction> get actions => [
     AppAction(
       name: "open_latest_picture",
-      callback: (_) { openLatestPhoto(); },
+      callback: (_, response) { openLatestPhoto(); response(true, "Opened latest picture for viewing"); },
       title: "Open Latest Picture",
       description: "View the most recently captured picture.",
       examples: const ["latest", "most recent", "last photo", "last picture", "open latest"],
     ),
     AppAction(
       name: "back",
-      callback: (_) { onPressedBack(); },
+      callback: (_, response) { onPressedBack(); response(true, "Back button pressed"); },
       title: "Back",
       description: "Return to the previous screen.",
       examples: backPhrases,

--- a/lib/views/photo_booth_screen/screens/manual_collage_screen/manual_collage_screen_controller.dart
+++ b/lib/views/photo_booth_screen/screens/manual_collage_screen/manual_collage_screen_controller.dart
@@ -16,6 +16,9 @@ import 'package:path/path.dart' as path;
 
 class ManualCollageScreenController extends ScreenControllerBase<ManualCollageScreenViewModel> {
 
+  @override
+  String get scopeName => "Manual Collage Screen";
+
   // Initialization/Deinitialization
 
   ManualCollageScreenController({

--- a/lib/views/photo_booth_screen/screens/multi_capture_screen/multi_capture_screen_controller.dart
+++ b/lib/views/photo_booth_screen/screens/multi_capture_screen/multi_capture_screen_controller.dart
@@ -5,6 +5,9 @@ import 'package:momento_booth/views/photo_booth_screen/screens/multi_capture_scr
 
 class MultiCaptureScreenController extends ScreenControllerBase<MultiCaptureScreenViewModel> {
 
+  @override
+  String get scopeName => "Multi Capture Screen";
+
   // Initialization/Deinitialization
 
   MultiCaptureScreenController({

--- a/lib/views/photo_booth_screen/screens/navigation_screen/navigation_screen_controller.dart
+++ b/lib/views/photo_booth_screen/screens/navigation_screen/navigation_screen_controller.dart
@@ -2,6 +2,7 @@ import 'package:auto_size_text/auto_size_text.dart';
 import 'package:fluent_ui/fluent_ui.dart';
 import 'package:momento_booth/main.dart';
 import 'package:momento_booth/managers/window_manager.dart';
+import 'package:momento_booth/models/app_action.dart';
 import 'package:momento_booth/views/base/screen_controller_base.dart';
 import 'package:momento_booth/views/components/dialogs/language_choice_dialog.dart';
 import 'package:momento_booth/views/photo_booth_screen/screens/gallery_screen/gallery_screen.dart';
@@ -12,6 +13,16 @@ import 'package:momento_booth/views/photo_booth_screen/screens/single_capture_sc
 class NavigationScreenController extends ScreenControllerBase<NavigationScreenViewModel> {
 
   AutoSizeGroup autoSizeGroup = AutoSizeGroup();
+
+  @override
+  List<AppAction> get actions => [
+    if (viewModel.enableSingleCapture)
+    AppAction(name: "single_photo", callback: (_) { onClickSinglePhoto(); }),
+    if (viewModel.enableCollageCapture)
+    AppAction(name: "collage", callback: (_) { onClickCollage(); }),
+    AppAction(name: "galery", callback: (_) { onClickGallery(); }),
+    AppAction(name: "language", callback: (_) { onClickLanguage(); }),
+  ];
 
   // Initialization/Deinitialization
 

--- a/lib/views/photo_booth_screen/screens/navigation_screen/navigation_screen_controller.dart
+++ b/lib/views/photo_booth_screen/screens/navigation_screen/navigation_screen_controller.dart
@@ -17,11 +17,31 @@ class NavigationScreenController extends ScreenControllerBase<NavigationScreenVi
   @override
   List<AppAction> get actions => [
     if (viewModel.enableSingleCapture)
-    AppAction(name: "single_photo", callback: (_) { onClickSinglePhoto(); }),
+    AppAction(
+      name: "single_photo",
+      callback: (_) { onClickSinglePhoto(); },
+      title: "Single Photo",
+      description: "Take a single photo."
+    ),
     if (viewModel.enableCollageCapture)
-    AppAction(name: "collage", callback: (_) { onClickCollage(); }),
-    AppAction(name: "galery", callback: (_) { onClickGallery(); }),
-    AppAction(name: "language", callback: (_) { onClickLanguage(); }),
+    AppAction(
+      name: "collage",
+      callback: (_) { onClickCollage(); },
+      title: "Collage",
+      description: "Shoot multiple photos and create a collage from them."
+    ),
+    AppAction(
+      name: "gallery",
+      callback: (_) { onClickGallery(); },
+      title: "Gallery",
+      description: "View the previously captured photos."
+    ),
+    AppAction(
+      name: "language",
+      callback: (_) { onClickLanguage(); },
+      title: "Language",
+      description: "Open the language selection dialog."
+    ),
   ];
 
   // Initialization/Deinitialization

--- a/lib/views/photo_booth_screen/screens/navigation_screen/navigation_screen_controller.dart
+++ b/lib/views/photo_booth_screen/screens/navigation_screen/navigation_screen_controller.dart
@@ -15,6 +15,9 @@ class NavigationScreenController extends ScreenControllerBase<NavigationScreenVi
   AutoSizeGroup autoSizeGroup = AutoSizeGroup();
 
   @override
+  String get scopeName => "Navigation Screen";
+
+  @override
   List<AppAction> get actions => [
     if (viewModel.enableSingleCapture)
     AppAction(

--- a/lib/views/photo_booth_screen/screens/navigation_screen/navigation_screen_controller.dart
+++ b/lib/views/photo_booth_screen/screens/navigation_screen/navigation_screen_controller.dart
@@ -3,6 +3,7 @@ import 'package:fluent_ui/fluent_ui.dart';
 import 'package:momento_booth/main.dart';
 import 'package:momento_booth/managers/window_manager.dart';
 import 'package:momento_booth/models/app_action.dart';
+import 'package:momento_booth/models/app_action_call.dart';
 import 'package:momento_booth/views/base/screen_controller_base.dart';
 import 'package:momento_booth/views/components/dialogs/language_choice_dialog.dart';
 import 'package:momento_booth/views/photo_booth_screen/screens/gallery_screen/gallery_screen.dart';
@@ -43,7 +44,7 @@ class NavigationScreenController extends ScreenControllerBase<NavigationScreenVi
       examples: const ["gallery", "view gallery", "see photos", "browse images"],
     ),
     AppAction(
-      name: "language",
+      name: "open_language_dialog",
       callback: (_) { onClickLanguage(); },
       title: "Language",
       description: "Open the language selection dialog.",
@@ -72,9 +73,11 @@ class NavigationScreenController extends ScreenControllerBase<NavigationScreenVi
     final singleCapture = viewModel.enableSingleCapture;
     final collageCapture = viewModel.enableCollageCapture;
     if (singleCapture) {
+      registerActionCall(const AppActionCall(tool: "single_photo"));
       router.go(SingleCaptureScreen.defaultRoute);
       return;
     } else if (collageCapture) {
+      registerActionCall(const AppActionCall(tool: "collage"));
       router.go(MultiCaptureScreen.defaultRoute);
       return;
     } else {
@@ -95,10 +98,12 @@ class NavigationScreenController extends ScreenControllerBase<NavigationScreenVi
   }
 
   void onClickGallery() {
+    registerActionCall(const AppActionCall(tool: "gallery"));
     router.push(GalleryScreen.defaultRoute);
   }
 
   Future<void> onClickLanguage() async {
+    registerActionCall(const AppActionCall(tool: "open_language_dialog"));
     await showUserDialog(
       dialog: LanguageChoiceDialog(onChosen: (language) {
         navigator.pop();

--- a/lib/views/photo_booth_screen/screens/navigation_screen/navigation_screen_controller.dart
+++ b/lib/views/photo_booth_screen/screens/navigation_screen/navigation_screen_controller.dart
@@ -21,26 +21,30 @@ class NavigationScreenController extends ScreenControllerBase<NavigationScreenVi
       name: "single_photo",
       callback: (_) { onClickSinglePhoto(); },
       title: "Single Photo",
-      description: "Take a single photo."
+      description: "Take a single photo.",
+      examples: const ["single", "single capture", "single photo", "single picture", "take a photo"],
     ),
     if (viewModel.enableCollageCapture)
     AppAction(
       name: "collage",
       callback: (_) { onClickCollage(); },
       title: "Collage",
-      description: "Shoot multiple photos and create a collage from them."
+      description: "Shoot multiple photos and create a collage from them.",
+      examples: const ["collage", "collage capture", "collage photo", "collage picture", "take a collage"],
     ),
     AppAction(
       name: "gallery",
       callback: (_) { onClickGallery(); },
       title: "Gallery",
-      description: "View the previously captured photos."
+      description: "View the previously captured photos.",
+      examples: const ["gallery", "view gallery", "see photos", "browse images"],
     ),
     AppAction(
       name: "language",
       callback: (_) { onClickLanguage(); },
       title: "Language",
-      description: "Open the language selection dialog."
+      description: "Open the language selection dialog.",
+      examples: const ["language", "change language", "select language", "set language", "open language settings"],
     ),
   ];
 

--- a/lib/views/photo_booth_screen/screens/navigation_screen/navigation_screen_controller.dart
+++ b/lib/views/photo_booth_screen/screens/navigation_screen/navigation_screen_controller.dart
@@ -4,6 +4,7 @@ import 'package:momento_booth/main.dart';
 import 'package:momento_booth/managers/window_manager.dart';
 import 'package:momento_booth/models/app_action.dart';
 import 'package:momento_booth/models/app_action_call.dart';
+import 'package:momento_booth/models/app_action_example.dart';
 import 'package:momento_booth/views/base/screen_controller_base.dart';
 import 'package:momento_booth/views/components/dialogs/language_choice_dialog.dart';
 import 'package:momento_booth/views/photo_booth_screen/screens/gallery_screen/gallery_screen.dart';
@@ -26,7 +27,7 @@ class NavigationScreenController extends ScreenControllerBase<NavigationScreenVi
       callback: (_, response) { onClickSinglePhoto(); response(true, "Commencing to take a single photo"); },
       title: "Single Photo",
       description: "Take a single photo.",
-      examples: const ["single", "single capture", "single photo", "single picture", "take a photo"],
+      examples: const ["single", "single capture", "single photo", "single picture", "take a photo"].map((phrase) => AppActionExample(phrase: phrase)).toList(),
     ),
     if (viewModel.enableCollageCapture)
     AppAction(
@@ -34,21 +35,21 @@ class NavigationScreenController extends ScreenControllerBase<NavigationScreenVi
       callback: (_, response) { onClickCollage(); response(true, "Commencing to create a collage"); },
       title: "Collage",
       description: "Shoot multiple photos and create a collage from them.",
-      examples: const ["collage", "collage capture", "collage photo", "collage picture", "take a collage"],
+      examples: const ["collage", "collage capture", "collage photo", "collage picture", "take a collage"].map((phrase) => AppActionExample(phrase: phrase)).toList(),
     ),
     AppAction(
       name: "gallery",
       callback: (_, response) { onClickGallery(); response(true, "Opening gallery"); },
       title: "Gallery",
       description: "View the previously captured photos.",
-      examples: const ["gallery", "view gallery", "see photos", "browse images"],
+      examples: const ["gallery", "view gallery", "see photos", "browse images"].map((phrase) => AppActionExample(phrase: phrase)).toList(),
     ),
     AppAction(
       name: "open_language_dialog",
       callback: (_, response) { onClickLanguage(); response(true, "Opening language dialog"); },
       title: "Language",
       description: "Open the language selection dialog.",
-      examples: const ["language", "change language", "select language", "set language", "open language settings"],
+      examples: const ["language", "change language", "select language", "set language", "open language settings"].map((phrase) => AppActionExample(phrase: phrase)).toList(),
     ),
   ];
 

--- a/lib/views/photo_booth_screen/screens/navigation_screen/navigation_screen_controller.dart
+++ b/lib/views/photo_booth_screen/screens/navigation_screen/navigation_screen_controller.dart
@@ -108,7 +108,9 @@ class NavigationScreenController extends ScreenControllerBase<NavigationScreenVi
       dialog: LanguageChoiceDialog(onChosen: (language) {
         navigator.pop();
         getIt<WindowManager>().setLanguage(language);
-      },), barrierDismissible: true,
+      }, onCancel: () {
+        navigator.pop();
+      }), barrierDismissible: true,
     );
   }
 

--- a/lib/views/photo_booth_screen/screens/navigation_screen/navigation_screen_controller.dart
+++ b/lib/views/photo_booth_screen/screens/navigation_screen/navigation_screen_controller.dart
@@ -23,7 +23,7 @@ class NavigationScreenController extends ScreenControllerBase<NavigationScreenVi
     if (viewModel.enableSingleCapture)
     AppAction(
       name: "single_photo",
-      callback: (_) { onClickSinglePhoto(); },
+      callback: (_, response) { onClickSinglePhoto(); response(true, "Commencing to take a single photo"); },
       title: "Single Photo",
       description: "Take a single photo.",
       examples: const ["single", "single capture", "single photo", "single picture", "take a photo"],
@@ -31,21 +31,21 @@ class NavigationScreenController extends ScreenControllerBase<NavigationScreenVi
     if (viewModel.enableCollageCapture)
     AppAction(
       name: "collage",
-      callback: (_) { onClickCollage(); },
+      callback: (_, response) { onClickCollage(); response(true, "Commencing to create a collage"); },
       title: "Collage",
       description: "Shoot multiple photos and create a collage from them.",
       examples: const ["collage", "collage capture", "collage photo", "collage picture", "take a collage"],
     ),
     AppAction(
       name: "gallery",
-      callback: (_) { onClickGallery(); },
+      callback: (_, response) { onClickGallery(); response(true, "Opening gallery"); },
       title: "Gallery",
       description: "View the previously captured photos.",
       examples: const ["gallery", "view gallery", "see photos", "browse images"],
     ),
     AppAction(
       name: "open_language_dialog",
-      callback: (_) { onClickLanguage(); },
+      callback: (_, response) { onClickLanguage(); response(true, "Opening language dialog"); },
       title: "Language",
       description: "Open the language selection dialog.",
       examples: const ["language", "change language", "select language", "set language", "open language settings"],

--- a/lib/views/photo_booth_screen/screens/photo_details_screen/photo_details_screen_controller.dart
+++ b/lib/views/photo_booth_screen/screens/photo_details_screen/photo_details_screen_controller.dart
@@ -69,15 +69,13 @@ class PhotoDetailsScreenController extends ScreenControllerBase<PhotoDetailsScre
     if (!viewModel.printEnabled) return;
     showUserDialog(
       barrierDismissible: false,
-      dialog: Observer(builder: (_) {
-        return PrintDialog(
-          onPrintPressed: (size, copies) {
-            navigator.pop();
-            onConfirmPrint(size, copies);
-          },
-          onCancel: () => navigator.pop(),
-        );
-      }),
+      dialog: PrintDialog(
+        onPrintPressed: (size, copies) {
+          navigator.pop();
+          onConfirmPrint(size, copies);
+        },
+        onCancel: () => navigator.pop(),
+      ),
     );
   }
 

--- a/lib/views/photo_booth_screen/screens/photo_details_screen/photo_details_screen_controller.dart
+++ b/lib/views/photo_booth_screen/screens/photo_details_screen/photo_details_screen_controller.dart
@@ -5,6 +5,7 @@ import 'package:flutter_mobx/flutter_mobx.dart';
 import 'package:momento_booth/main.dart';
 import 'package:momento_booth/managers/printing_manager.dart';
 import 'package:momento_booth/models/app_action.dart';
+import 'package:momento_booth/models/app_action_call.dart';
 import 'package:momento_booth/models/settings.dart';
 import 'package:momento_booth/utils/hardware.dart';
 import 'package:momento_booth/utils/speech_phrases.dart';
@@ -39,7 +40,7 @@ class PhotoDetailsScreenController extends ScreenControllerBase<PhotoDetailsScre
       examples: getQRPhrases
     ),
     AppAction(
-      name: "print",
+      name: "open_print_dialog",
       callback: (_) { onClickPrint(); },
       title: "Print",
       description: "Open the print dialog.",
@@ -55,10 +56,12 @@ class PhotoDetailsScreenController extends ScreenControllerBase<PhotoDetailsScre
   });
 
   void onClickPrev() {
+    registerActionCall(const AppActionCall(tool: "back"));
     router.pop();
   }
 
   void onClickGetQR() {
+    registerActionCall(const AppActionCall(tool: "get_qr"));
     viewModel.uploadPhotoToSend();
     showUserDialog(
       barrierDismissible: false,
@@ -89,6 +92,7 @@ class PhotoDetailsScreenController extends ScreenControllerBase<PhotoDetailsScre
 
   void onClickPrint() {
     if (!viewModel.printEnabled) return;
+    registerActionCall(const AppActionCall(tool: "open_print_dialog"));
     showUserDialog(
       barrierDismissible: false,
       dialog: PrintDialog(

--- a/lib/views/photo_booth_screen/screens/photo_details_screen/photo_details_screen_controller.dart
+++ b/lib/views/photo_booth_screen/screens/photo_details_screen/photo_details_screen_controller.dart
@@ -20,6 +20,9 @@ class PhotoDetailsScreenController extends ScreenControllerBase<PhotoDetailsScre
   AutoSizeGroup actionButtonGroup = AutoSizeGroup();
 
   @override
+  String get scopeName => "Photo Details Screen";
+
+  @override
   List<AppAction> get actions => [
     AppAction(
       name: "back",

--- a/lib/views/photo_booth_screen/screens/photo_details_screen/photo_details_screen_controller.dart
+++ b/lib/views/photo_booth_screen/screens/photo_details_screen/photo_details_screen_controller.dart
@@ -4,6 +4,7 @@ import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
 import 'package:momento_booth/main.dart';
 import 'package:momento_booth/managers/printing_manager.dart';
+import 'package:momento_booth/models/app_action.dart';
 import 'package:momento_booth/models/settings.dart';
 import 'package:momento_booth/utils/hardware.dart';
 import 'package:momento_booth/views/base/screen_controller_base.dart';
@@ -16,6 +17,13 @@ import 'package:path/path.dart' as path;
 class PhotoDetailsScreenController extends ScreenControllerBase<PhotoDetailsScreenViewModel> {
 
   AutoSizeGroup actionButtonGroup = AutoSizeGroup();
+
+  @override
+  List<AppAction> get actions => [
+    AppAction(name: "back", callback: (_) { onClickPrev(); }),
+    AppAction(name: "get_qr", callback: (_) { onClickGetQR(); }),
+    AppAction(name: "print", callback: (_) { onClickPrint(); }),
+  ];
 
   // Initialization/Deinitialization
 

--- a/lib/views/photo_booth_screen/screens/photo_details_screen/photo_details_screen_controller.dart
+++ b/lib/views/photo_booth_screen/screens/photo_details_screen/photo_details_screen_controller.dart
@@ -7,6 +7,7 @@ import 'package:momento_booth/managers/printing_manager.dart';
 import 'package:momento_booth/models/app_action.dart';
 import 'package:momento_booth/models/settings.dart';
 import 'package:momento_booth/utils/hardware.dart';
+import 'package:momento_booth/utils/speech_phrases.dart';
 import 'package:momento_booth/views/base/screen_controller_base.dart';
 import 'package:momento_booth/views/components/dialogs/print_dialog.dart';
 import 'package:momento_booth/views/components/dialogs/printing_error_dialog.dart';
@@ -24,19 +25,22 @@ class PhotoDetailsScreenController extends ScreenControllerBase<PhotoDetailsScre
       name: "back",
       callback: (_) { onClickPrev(); },
       title: "Back",
-      description: "Return to the gallery screen."
+      description: "Return to the gallery screen.",
+      examples: backPhrases
     ),
     AppAction(
       name: "get_qr",
       callback: (_) { onClickGetQR(); },
       title: "Get QR Code",
-      description: "Generate a QR code for sharing the photo."
+      description: "Generate a QR code for sharing the photo.",
+      examples: getQRPhrases
     ),
     AppAction(
       name: "print",
       callback: (_) { onClickPrint(); },
       title: "Print",
-      description: "Open the print dialog."
+      description: "Open the print dialog.",
+      examples: printPhrases
     ),
   ];
 

--- a/lib/views/photo_booth_screen/screens/photo_details_screen/photo_details_screen_controller.dart
+++ b/lib/views/photo_booth_screen/screens/photo_details_screen/photo_details_screen_controller.dart
@@ -20,9 +20,24 @@ class PhotoDetailsScreenController extends ScreenControllerBase<PhotoDetailsScre
 
   @override
   List<AppAction> get actions => [
-    AppAction(name: "back", callback: (_) { onClickPrev(); }),
-    AppAction(name: "get_qr", callback: (_) { onClickGetQR(); }),
-    AppAction(name: "print", callback: (_) { onClickPrint(); }),
+    AppAction(
+      name: "back",
+      callback: (_) { onClickPrev(); },
+      title: "Back",
+      description: "Return to the gallery screen."
+    ),
+    AppAction(
+      name: "get_qr",
+      callback: (_) { onClickGetQR(); },
+      title: "Get QR Code",
+      description: "Generate a QR code for sharing the photo."
+    ),
+    AppAction(
+      name: "print",
+      callback: (_) { onClickPrint(); },
+      title: "Print",
+      description: "Open the print dialog."
+    ),
   ];
 
   // Initialization/Deinitialization

--- a/lib/views/photo_booth_screen/screens/photo_details_screen/photo_details_screen_controller.dart
+++ b/lib/views/photo_booth_screen/screens/photo_details_screen/photo_details_screen_controller.dart
@@ -27,21 +27,21 @@ class PhotoDetailsScreenController extends ScreenControllerBase<PhotoDetailsScre
   List<AppAction> get actions => [
     AppAction(
       name: "back",
-      callback: (_) { onClickPrev(); },
+      callback: (_, response) { onClickPrev(); response(true, "Back button pressed"); },
       title: "Back",
       description: "Return to the gallery screen.",
       examples: backPhrases
     ),
     AppAction(
       name: "get_qr",
-      callback: (_) { onClickGetQR(); },
+      callback: (_, response) { onClickGetQR(); response(true, "Uploading the picture to get a QR code"); },
       title: "Get QR Code",
       description: "Generate a QR code for sharing the photo.",
       examples: getQRPhrases
     ),
     AppAction(
       name: "open_print_dialog",
-      callback: (_) { onClickPrint(); },
+      callback: (_, response) { onClickPrint(); response(true, "Opening the print dialog"); },
       title: "Print",
       description: "Open the print dialog.",
       examples: printPhrases

--- a/lib/views/photo_booth_screen/screens/photo_details_screen/photo_details_screen_controller.dart
+++ b/lib/views/photo_booth_screen/screens/photo_details_screen/photo_details_screen_controller.dart
@@ -73,7 +73,7 @@ class PhotoDetailsScreenController extends ScreenControllerBase<PhotoDetailsScre
         onDismiss: () => navigator.pop(),
         actionsToken: actionsToken,
       ),
-      actionStackToken: actionsToken,
+      publishActions: false,
     );
   }
 
@@ -98,6 +98,7 @@ class PhotoDetailsScreenController extends ScreenControllerBase<PhotoDetailsScre
         },
         onCancel: () => navigator.pop(),
       ),
+      publishActions: false,
     );
   }
 

--- a/lib/views/photo_booth_screen/screens/photo_details_screen/photo_details_screen_controller.dart
+++ b/lib/views/photo_booth_screen/screens/photo_details_screen/photo_details_screen_controller.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 
 import 'package:auto_size_text/auto_size_text.dart';
-import 'package:flutter_mobx/flutter_mobx.dart';
 import 'package:momento_booth/main.dart';
 import 'package:momento_booth/managers/printing_manager.dart';
 import 'package:momento_booth/models/app_action.dart';
@@ -62,22 +61,19 @@ class PhotoDetailsScreenController extends ScreenControllerBase<PhotoDetailsScre
 
   void onClickGetQR() {
     registerActionCall(const AppActionCall(tool: "get_qr"));
-    viewModel.uploadPhotoToSend();
+    if (viewModel.file == null) {
+      logError("File is null when trying to get QR code");
+      return;
+    }
+    final actionsToken = Object();
     showUserDialog(
       barrierDismissible: false,
-      dialog: Observer(builder: (_) {
-        return QrShareDialog(
-          state: viewModel.uploadFailed
-              ? ShareDialogState.error
-              : viewModel.uploadProgress != null || viewModel.qrUrl == null
-                  ? ShareDialogState.uploading
-                  : ShareDialogState.uploaded,
-          uploadProgress: (viewModel.uploadProgress ?? 0) * 100,
-          qrText: viewModel.qrUrl,
-          onDismiss: () => navigator.pop(),
-          onRedoUpload: viewModel.uploadPhotoToSend,
-        );
-      }),
+      dialog: QrShareDialog(
+        file: viewModel.file!,
+        onDismiss: () => navigator.pop(),
+        actionsToken: actionsToken,
+      ),
+      actionStackToken: actionsToken,
     );
   }
 

--- a/lib/views/photo_booth_screen/screens/photo_details_screen/photo_details_screen_controller.dart
+++ b/lib/views/photo_booth_screen/screens/photo_details_screen/photo_details_screen_controller.dart
@@ -29,21 +29,21 @@ class PhotoDetailsScreenController extends ScreenControllerBase<PhotoDetailsScre
       callback: (_, response) { onClickPrev(); response(true, "Back button pressed"); },
       title: "Back",
       description: "Return to the gallery screen.",
-      examples: backPhrases
+      examples: backPhrasesExamples
     ),
     AppAction(
       name: "get_qr",
       callback: (_, response) { onClickGetQR(); response(true, "Uploading the picture to get a QR code"); },
       title: "Get QR Code",
       description: "Generate a QR code for sharing the photo.",
-      examples: getQRPhrases
+      examples: getQRPhrasesExamples
     ),
     AppAction(
       name: "open_print_dialog",
       callback: (_, response) { onClickPrint(); response(true, "Opening the print dialog"); },
       title: "Print",
       description: "Open the print dialog.",
-      examples: printPhrases
+      examples: printPhrasesExamples
     ),
   ];
 

--- a/lib/views/photo_booth_screen/screens/photo_details_screen/photo_details_screen_controller.dart
+++ b/lib/views/photo_booth_screen/screens/photo_details_screen/photo_details_screen_controller.dart
@@ -32,18 +32,18 @@ class PhotoDetailsScreenController extends ScreenControllerBase<PhotoDetailsScre
       examples: backPhrasesExamples
     ),
     AppAction(
-      name: "get_qr",
+      name: "share_with_qr_code_dialog",
       callback: (_, response) { onClickGetQR(); response(true, "Uploading the picture to get a QR code"); },
-      title: "Get QR Code",
-      description: "Generate a QR code for sharing the photo.",
-      examples: getQRPhrasesExamples
+      title: "Share with QR Code",
+      description: "Upload the photo, generate a QR code and display it in a dialog to share the photo.",
+      examples: getQRPhrasesExamples,
     ),
     AppAction(
       name: "open_print_dialog",
       callback: (_, response) { onClickPrint(); response(true, "Opening the print dialog"); },
-      title: "Print",
-      description: "Open the print dialog.",
-      examples: printPhrasesExamples
+      title: "Open Print Dialog",
+      description: "Open the print dialog where options can be selected and a print job can be submitted.",
+      examples: printPhrasesExamples,
     ),
   ];
 
@@ -65,13 +65,11 @@ class PhotoDetailsScreenController extends ScreenControllerBase<PhotoDetailsScre
       logError("File is null when trying to get QR code");
       return;
     }
-    final actionsToken = Object();
     showUserDialog(
       barrierDismissible: false,
       dialog: QrShareDialog(
         file: viewModel.file!,
         onDismiss: () => navigator.pop(),
-        actionsToken: actionsToken,
       ),
       publishActions: false,
     );

--- a/lib/views/photo_booth_screen/screens/photo_details_screen/photo_details_screen_view_model.dart
+++ b/lib/views/photo_booth_screen/screens/photo_details_screen/photo_details_screen_view_model.dart
@@ -4,14 +4,10 @@ import 'dart:ui';
 import 'package:mobx/mobx.dart';
 import 'package:momento_booth/main.dart';
 import 'package:momento_booth/managers/project_manager.dart';
-import 'package:momento_booth/managers/settings_manager.dart';
-import 'package:momento_booth/managers/stats_manager.dart';
 import 'package:momento_booth/models/gallery_image.dart';
 import 'package:momento_booth/models/maker_note_data.dart';
-import 'package:momento_booth/src/rust/api/ffsend.dart';
 import 'package:momento_booth/src/rust/api/images.dart';
 import 'package:momento_booth/src/rust/models/images.dart';
-import 'package:momento_booth/src/rust/utils/ffsend_client.dart';
 import 'package:momento_booth/views/base/screen_view_model_base.dart';
 import 'package:path/path.dart' as path;
 
@@ -41,54 +37,7 @@ abstract class PhotoDetailsScreenViewModelBase extends ScreenViewModelBase with 
   bool printEnabled = true;
 
   @readonly
-  double? _uploadProgress;
-
-  @readonly
-  bool _uploadFailed = false;
-
-  @readonly
-  String? _qrUrl;
-
-  @readonly
   Size? _imageSize;
-
-  String get ffSendUrl => getIt<SettingsManager>().settings.output.firefoxSendServerUrl;
-
-  Future<void> uploadPhotoToSend() async {
-    logDebug("Uploading ${file!.path}");
-
-    String basename = path.basename(file!.path);
-    Stream<FfSendTransferProgress> stream = ffsendUploadFile(
-      filePath: file!.path,
-      hostUrl: ffSendUrl,
-      downloadFilename: basename,
-      controlCommandTimeout: getIt<SettingsManager>().settings.output.firefoxSendControlCommandTimeout,
-      transferTimeout: getIt<SettingsManager>().settings.output.firefoxSendTransferTimeout,
-    );
-
-    _uploadProgress = 0.0;
-    _uploadFailed = false;
-
-    stream.listen((event) async {
-      if (event.isFinished) {
-        logDebug("Upload complete: ${event.downloadUrl}");
-
-        await Future.delayed(const Duration(milliseconds: 500));
-        _qrUrl = event.downloadUrl;
-        _uploadProgress = null;
-
-        getIt<StatsManager>().addUploadedPhoto();
-      } else {
-        logDebug("Uploading: ${event.transferredBytes}/${event.totalBytes} bytes");
-        _uploadProgress = event.transferredBytes / (event.totalBytes ?? 0);
-      }
-    }).onError((x) async {
-      logError("Upload failed, file path: ${file!.path}", x);
-      await Future.delayed(const Duration(seconds: 1));
-      _uploadProgress = null;
-      _uploadFailed = true;
-    });
-  }
 
   void onImageDecoded(Size size) => _imageSize = size;
 

--- a/lib/views/photo_booth_screen/screens/share_screen/share_screen_controller.dart
+++ b/lib/views/photo_booth_screen/screens/share_screen/share_screen_controller.dart
@@ -7,6 +7,7 @@ import 'package:momento_booth/managers/photos_manager.dart';
 import 'package:momento_booth/managers/printing_manager.dart';
 import 'package:momento_booth/managers/sfx_manager.dart';
 import 'package:momento_booth/managers/stats_manager.dart';
+import 'package:momento_booth/models/app_action.dart';
 import 'package:momento_booth/models/settings.dart';
 import 'package:momento_booth/views/base/printer_status_dialog_mixin.dart';
 import 'package:momento_booth/views/base/screen_controller_base.dart';
@@ -23,6 +24,14 @@ import 'package:path/path.dart' as path;
 class ShareScreenController extends ScreenControllerBase<ShareScreenViewModel> with PrinterStatusDialogMixin<ShareScreenViewModel> {
 
   AutoSizeGroup actionButtonGroup = AutoSizeGroup(), navigationButtonGroup = AutoSizeGroup();
+
+  @override
+  List<AppAction> get actions => [
+    AppAction(name: "retake", callback: (_) { onClickPrev(); }),
+    AppAction(name: "get_qr", callback: (_) { onClickGetQR(); }),
+    AppAction(name: "print", callback: (_) { onClickPrint(); }),
+    AppAction(name: "continue", callback: (_) { onClickNext(); }),
+  ];
 
   // Initialization/Deinitialization
 

--- a/lib/views/photo_booth_screen/screens/share_screen/share_screen_controller.dart
+++ b/lib/views/photo_booth_screen/screens/share_screen/share_screen_controller.dart
@@ -27,6 +27,9 @@ class ShareScreenController extends ScreenControllerBase<ShareScreenViewModel> w
   AutoSizeGroup actionButtonGroup = AutoSizeGroup(), navigationButtonGroup = AutoSizeGroup();
 
   @override
+  String get scopeName => "Share Screen";
+
+  @override
   List<AppAction> get actions => [
     AppAction(
       name: "retake",

--- a/lib/views/photo_booth_screen/screens/share_screen/share_screen_controller.dart
+++ b/lib/views/photo_booth_screen/screens/share_screen/share_screen_controller.dart
@@ -27,10 +27,30 @@ class ShareScreenController extends ScreenControllerBase<ShareScreenViewModel> w
 
   @override
   List<AppAction> get actions => [
-    AppAction(name: "retake", callback: (_) { onClickPrev(); }),
-    AppAction(name: "get_qr", callback: (_) { onClickGetQR(); }),
-    AppAction(name: "print", callback: (_) { onClickPrint(); }),
-    AppAction(name: "continue", callback: (_) { onClickNext(); }),
+    AppAction(
+      name: "retake",
+      callback: (_) { onClickPrev(); },
+      title: "Retake Photo",
+      description: "Retake the current photo."
+    ),
+    AppAction(
+      name: "get_qr",
+      callback: (_) { onClickGetQR(); },
+      title: "Get QR Code",
+      description: "Generate a QR code for sharing the photo."
+    ),
+    AppAction(
+      name: "print",
+      callback: (_) { onClickPrint(); },
+      title: "Print Photo",
+      description: "Open the print dialog."
+    ),
+    AppAction(
+      name: "continue",
+      callback: (_) { onClickNext(); },
+      title: "Continue",
+      description: "Proceed to the next screen."
+    ),
   ];
 
   // Initialization/Deinitialization

--- a/lib/views/photo_booth_screen/screens/share_screen/share_screen_controller.dart
+++ b/lib/views/photo_booth_screen/screens/share_screen/share_screen_controller.dart
@@ -8,6 +8,7 @@ import 'package:momento_booth/managers/printing_manager.dart';
 import 'package:momento_booth/managers/sfx_manager.dart';
 import 'package:momento_booth/managers/stats_manager.dart';
 import 'package:momento_booth/models/app_action.dart';
+import 'package:momento_booth/models/app_action_call.dart';
 import 'package:momento_booth/models/settings.dart';
 import 'package:momento_booth/utils/speech_phrases.dart';
 import 'package:momento_booth/views/base/printer_status_dialog_mixin.dart';
@@ -76,6 +77,7 @@ class ShareScreenController extends ScreenControllerBase<ShareScreenViewModel> w
 
   void onRetake (bool delete) {
     navigator.pop();
+    registerActionCall(AppActionCall(tool: "retake", arguments: {"delete": delete}));
     // The reset function will clear the capture mode, so we need to save it.
     final captureMode = getIt<PhotosManager>().captureMode;
     getIt<PhotosManager>().reset(advance: !delete);
@@ -92,12 +94,14 @@ class ShareScreenController extends ScreenControllerBase<ShareScreenViewModel> w
     if (viewModel.canRetake) {
       showUserDialog(dialog: RetakeDialog(onDelete: () => onRetake(true), onKeep: () => onRetake(false), onCancel: () => navigator.pop() ), barrierDismissible: false);
     } else {
+      registerActionCall(const AppActionCall(tool: "back"));
       getIt<StatsManager>().addCollageChange();
       router.go(CollageMakerScreen.defaultRoute);
     }
   }
 
   void onClickGetQR() {
+    registerActionCall(const AppActionCall(tool: "get_qr"));
     viewModel.uploadPhotoToSend();
     showUserDialog(
       barrierDismissible: false,
@@ -128,6 +132,7 @@ class ShareScreenController extends ScreenControllerBase<ShareScreenViewModel> w
 
   void onClickPrint() {
     if (!viewModel.printEnabled) return;
+    registerActionCall(const AppActionCall(tool: "open_print_dialog"));
     showUserDialog(
       barrierDismissible: false,
       dialog: PrintDialog(

--- a/lib/views/photo_booth_screen/screens/share_screen/share_screen_controller.dart
+++ b/lib/views/photo_booth_screen/screens/share_screen/share_screen_controller.dart
@@ -9,6 +9,7 @@ import 'package:momento_booth/managers/sfx_manager.dart';
 import 'package:momento_booth/managers/stats_manager.dart';
 import 'package:momento_booth/models/app_action.dart';
 import 'package:momento_booth/models/settings.dart';
+import 'package:momento_booth/utils/speech_phrases.dart';
 import 'package:momento_booth/views/base/printer_status_dialog_mixin.dart';
 import 'package:momento_booth/views/base/screen_controller_base.dart';
 import 'package:momento_booth/views/components/dialogs/print_dialog.dart';
@@ -31,25 +32,29 @@ class ShareScreenController extends ScreenControllerBase<ShareScreenViewModel> w
       name: "retake",
       callback: (_) { onClickPrev(); },
       title: "Retake Photo",
-      description: "Retake the current photo."
+      description: "Retake the current photo.",
+      examples: const ["retake", "take again", "try again", "do it again"],
     ),
     AppAction(
       name: "get_qr",
       callback: (_) { onClickGetQR(); },
       title: "Get QR Code",
-      description: "Generate a QR code for sharing the photo."
+      description: "Generate a QR code for sharing the photo.",
+      examples: getQRPhrases,
     ),
     AppAction(
       name: "print",
       callback: (_) { onClickPrint(); },
       title: "Print Photo",
-      description: "Open the print dialog."
+      description: "Open the print dialog.",
+      examples: printPhrases,
     ),
     AppAction(
       name: "continue",
       callback: (_) { onClickNext(); },
       title: "Continue",
-      description: "Proceed to the next screen."
+      description: "Proceed to the next screen.",
+      examples: continuePhrases,
     ),
   ];
 
@@ -122,15 +127,13 @@ class ShareScreenController extends ScreenControllerBase<ShareScreenViewModel> w
     if (!viewModel.printEnabled) return;
     showUserDialog(
       barrierDismissible: false,
-      dialog: Observer(builder: (_) {
-        return PrintDialog(
-          onPrintPressed: (size, copies) {
-            navigator.pop();
-            onConfirmPrint(size, copies);
-          },
-          onCancel: () => navigator.pop(),
-        );
-      }),
+      dialog: PrintDialog(
+        onPrintPressed: (size, copies) {
+          navigator.pop();
+          onConfirmPrint(size, copies);
+        },
+        onCancel: () => navigator.pop(),
+      ),
     );
   }
 

--- a/lib/views/photo_booth_screen/screens/share_screen/share_screen_controller.dart
+++ b/lib/views/photo_booth_screen/screens/share_screen/share_screen_controller.dart
@@ -8,6 +8,7 @@ import 'package:momento_booth/managers/sfx_manager.dart';
 import 'package:momento_booth/managers/stats_manager.dart';
 import 'package:momento_booth/models/app_action.dart';
 import 'package:momento_booth/models/app_action_call.dart';
+import 'package:momento_booth/models/app_action_example.dart';
 import 'package:momento_booth/models/settings.dart';
 import 'package:momento_booth/utils/speech_phrases.dart';
 import 'package:momento_booth/views/base/printer_status_dialog_mixin.dart';
@@ -36,28 +37,28 @@ class ShareScreenController extends ScreenControllerBase<ShareScreenViewModel> w
       callback: (_, response) { onClickPrev(); response(true, "Retaking photo"); },
       title: "Retake Photo",
       description: "Retake the current photo.",
-      examples: const ["retake", "take again", "try again", "do it again"],
+      examples: const ["retake", "take again", "try again", "do it again"].map((phrase) => AppActionExample(phrase: phrase)).toList(),
     ),
     AppAction(
       name: "get_qr",
       callback: (_, response) { onClickGetQR(); response(true, "Uploading the picture to get a QR code"); },
       title: "Get QR Code",
       description: "Generate a QR code for sharing the photo.",
-      examples: getQRPhrases,
+      examples: getQRPhrasesExamples,
     ),
     AppAction(
       name: "print",
       callback: (_, response) { onClickPrint(); response(true, "Opening the print dialog"); },
       title: "Print Photo",
       description: "Open the print dialog.",
-      examples: printPhrases,
+      examples: printPhrasesExamples,
     ),
     AppAction(
       name: "continue",
       callback: (_, response) { onClickNext(); response(true, "Continuing to the start screen"); },
       title: "Continue",
       description: "Proceed to the start screen.",
-      examples: continuePhrases,
+      examples: continuePhrasesExamples,
     ),
   ];
 

--- a/lib/views/photo_booth_screen/screens/share_screen/share_screen_controller.dart
+++ b/lib/views/photo_booth_screen/screens/share_screen/share_screen_controller.dart
@@ -34,30 +34,30 @@ class ShareScreenController extends ScreenControllerBase<ShareScreenViewModel> w
   List<AppAction> get actions => [
     AppAction(
       name: "retake",
-      callback: (_) { onClickPrev(); },
+      callback: (_, response) { onClickPrev(); response(true, "Retaking photo"); },
       title: "Retake Photo",
       description: "Retake the current photo.",
       examples: const ["retake", "take again", "try again", "do it again"],
     ),
     AppAction(
       name: "get_qr",
-      callback: (_) { onClickGetQR(); },
+      callback: (_, response) { onClickGetQR(); response(true, "Uploading the picture to get a QR code"); },
       title: "Get QR Code",
       description: "Generate a QR code for sharing the photo.",
       examples: getQRPhrases,
     ),
     AppAction(
       name: "print",
-      callback: (_) { onClickPrint(); },
+      callback: (_, response) { onClickPrint(); response(true, "Opening the print dialog"); },
       title: "Print Photo",
       description: "Open the print dialog.",
       examples: printPhrases,
     ),
     AppAction(
       name: "continue",
-      callback: (_) { onClickNext(); },
+      callback: (_, response) { onClickNext(); response(true, "Continuing to the start screen"); },
       title: "Continue",
-      description: "Proceed to the next screen.",
+      description: "Proceed to the start screen.",
       examples: continuePhrases,
     ),
   ];

--- a/lib/views/photo_booth_screen/screens/share_screen/share_screen_controller.dart
+++ b/lib/views/photo_booth_screen/screens/share_screen/share_screen_controller.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 
 import 'package:auto_size_text/auto_size_text.dart';
-import 'package:flutter_mobx/flutter_mobx.dart';
 import 'package:momento_booth/main.dart';
 import 'package:momento_booth/managers/photos_manager.dart';
 import 'package:momento_booth/managers/printing_manager.dart';
@@ -102,22 +101,20 @@ class ShareScreenController extends ScreenControllerBase<ShareScreenViewModel> w
 
   void onClickGetQR() {
     registerActionCall(const AppActionCall(tool: "get_qr"));
-    viewModel.uploadPhotoToSend();
+    viewModel.ensureFile();
+    if (viewModel.file == null) {
+      logError("File is null when trying to get QR code");
+      return;
+    }
+    final actionsToken = Object();
     showUserDialog(
       barrierDismissible: false,
-      dialog: Observer(builder: (_) {
-        return QrShareDialog(
-          state: viewModel.uploadFailed
-              ? ShareDialogState.error
-              : viewModel.uploadProgress != null || viewModel.qrUrl == null
-                  ? ShareDialogState.uploading
-                  : ShareDialogState.uploaded,
-          uploadProgress: (viewModel.uploadProgress ?? 0) * 100,
-          qrText: viewModel.qrUrl,
-          onDismiss: () => navigator.pop(),
-          onRedoUpload: viewModel.uploadPhotoToSend,
-        );
-      }),
+      dialog: QrShareDialog(
+        file: viewModel.file!,
+        onDismiss: () => navigator.pop(),
+        actionsToken: actionsToken,
+      ),
+      actionStackToken: actionsToken,
     );
   }
 

--- a/lib/views/photo_booth_screen/screens/share_screen/share_screen_controller.dart
+++ b/lib/views/photo_booth_screen/screens/share_screen/share_screen_controller.dart
@@ -114,7 +114,7 @@ class ShareScreenController extends ScreenControllerBase<ShareScreenViewModel> w
         onDismiss: () => navigator.pop(),
         actionsToken: actionsToken,
       ),
-      actionStackToken: actionsToken,
+      publishActions: false,
     );
   }
 
@@ -139,6 +139,7 @@ class ShareScreenController extends ScreenControllerBase<ShareScreenViewModel> w
         },
         onCancel: () => navigator.pop(),
       ),
+      publishActions: false,
     );
   }
 

--- a/lib/views/photo_booth_screen/screens/share_screen/share_screen_controller.dart
+++ b/lib/views/photo_booth_screen/screens/share_screen/share_screen_controller.dart
@@ -36,21 +36,21 @@ class ShareScreenController extends ScreenControllerBase<ShareScreenViewModel> w
       name: "retake",
       callback: (_, response) { onClickPrev(); response(true, "Retaking photo"); },
       title: "Retake Photo",
-      description: "Retake the current photo.",
+      description: "Open the retake dialog, where a user can choose to delete or keep the current photo.",
       examples: const ["retake", "take again", "try again", "do it again"].map((phrase) => AppActionExample(phrase: phrase)).toList(),
     ),
     AppAction(
-      name: "get_qr",
+      name: "share_with_qr_code_dialog",
       callback: (_, response) { onClickGetQR(); response(true, "Uploading the picture to get a QR code"); },
-      title: "Get QR Code",
-      description: "Generate a QR code for sharing the photo.",
+      title: "Share with QR Code",
+      description: "Upload the photo, generate a QR code and display it in a dialog to share the photo.",
       examples: getQRPhrasesExamples,
     ),
     AppAction(
-      name: "print",
+      name: "open_print_dialog",
       callback: (_, response) { onClickPrint(); response(true, "Opening the print dialog"); },
-      title: "Print Photo",
-      description: "Open the print dialog.",
+      title: "Open Print Dialog",
+      description: "Open the print dialog where options can be selected and a print job can be submitted.",
       examples: printPhrasesExamples,
     ),
     AppAction(
@@ -107,13 +107,11 @@ class ShareScreenController extends ScreenControllerBase<ShareScreenViewModel> w
       logError("File is null when trying to get QR code");
       return;
     }
-    final actionsToken = Object();
     showUserDialog(
       barrierDismissible: false,
       dialog: QrShareDialog(
         file: viewModel.file!,
         onDismiss: () => navigator.pop(),
-        actionsToken: actionsToken,
       ),
       publishActions: false,
     );

--- a/lib/views/photo_booth_screen/screens/share_screen/share_screen_view_model.dart
+++ b/lib/views/photo_booth_screen/screens/share_screen/share_screen_view_model.dart
@@ -3,16 +3,12 @@ import 'dart:typed_data';
 
 import 'package:confetti/confetti.dart';
 import 'package:fluent_ui/fluent_ui.dart';
-import 'package:intl/intl.dart';
 import 'package:mobx/mobx.dart';
 import 'package:momento_booth/main.dart';
 import 'package:momento_booth/managers/photos_manager.dart';
 import 'package:momento_booth/managers/project_manager.dart';
 import 'package:momento_booth/managers/settings_manager.dart';
-import 'package:momento_booth/managers/stats_manager.dart';
 import 'package:momento_booth/models/project_settings.dart';
-import 'package:momento_booth/src/rust/api/ffsend.dart';
-import 'package:momento_booth/src/rust/utils/ffsend_client.dart';
 import 'package:momento_booth/views/base/screen_view_model_base.dart';
 
 part 'share_screen_view_model.g.dart';
@@ -35,15 +31,6 @@ abstract class ShareScreenViewModelBase extends ScreenViewModelBase with Store {
 
   @observable
   bool printEnabled = true;
-
-  @readonly
-  double? _uploadProgress;
-
-  @readonly
-  bool _uploadFailed = false;
-
-  @readonly
-  String? _qrUrl;
 
   @readonly
   File? _file;
@@ -74,45 +61,8 @@ abstract class ShareScreenViewModelBase extends ScreenViewModelBase with Store {
   }
   String get backText => canRetake ? localizations.shareScreenRetakeButton : localizations.shareScreenChangeButton;
 
-  Future<void> uploadPhotoToSend() async {
+  Future<void> ensureFile() async {
     _file ??= getIt<PhotosManager>().lastPhotoFile ?? await getIt<PhotosManager>().getOutputImageAsTempFile();
-    final ext = getIt<SettingsManager>().settings.output.exportFormat.name.toLowerCase();
-
-    logDebug("Uploading ${_file!.path}");
-
-    // HHmmss string
-    DateFormat formatter = DateFormat('HHmmss');
-    String filename = "MomentoBooth ${formatter.format(DateTime.now())}.$ext";
-    Stream<FfSendTransferProgress> stream = ffsendUploadFile(
-      filePath: _file!.path,
-      hostUrl: ffSendUrl,
-      downloadFilename: filename,
-      controlCommandTimeout: getIt<SettingsManager>().settings.output.firefoxSendControlCommandTimeout,
-      transferTimeout: getIt<SettingsManager>().settings.output.firefoxSendTransferTimeout,
-    );
-
-    _uploadProgress = 0.0;
-    _uploadFailed = false;
-
-    stream.listen((event) async {
-      if (event.isFinished) {
-        logDebug("Upload complete: ${event.downloadUrl}");
-
-        await Future.delayed(const Duration(milliseconds: 500));
-        _qrUrl = event.downloadUrl;
-        _uploadProgress = null;
-
-        getIt<StatsManager>().addUploadedPhoto();
-      } else {
-        logDebug("Uploading: ${event.transferredBytes}/${event.totalBytes} bytes");
-        _uploadProgress = event.transferredBytes / (event.totalBytes ?? 0);
-      }
-    }).onError((x) async {
-      logError("Upload failed, file path: ${_file!.path}", x);
-      await Future.delayed(const Duration(seconds: 1));
-      _uploadProgress = null;
-      _uploadFailed = true;
-    });
   }
 
   void onImageDecoded(Size size) => _imageSize = size;

--- a/lib/views/photo_booth_screen/screens/single_capture_screen/single_capture_screen_controller.dart
+++ b/lib/views/photo_booth_screen/screens/single_capture_screen/single_capture_screen_controller.dart
@@ -5,6 +5,9 @@ import 'package:momento_booth/views/photo_booth_screen/screens/single_capture_sc
 
 class SingleCaptureScreenController extends ScreenControllerBase<SingleCaptureScreenViewModel> {
 
+  @override
+  String get scopeName => "Single Capture Screen";
+
   // Initialization/Deinitialization
 
   SingleCaptureScreenController({

--- a/lib/views/photo_booth_screen/screens/start_screen/start_screen_controller.dart
+++ b/lib/views/photo_booth_screen/screens/start_screen/start_screen_controller.dart
@@ -18,6 +18,9 @@ import 'package:momento_booth/views/settings_overlay/settings_overlay_view.dart'
 class StartScreenController extends ScreenControllerBase<StartScreenViewModel> with PrinterStatusDialogMixin<StartScreenViewModel> {
 
   @override
+  String get scopeName => "Start Screen";
+
+  @override
   List<AppAction> get actions => [
     AppAction(
       name: "start",

--- a/lib/views/photo_booth_screen/screens/start_screen/start_screen_controller.dart
+++ b/lib/views/photo_booth_screen/screens/start_screen/start_screen_controller.dart
@@ -23,7 +23,8 @@ class StartScreenController extends ScreenControllerBase<StartScreenViewModel> w
       name: "start",
       callback: (_) { onPressedContinue(); },
       title: "Start",
-      description: "Begin the photo booth experience."
+      description: "Begin the photo booth experience.",
+      examples: const ["start", "begin", "let's go", "proceed", "continue"],
     )
   ];
 

--- a/lib/views/photo_booth_screen/screens/start_screen/start_screen_controller.dart
+++ b/lib/views/photo_booth_screen/screens/start_screen/start_screen_controller.dart
@@ -5,6 +5,7 @@ import 'package:momento_booth/main.dart';
 import 'package:momento_booth/managers/project_manager.dart';
 import 'package:momento_booth/managers/window_manager.dart';
 import 'package:momento_booth/models/app_action.dart';
+import 'package:momento_booth/models/app_action_call.dart';
 import 'package:momento_booth/repositories/secrets/secrets_repository.dart';
 import 'package:momento_booth/views/base/printer_status_dialog_mixin.dart';
 import 'package:momento_booth/views/base/screen_controller_base.dart';
@@ -52,6 +53,7 @@ class StartScreenController extends ScreenControllerBase<StartScreenViewModel> w
   // User interaction methods
 
   void onPressedContinue() {
+    registerActionCall(const AppActionCall(tool: "start"));
     router.go(NavigationScreen.defaultRoute);
   }
 

--- a/lib/views/photo_booth_screen/screens/start_screen/start_screen_controller.dart
+++ b/lib/views/photo_booth_screen/screens/start_screen/start_screen_controller.dart
@@ -4,18 +4,21 @@ import 'package:fluent_ui/fluent_ui.dart';
 import 'package:momento_booth/main.dart';
 import 'package:momento_booth/managers/project_manager.dart';
 import 'package:momento_booth/managers/window_manager.dart';
+import 'package:momento_booth/models/app_action.dart';
 import 'package:momento_booth/repositories/secrets/secrets_repository.dart';
 import 'package:momento_booth/views/base/printer_status_dialog_mixin.dart';
 import 'package:momento_booth/views/base/screen_controller_base.dart';
 import 'package:momento_booth/views/components/dialogs/enter_pin_dialog.dart';
 import 'package:momento_booth/views/components/dialogs/no_project_open_dialog.dart';
-import 'package:momento_booth/views/photo_booth_screen/screens/gallery_screen/gallery_screen.dart';
 import 'package:momento_booth/views/photo_booth_screen/screens/navigation_screen/navigation_screen.dart';
 import 'package:momento_booth/views/photo_booth_screen/screens/start_screen/start_screen_view_model.dart';
 import 'package:momento_booth/views/settings_overlay/settings_overlay.dart';
 import 'package:momento_booth/views/settings_overlay/settings_overlay_view.dart';
 
 class StartScreenController extends ScreenControllerBase<StartScreenViewModel> with PrinterStatusDialogMixin<StartScreenViewModel> {
+
+  @override
+  List<AppAction> get actions => [AppAction(name: "start", callback: (_) { onPressedContinue(); })];
 
   // Initialization/Deinitialization
 
@@ -39,10 +42,6 @@ class StartScreenController extends ScreenControllerBase<StartScreenViewModel> w
 
   void onPressedContinue() {
     router.go(NavigationScreen.defaultRoute);
-  }
-
-  void onPressedGallery() {
-    router.push(GalleryScreen.defaultRoute);
   }
 
   Future<void> onPressedOpenSettings() async {

--- a/lib/views/photo_booth_screen/screens/start_screen/start_screen_controller.dart
+++ b/lib/views/photo_booth_screen/screens/start_screen/start_screen_controller.dart
@@ -18,7 +18,14 @@ import 'package:momento_booth/views/settings_overlay/settings_overlay_view.dart'
 class StartScreenController extends ScreenControllerBase<StartScreenViewModel> with PrinterStatusDialogMixin<StartScreenViewModel> {
 
   @override
-  List<AppAction> get actions => [AppAction(name: "start", callback: (_) { onPressedContinue(); })];
+  List<AppAction> get actions => [
+    AppAction(
+      name: "start",
+      callback: (_) { onPressedContinue(); },
+      title: "Start",
+      description: "Begin the photo booth experience."
+    )
+  ];
 
   // Initialization/Deinitialization
 

--- a/lib/views/photo_booth_screen/screens/start_screen/start_screen_controller.dart
+++ b/lib/views/photo_booth_screen/screens/start_screen/start_screen_controller.dart
@@ -6,6 +6,7 @@ import 'package:momento_booth/managers/project_manager.dart';
 import 'package:momento_booth/managers/window_manager.dart';
 import 'package:momento_booth/models/app_action.dart';
 import 'package:momento_booth/models/app_action_call.dart';
+import 'package:momento_booth/models/app_action_example.dart';
 import 'package:momento_booth/repositories/secrets/secrets_repository.dart';
 import 'package:momento_booth/views/base/printer_status_dialog_mixin.dart';
 import 'package:momento_booth/views/base/screen_controller_base.dart';
@@ -28,7 +29,7 @@ class StartScreenController extends ScreenControllerBase<StartScreenViewModel> w
       callback: (_, response) { onPressedContinue(); response(true, "Navigating to the central navigation screen"); },
       title: "Start",
       description: "Begin the photo booth experience.",
-      examples: const ["start", "begin", "let's go", "proceed", "continue"],
+      examples: const ["start", "begin", "let's go", "proceed", "continue"].map((phrase) => AppActionExample(phrase: phrase)).toList(),
     )
   ];
 

--- a/lib/views/photo_booth_screen/screens/start_screen/start_screen_controller.dart
+++ b/lib/views/photo_booth_screen/screens/start_screen/start_screen_controller.dart
@@ -25,7 +25,7 @@ class StartScreenController extends ScreenControllerBase<StartScreenViewModel> w
   List<AppAction> get actions => [
     AppAction(
       name: "start",
-      callback: (_) { onPressedContinue(); },
+      callback: (_, response) { onPressedContinue(); response(true, "Navigating to the central navigation screen"); },
       title: "Start",
       description: "Begin the photo booth experience.",
       examples: const ["start", "begin", "let's go", "proceed", "continue"],

--- a/lib/views/settings_overlay/pages/settings_overlay_view.general.dart
+++ b/lib/views/settings_overlay/pages/settings_overlay_view.general.dart
@@ -25,6 +25,30 @@ Widget _getGeneralSettings(SettingsOverlayViewModel viewModel, SettingsOverlayCo
         value: () => viewModel.enableWakelockSetting,
         onChanged: controller.onEnableWakelockChanged,
       ),
+      SettingsSection(
+        title: "Control",
+        settings: [
+          Padding(
+            padding: EdgeInsets.symmetric(vertical: 8.0),
+            child: Text("When control is enabled, MomentoBooth can receive commands and send updates to external applications, such as Home Assistant. "
+            "This allows you to integrate MomentoBooth into your smart home setup and automate it based on various triggers. Currently this is done through MQTT, configure this in the MQTT settings."),
+          ),
+          SettingsToggleTile(
+            icon: LucideIcons.sendToBack,
+            title: "Enable control features",
+            subtitle: "When enabled, MomentoBooth will publish updates about its state and listen for incoming commands to control it. If you don't use this, it's best to keep it disabled for security and performance reasons.",
+            value: () => viewModel.allowControlSetting,
+            onChanged: controller.onAllowControlChanged,
+          ),
+          SettingsNumberEditTile(
+            icon: LucideIcons.shieldEllipsis,
+            title: "Control disable duration after touch",
+            subtitle: 'In milliseconds. After a user interacts with the photobooth (e.g. by touching the screen), control features will be automatically disabled for this duration to prevent unwanted remote interactions while people are using the booth.',
+            value: () => viewModel.controlDisableDurationMsAfterTouchSetting,
+            onFinishedEditing: controller.onControlDisableDurationAfterTouchChanged,
+          ),
+        ]
+      ),
       const SettingsSection(
         title: "Hotkeys",
         settings: [

--- a/lib/views/settings_overlay/pages/settings_overlay_view.general.dart
+++ b/lib/views/settings_overlay/pages/settings_overlay_view.general.dart
@@ -47,6 +47,13 @@ Widget _getGeneralSettings(SettingsOverlayViewModel viewModel, SettingsOverlayCo
             value: () => viewModel.controlDisableDurationMsAfterTouchSetting,
             onFinishedEditing: controller.onControlDisableDurationAfterTouchChanged,
           ),
+          SettingsNumberEditTile(
+            icon: LucideIcons.history,
+            title: "Control history retention duration",
+            subtitle: 'In seconds. MomentoBooth keeps a history of received control commands for this duration. This can be used to provide context to new commands.',
+            value: () => viewModel.controlHistoryDurationSecondsSetting,
+            onFinishedEditing: controller.onControlHistoryDurationSecondsChanged,
+          ),
         ]
       ),
       const SettingsSection(

--- a/lib/views/settings_overlay/settings_overlay_controller.dart
+++ b/lib/views/settings_overlay/settings_overlay_controller.dart
@@ -229,6 +229,12 @@ class SettingsOverlayController extends ScreenControllerBase<SettingsOverlayView
     }
   }
 
+  void onControlHistoryDurationSecondsChanged(int? duration) {
+    if (duration != null) {
+      viewModel.updateSettings((settings) => settings.copyWith.control(controlHistoryDurationSeconds: duration));
+    }
+  }
+
   void onLiveViewAndCaptureRotateChanged(Rotate? liveViewAndCaptureRotate) {
     if (liveViewAndCaptureRotate != null) {
       viewModel.updateSettings((settings) => settings.copyWith.hardware(liveViewAndCaptureRotate: liveViewAndCaptureRotate));

--- a/lib/views/settings_overlay/settings_overlay_controller.dart
+++ b/lib/views/settings_overlay/settings_overlay_controller.dart
@@ -217,6 +217,18 @@ class SettingsOverlayController extends ScreenControllerBase<SettingsOverlayView
     }
   }
 
+  void onAllowControlChanged(bool? enable) {
+    if (enable != null) {
+      viewModel.updateSettings((settings) => settings.copyWith.control(enable: enable));
+    }
+  }
+
+  void onControlDisableDurationAfterTouchChanged(int? duration) {
+    if (duration != null) {
+      viewModel.updateSettings((settings) => settings.copyWith.control(controlDisableDurationMsAfterTouch: duration));
+    }
+  }
+
   void onLiveViewAndCaptureRotateChanged(Rotate? liveViewAndCaptureRotate) {
     if (liveViewAndCaptureRotate != null) {
       viewModel.updateSettings((settings) => settings.copyWith.hardware(liveViewAndCaptureRotate: liveViewAndCaptureRotate));

--- a/lib/views/settings_overlay/settings_overlay_view_model.dart
+++ b/lib/views/settings_overlay/settings_overlay_view_model.dart
@@ -227,6 +227,7 @@ abstract class SettingsOverlayViewModelBase extends ScreenViewModelBase with Sto
   bool get loadLastProjectSetting => getIt<SettingsManager>().settings.loadLastProject;
   bool get allowControlSetting => getIt<SettingsManager>().settings.control.enable;
   int get controlDisableDurationMsAfterTouchSetting => getIt<SettingsManager>().settings.control.controlDisableDurationMsAfterTouch;
+  int get controlHistoryDurationSecondsSetting => getIt<SettingsManager>().settings.control.controlHistoryDurationSeconds;
   double get collageAspectRatioSetting => getIt<SettingsManager>().settings.collageAspectRatio;
   double get collagePaddingSetting => getIt<SettingsManager>().settings.collagePadding;
   bool get enableWakelockSetting => getIt<SettingsManager>().settings.enableWakelock;

--- a/lib/views/settings_overlay/settings_overlay_view_model.dart
+++ b/lib/views/settings_overlay/settings_overlay_view_model.dart
@@ -225,6 +225,8 @@ abstract class SettingsOverlayViewModelBase extends ScreenViewModelBase with Sto
   // System settings current values
   int get captureDelaySecondsSetting => getIt<SettingsManager>().settings.captureDelaySeconds;
   bool get loadLastProjectSetting => getIt<SettingsManager>().settings.loadLastProject;
+  bool get allowControlSetting => getIt<SettingsManager>().settings.control.enable;
+  int get controlDisableDurationMsAfterTouchSetting => getIt<SettingsManager>().settings.control.controlDisableDurationMsAfterTouch;
   double get collageAspectRatioSetting => getIt<SettingsManager>().settings.collageAspectRatio;
   double get collagePaddingSetting => getIt<SettingsManager>().settings.collagePadding;
   bool get enableWakelockSetting => getIt<SettingsManager>().settings.enableWakelock;


### PR DESCRIPTION
This PR adds an API to the app that allows controlling it without a mouse or a touchscreen. It does this by gathering so-called "actions" that represent the buttons that can be pressed and other controls in the currently visible scope (page/dialog). The current interaction is implemented in MQTT, but could later be extended to other forms of communication.

## MQTT API
The actions are exposed through MQTT under `$base_topic/actions/list` and can be called through `$base_topic/actions/execute`. An executed action can return a result under `$base_topic/actions/execute/result`. Additionally, `$base_topic/actions/scopes` contains the current navigation stack as a list of scope names. `$base_topic/actions/call_history` contains a map of the actions executed in the last $x$ seconds (configurable). `$base_topic/actions/listening` is a boolean that indicates whether the software currently accepts commands. Finally, `$base_topic/notify` allows showing a toast notification on screen.

### Home Assistant integration
The actions are also published as an [MQTT select entity](https://www.home-assistant.io/integrations/select.mqtt/). Thus, one can execute an action from the UI or from an automation. The available options in the UI update live as MomentoBooth's state changes. Also, a [MQTT notify enitity](https://www.home-assistant.io/integrations/notify.mqtt/) is added to show the toast notifications in MomentoBooth from an automation in Home Assistant.

## Interaction notes
The "listening" boolean is implemented in a way that it is false in scopes without actions (mainly settings screen, capture screens), and during a short time after the user touches/clicks on the screen, to prevent interference of external control when a local user is using the interface. The previously-mentioned toast notifications show only when "listening" is true.

The image below shows a screenshot of a toast with a transcript of a user's speech.
<img width="1280" height="707" alt="image" src="https://github.com/user-attachments/assets/804c0aab-5eb9-449b-9917-aace6bff2f15" />


## Data notes
The models are `AppAction`, `AppActionCall`, and `AppActionResponse`. Below, `AppAction` is shown. It is a superset of an [MCP tool definition](https://modelcontextprotocol.io/specification/2025-11-25/server/tools#tool), where `examples` and `inputSchemaExample` are added that can be used in prompting an LLM and steer it in the right direction. The examples can also be used for direct matching of queries, although this, of course, is only English in the current state. I've considered having this map of examples to the actions outside of the main Dart source code to make it less obnoxious to update, but this can always be done in the future or on a client's side if one wishes.
```dart
AppAction({
    required String name,
    required String title,
    required String description,
    @Default([]) List<AppActionExample> examples,
    @Default({ "type": "object", "additionalProperties": false }) Map<String, dynamic> inputSchema,
    @Default('{}') String inputSchemaExample,
    @JsonKey(includeToJson: false, includeFromJson: false)
    required Function(Map<String, dynamic>, Function(bool, String)) callback,
})
```

### Example data
- `list`
  ```json
  [
      {
          "name": "cancel",
          "title": "Cancel",
          "description": "Presses the cancel button in the print dialog.",
          "examples": [
              {
                  "phrase": "cancel",
                  "arguments": {}
              },
              {
                  "phrase": "stop",
                  "arguments": {}
              },
              {
                  "phrase": "abort",
                  "arguments": {}
              },
              {
                  "phrase": "never mind",
                  "arguments": {}
              },
              {
                  "phrase": "forget it",
                  "arguments": {}
              },
              {
                  "phrase": "close",
                  "arguments": {}
              },
              {
                  "phrase": "dismiss",
                  "arguments": {}
              },
              {
                  "phrase": "exit",
                  "arguments": {}
              }
          ],
          "inputSchema": {
              "type": "object",
              "additionalProperties": false
          },
          "inputSchemaExample": "{}"
      },
      {
          "name": "set_copies",
          "title": "Set Copies",
          "description": "Sets the number of copies to print.",
          "examples": [
              {
                  "phrase": "set copies to {copies:1}",
                  "arguments": {
                      "copies": 1
                  }
              },
              {
                  "phrase": "make {copies:three} copies",
                  "arguments": {
                      "copies": 3
                  }
              },
              {
                  "phrase": "change copies to {copies:four}",
                  "arguments": {
                      "copies": 4
                  }
              },
              {
                  "phrase": "set number of copies to {copies:2}",
                  "arguments": {
                      "copies": 2
                  }
              }
          ],
          "inputSchema": {
              "type": "object",
              "properties": {
                  "copies": {
                      "type": "integer",
                      "description": "The number of copies to print",
                      "minimum": 1,
                      "maximum": 5
                  }
              },
              "required": [
                  "copies"
              ],
              "additionalProperties": false
          },
          "inputSchemaExample": "{ \"copies\": integer between 1 and 5 }"
      },
      {
          "name": "set_size",
          "title": "Set Size",
          "description": "Sets the print size.",
          "examples": [
              {
                  "phrase": "set print size to {size:Normal print size}",
                  "arguments": {
                      "size": "Normal print size"
                  }
              },
              {
                  "phrase": "change print size to {size:Small print size}",
                  "arguments": {
                      "size": "Small print size"
                  }
              },
              {
                  "phrase": "set size to {size:Normal print size}",
                  "arguments": {
                      "size": "Normal print size"
                  }
              },
              {
                  "phrase": "change size to {size:Tiny print size}",
                  "arguments": {
                      "size": "Tiny print size"
                  }
              }
          ],
          "inputSchema": {
              "type": "object",
              "properties": {
                  "size": {
                      "enum": [
                          "Normal print size",
                          "Small print size",
                          "Tiny print size"
                      ],
                      "description": "The print size to set"
                  }
              },
              "required": [
                  "size"
              ],
              "additionalProperties": false
          },
          "inputSchemaExample": "{ \"size\": one of \"Normal print size\", \"Small print size\", \"Tiny print size\" }"
      },
      {
          "name": "print",
          "title": "Print",
          "description": "Presses the print button in the print dialog.",
          "examples": [
              {
                  "phrase": "print",
                  "arguments": {}
              },
              {
                  "phrase": "print it",
                  "arguments": {}
              },
              {
                  "phrase": "print photo",
                  "arguments": {}
              },
              {
                  "phrase": "print picture",
                  "arguments": {}
              },
              {
                  "phrase": "i want a print",
                  "arguments": {}
              },
              {
                  "phrase": "i want to print",
                  "arguments": {}
              },
              {
                  "phrase": "let's print",
                  "arguments": {}
              }
          ],
          "inputSchema": {
              "type": "object",
              "additionalProperties": false
          },
          "inputSchemaExample": "{}"
      }
  ]
  ```
- `scopes`
  ```json
    ["Navigation Screen","Gallery Screen","Photo Details Screen","Print Dialog"]
  ```
- `call_history`
  ```json
    {
      "2026-05-10T23:04:53.699725": {
          "tool": "gallery",
          "arguments": {}
      },
      "2026-05-10T23:05:02.443504": {
          "tool": "open_photo",
          "arguments": {
              "filename": "MomentoBooth-image-0017.jpg"
          }
      },
      "2026-05-10T23:05:03.862882": {
          "tool": "open_print_dialog",
          "arguments": {}
      }
  }
  ```
- `listening`
  ```json
  true
  ```
- `execute`
  ```json
  {
      "tool": "open_print_dialog",
      "arguments": {}
  }
  ```
  - `result`
    ```json
    {
        "success": true,
        "message": "Opening the print dialog"
    }
    ```

## Settings
Three new settings are added
1. Enable/disable control
  Currently, the control is implemented using MQTT, so maybe this setting should end up there.
2. Control disable after touch duration
3. Control history retention duration

## Usage
I've been tinkering and experimenting a bit see https://github.com/momentobooth/MomentoVoiceControl