### PR TITLE
Add per-collage-type printer routing

### DIFF
--- a/lib/hardware_control/printing/printing_system_client.dart
+++ b/lib/hardware_control/printing/printing_system_client.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:io';
 import 'dart:typed_data';
 
+import 'package:collection/collection.dart';
 import 'package:intl/intl.dart';
 import 'package:momento_booth/exceptions/printing_exception.dart';
 import 'package:momento_booth/main.dart';
@@ -23,6 +24,11 @@ abstract class PrintingSystemClient with Logger {
   Future<void> printPdfToQueue(String queueId, String taskName, Uint8List pdfData, {PrintSize printSize = PrintSize.normal});
 
   Future<void> printPdf(String taskName, Uint8List pdfData, {int copies=1, PrintSize printSize = PrintSize.normal}) async {
+    if (getIt<SettingsManager>().settings.hardware.enablePrinterRouting) {
+      await _printRouted(taskName, pdfData, copies: copies, printSize: printSize);
+      return;
+    }
+
     final printers = await getSelectedPrintQueues();
     if (printers.isEmpty) throw PrintingException('No valid printers selected');
 
@@ -55,6 +61,44 @@ abstract class PrintingSystemClient with Logger {
         'printers': usedPrinters,
         'printSize': printSize.toString(),
       }));
+    }
+  }
+
+  /// Routed printing: dispatch a job only to the printers whose assignment is enabled and covers [printSize].
+  /// This lets the user bind, for example, a physical printer to single-photo prints and a virtual printer to 3-photo collages.
+  Future<void> _printRouted(String taskName, Uint8List pdfData, {required int copies, required PrintSize printSize}) async {
+    final settings = getIt<SettingsManager>().settings.hardware;
+    final available = await getPrintQueues();
+
+    // Imprimantes activées dont l'assignation couvre ce type de collage.
+    final List<PrintQueueInfo> targets = [];
+    for (final assignment in settings.printerAssignments) {
+      if (!assignment.enabled || !assignment.printSizes.contains(printSize)) continue;
+      final PrintQueueInfo? match = available.firstWhereOrNull((printer) => printer.id == assignment.queueId);
+      if (match == null) {
+        logError("Routed printer not found or offline [${assignment.queueId}] for print size ${printSize.name}");
+      } else {
+        targets.add(match);
+      }
+    }
+
+    if (targets.isEmpty) throw PrintingException('No printer assigned to print size ${printSize.name}');
+
+    Future<void> printToTarget(PrintQueueInfo printer) async {
+      for (int i = 0; i < copies; i++) {
+        final String jobName = "$taskName | ${printSize.name} | copy ${i + 1} / $copies";
+        logDebug("Routed printing $taskName at ${printSize.name}, copy #${i + 1} / $copies to printer [${printer.name}]");
+        await printPdfToQueue(printer.id, jobName, pdfData, printSize: printSize);
+        getIt<StatsManager>().addPrintedPhoto(size: printSize);
+      }
+    }
+
+    if (settings.printDispatchMode == PrintDispatchMode.parallel) {
+      await Future.wait(targets.map(printToTarget));
+    } else {
+      for (final target in targets) {
+        await printToTarget(target);
+      }
     }
   }
 

--- a/lib/models/settings.dart
+++ b/lib/models/settings.dart
@@ -83,6 +83,9 @@ sealed class HardwareSettings with _$HardwareSettings implements TomlEncodableVa
     @Default(true) bool saveCapturesToDisk,
     @Default(PrintingImplementation.flutterPrinting) PrintingImplementation printingImplementation,
     @Default([]) List<String> flutterPrintingPrinterNames,
+    @Default(false) bool enablePrinterRouting,
+    @Default([]) List<PrinterAssignment> printerAssignments,
+    @Default(PrintDispatchMode.sequential) PrintDispatchMode printDispatchMode,
     @Default("http://localhost:631/") String cupsUri,
     @Default(false) bool cupsIgnoreTlsErrors,
     @Default("") String cupsUsername,
@@ -126,6 +129,26 @@ sealed class PrintLayoutSettings with _$PrintLayoutSettings implements TomlEncod
   factory PrintLayoutSettings.withDefaults() => PrintLayoutSettings.fromJson({});
 
   factory PrintLayoutSettings.fromJson(Map<String, Object?> json) => _$PrintLayoutSettingsFromJson(json);
+
+  @override
+  Map<String, dynamic> toTomlValue() => toJson();
+
+}
+
+@Freezed(fromJson: true, toJson: true)
+sealed class PrinterAssignment with _$PrinterAssignment implements TomlEncodableValue {
+
+  const PrinterAssignment._();
+
+  const factory PrinterAssignment({
+    @Default("") String queueId,
+    @Default(true) bool enabled,
+    @Default(<PrintSize>{}) Set<PrintSize> printSizes,
+  }) = _PrinterAssignment;
+
+  factory PrinterAssignment.withDefaults() => PrinterAssignment.fromJson({});
+
+  factory PrinterAssignment.fromJson(Map<String, Object?> json) => _$PrinterAssignmentFromJson(json);
 
   @override
   Map<String, dynamic> toTomlValue() => toJson();

--- a/lib/models/settings.enums.dart
+++ b/lib/models/settings.enums.dart
@@ -281,6 +281,25 @@ enum PrintSize {
   // can use named parameters if you want
   const PrintSize(this.name);
 
+  ComboBoxItem<PrintSize> toComboBoxItem() => ComboBoxItem(value: this, child: Text(name));
+
+  static List<ComboBoxItem<PrintSize>> asComboBoxItems() => values.map((value) => value.toComboBoxItem()).toList();
+
+}
+
+enum PrintDispatchMode {
+
+  sequential("Sequential"),
+  parallel("Parallel");
+
+  final String name;
+
+  const PrintDispatchMode(this.name);
+
+  ComboBoxItem<PrintDispatchMode> toComboBoxItem() => ComboBoxItem(value: this, child: Text(name));
+
+  static List<ComboBoxItem<PrintDispatchMode>> asComboBoxItems() => values.map((value) => value.toComboBoxItem()).toList();
+
 }
 
 enum ExternalSystemCheckType {

--- a/lib/views/settings_overlay/pages/settings_overlay_view.hardware.dart
+++ b/lib/views/settings_overlay/pages/settings_overlay_view.hardware.dart
@@ -192,6 +192,32 @@ Widget _getPrintingBlock(SettingsOverlayViewModel viewModel, SettingsOverlayCont
         value: () => viewModel.printingImplementationSetting,
         onChanged: controller.onPrintingImplementationChanged,
       ),
+      SettingsToggleTile(
+        icon: LucideIcons.route,
+        title: "Route prints by collage type",
+        subtitle: "Assign each printer to specific collage types (print sizes), e.g. a physical printer for single-photo prints and a virtual printer for 3-photo collages. When disabled, selected printers are used in round-robin.",
+        value: () => viewModel.enablePrinterRoutingSetting,
+        onChanged: controller.onEnablePrinterRoutingChanged,
+      ),
+      Observer(builder: (_) => viewModel.enablePrinterRoutingSetting
+          ? SettingsComboBoxTile(
+              icon: LucideIcons.splitSquareHorizontal,
+              title: "Dispatch mode",
+              subtitle: "When several printers are assigned to the same collage type: print one after another (sequential) or simultaneously (parallel).",
+              items: PrintDispatchMode.asComboBoxItems(),
+              value: () => viewModel.printDispatchModeSetting,
+              onChanged: controller.onPrintDispatchModeChanged,
+            )
+          : const SizedBox()),
+      Observer(builder: (_) => viewModel.enablePrinterRoutingSetting
+          ? Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                for (int i = 0; i <= viewModel.printerAssignmentsSetting.length; i++)
+                  _printerAssignmentCard(viewModel, controller, "Assignment ${i + 1}", i),
+              ],
+            )
+          : const SizedBox()),
       _printerMargins(viewModel, controller),
       SettingsNumberEditTile(
         icon: LucideIcons.printerCheck,
@@ -513,6 +539,68 @@ SettingsTile _printerCard(SettingsOverlayViewModel viewModel, SettingsOverlayCon
             disabledPlaceholder: Text('<No options>'),
           );
         }),
+      ],
+    ),
+  );
+}
+
+SettingsTile _printerAssignmentCard(SettingsOverlayViewModel viewModel, SettingsOverlayController controller, String title, int index) {
+  final bool exists = index < viewModel.printerAssignmentsSetting.length;
+  final PrinterAssignment? assignment = exists ? viewModel.printerAssignmentsSetting[index] : null;
+  final bool useCups = viewModel.printingImplementationSetting == PrintingImplementation.cups;
+  final List<ComboBoxItem<String>> queueItems = useCups ? viewModel.cupsQueues : viewModel.flutterPrintingQueues;
+
+  return SettingsTile(
+    icon: LucideIcons.printerCheck,
+    title: title,
+    subtitle: "Pick a printer and the collage types (print sizes) it should handle.",
+    setting: Column(
+      crossAxisAlignment: CrossAxisAlignment.end,
+      children: [
+        Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Button(
+              onPressed: useCups ? viewModel.setCupsQueueList : viewModel.setFlutterPrintingQueueList,
+              child: const Text('Refresh'),
+            ),
+            const SizedBox(width: 10),
+            ComboBox<String>(
+              items: queueItems,
+              value: assignment?.queueId.isNotEmpty == true ? assignment!.queueId : viewModel.unusedPrinterValue,
+              onChanged: (value) => controller.onAssignmentPrinterChanged(value, index),
+              disabledPlaceholder: const Text('<No options>'),
+            ),
+          ],
+        ),
+        if (exists) ...[
+          const SizedBox(height: 8),
+          Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const Text("Enabled"),
+              const SizedBox(width: 8),
+              ToggleSwitch(
+                checked: assignment!.enabled,
+                onChanged: (value) => controller.onAssignmentEnabledChanged(index, value),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          Wrap(
+            spacing: 12,
+            runSpacing: 4,
+            alignment: WrapAlignment.end,
+            children: [
+              for (final size in PrintSize.values)
+                Checkbox(
+                  checked: assignment.printSizes.contains(size),
+                  content: Text(size.name),
+                  onChanged: (value) => controller.onAssignmentPrintSizeToggled(index, size, value ?? false),
+                ),
+            ],
+          ),
+        ],
       ],
     ),
   );

--- a/lib/views/settings_overlay/settings_overlay_controller.dart
+++ b/lib/views/settings_overlay/settings_overlay_controller.dart
@@ -434,6 +434,50 @@ class SettingsOverlayController extends ScreenControllerBase<SettingsOverlayView
     }
   }
 
+  void onEnablePrinterRoutingChanged(bool? enable) {
+    if (enable != null) {
+      viewModel.updateSettings((settings) => settings.copyWith.hardware(enablePrinterRouting: enable));
+    }
+  }
+
+  void onPrintDispatchModeChanged(PrintDispatchMode? mode) {
+    if (mode != null) {
+      viewModel.updateSettings((settings) => settings.copyWith.hardware(printDispatchMode: mode));
+    }
+  }
+
+  void onAssignmentPrinterChanged(String? queueId, int index) {
+    if (queueId == null) return;
+    List<PrinterAssignment> currentList = List.from(viewModel.printerAssignmentsSetting);
+
+    if (queueId == viewModel.unusedPrinterValue) {
+      // Selecting "- Not used -" on the trailing (new) row is a no-op; on an existing row it removes it.
+      if (index < currentList.length) currentList.removeAt(index);
+    } else if (index >= currentList.length) {
+      currentList.add(PrinterAssignment(queueId: queueId));
+    } else {
+      currentList[index] = currentList[index].copyWith(queueId: queueId);
+    }
+    logDebug("Setting printer assignments to $currentList");
+    viewModel.updateSettings((settings) => settings.copyWith.hardware(printerAssignments: currentList));
+  }
+
+  void onAssignmentEnabledChanged(int index, bool? enabled) {
+    if (enabled == null || index >= viewModel.printerAssignmentsSetting.length) return;
+    List<PrinterAssignment> currentList = List.from(viewModel.printerAssignmentsSetting);
+    currentList[index] = currentList[index].copyWith(enabled: enabled);
+    viewModel.updateSettings((settings) => settings.copyWith.hardware(printerAssignments: currentList));
+  }
+
+  void onAssignmentPrintSizeToggled(int index, PrintSize size, bool selected) {
+    if (index >= viewModel.printerAssignmentsSetting.length) return;
+    List<PrinterAssignment> currentList = List.from(viewModel.printerAssignmentsSetting);
+    Set<PrintSize> sizes = Set.from(currentList[index].printSizes);
+    selected ? sizes.add(size) : sizes.remove(size);
+    currentList[index] = currentList[index].copyWith(printSizes: sizes);
+    viewModel.updateSettings((settings) => settings.copyWith.hardware(printerAssignments: currentList));
+  }
+
   void onFlutterPrintingPrinterChanged(String? printerName, int? printerIndex) {
     if (printerName != null && printerIndex != null) {
       List<String> currentList = List.from(viewModel.flutterPrintingPrinterNamesSetting);

--- a/lib/views/settings_overlay/settings_overlay_view_model.dart
+++ b/lib/views/settings_overlay/settings_overlay_view_model.dart
@@ -258,6 +258,9 @@ abstract class SettingsOverlayViewModelBase extends ScreenViewModelBase with Sto
   MediaSettings get mediaSizeTiny => getIt<SettingsManager>().settings.hardware.printLayoutSettings.mediaSizeTiny;
   GridSettings get gridTiny => getIt<SettingsManager>().settings.hardware.printLayoutSettings.gridTiny;
   List<String> get flutterPrintingPrinterNamesSetting => getIt<SettingsManager>().settings.hardware.flutterPrintingPrinterNames;
+  bool get enablePrinterRoutingSetting => getIt<SettingsManager>().settings.hardware.enablePrinterRouting;
+  PrintDispatchMode get printDispatchModeSetting => getIt<SettingsManager>().settings.hardware.printDispatchMode;
+  List<PrinterAssignment> get printerAssignmentsSetting => getIt<SettingsManager>().settings.hardware.printerAssignments;
   double get pageHeightSetting => getIt<SettingsManager>().settings.hardware.pageHeight;
   double get pageWidthSetting => getIt<SettingsManager>().settings.hardware.pageWidth;
   bool get usePrinterSettingsSetting => getIt<SettingsManager>().settings.hardware.usePrinterSettings;


### PR DESCRIPTION
## Summary

Adds the ability to assign each printer to specific print sizes (collage types). For example, a physical printer can handle single-photo prints while a second (virtual) printer handles 3-photo collages. Each assignment can be enabled/disabled independently, and when several printers match a job, dispatch can be sequential or parallel.

**Dart-only — no Rust changes.**

## Changes

- **`HardwareSettings`**: add `enablePrinterRouting`, `printerAssignments` (new `PrinterAssignment` model = `queueId` + `enabled` + `Set<PrintSize>`) and `printDispatchMode` (new `PrintDispatchMode` enum).
- **`PrintingSystemClient`**: add a routed printing path that selects only the enabled printers whose assigned print sizes match the current job, with sequential/parallel dispatch. Falls back to the existing round-robin behaviour when routing is disabled.
- **Hardware settings UI / view-model / controller**: routing toggle, dispatch-mode selector and per-printer assignment cards (printer picker + enabled switch + per-`PrintSize` checkboxes). Works for both the Flutter Printing and CUPS backends.

## Backward compatibility

Routing is **off by default**; the existing `flutterPrintingPrinterNames` / `cupsPrinterQueues` lists keep working exactly as before. `printSizes` is (de)serialised as a list of enum names, so existing TOML configs are unaffected.

## Notes

- Generated files (`*.freezed.dart`, `*.g.dart`) are not committed; run `just gen-code` after checkout.
- No new localization keys (consistent with the existing hardware settings page which uses inline strings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)