### PR TITLE
Add per-project control for the maximum number of prints

### DIFF
--- a/lib/models/project_settings.dart
+++ b/lib/models/project_settings.dart
@@ -33,6 +33,7 @@ sealed class ProjectSettings with _$ProjectSettings implements TomlEncodableValu
     @Default(CollageMode.userSelection) CollageMode collageMode,
     @Default(Language.noLanguage) Language language,
     @Default([]) List<Language> availableLanguages,
+    @Default(5) int maxPrintsPerPhoto,
   }) = _ProjectSettings;
 
   factory ProjectSettings.withDefaults() => ProjectSettings.fromJson({});

--- a/lib/views/components/dialogs/print_dialog.dart
+++ b/lib/views/components/dialogs/print_dialog.dart
@@ -80,21 +80,23 @@ class _PrintDialogState extends State<PrintDialog> {
             localizations.printDialogSummary(numPrints, numPrints * gridX * gridY),
             textAlign: TextAlign.left,
           ),
-          const SizedBox(height: 16.0),
-          Material(
-            color: Colors.transparent,
-            child: Slider(
-              activeColor: FluentTheme.of(context).accentColor,
-              value: numPrints.toDouble(),
-              min: 1,
-              max: widget.maxPrints.toDouble(),
-              divisions: widget.maxPrints - 1,
-              label: numPrints.toString(),
-              onChanged: (value) {
-                setState(() => numPrints = value.round());
-              },
+          if (widget.maxPrints > 1) ...[
+            const SizedBox(height: 16.0),
+            Material(
+              color: Colors.transparent,
+              child: Slider(
+                activeColor: FluentTheme.of(context).accentColor,
+                value: numPrints.toDouble(),
+                min: 1,
+                max: widget.maxPrints.toDouble(),
+                divisions: widget.maxPrints - 1,
+                label: numPrints.toString(),
+                onChanged: (value) {
+                  setState(() => numPrints = value.round());
+                },
+              ),
             ),
-          ),
+          ],
         ],
       ),
       actions: [

--- a/lib/views/photo_booth_screen/screens/photo_details_screen/photo_details_screen_controller.dart
+++ b/lib/views/photo_booth_screen/screens/photo_details_screen/photo_details_screen_controller.dart
@@ -4,6 +4,7 @@ import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
 import 'package:momento_booth/main.dart';
 import 'package:momento_booth/managers/printing_manager.dart';
+import 'package:momento_booth/managers/project_manager.dart';
 import 'package:momento_booth/models/settings.dart';
 import 'package:momento_booth/utils/hardware.dart';
 import 'package:momento_booth/views/base/screen_controller_base.dart';
@@ -68,6 +69,7 @@ class PhotoDetailsScreenController extends ScreenControllerBase<PhotoDetailsScre
             onConfirmPrint(size, copies);
           },
           onCancel: () => navigator.pop(),
+          maxPrints: getIt<ProjectManager>().settings.maxPrintsPerPhoto,
         );
       }),
     );

--- a/lib/views/photo_booth_screen/screens/share_screen/share_screen_controller.dart
+++ b/lib/views/photo_booth_screen/screens/share_screen/share_screen_controller.dart
@@ -5,6 +5,7 @@ import 'package:flutter_mobx/flutter_mobx.dart';
 import 'package:momento_booth/main.dart';
 import 'package:momento_booth/managers/photos_manager.dart';
 import 'package:momento_booth/managers/printing_manager.dart';
+import 'package:momento_booth/managers/project_manager.dart';
 import 'package:momento_booth/managers/sfx_manager.dart';
 import 'package:momento_booth/managers/stats_manager.dart';
 import 'package:momento_booth/models/settings.dart';
@@ -100,6 +101,7 @@ class ShareScreenController extends ScreenControllerBase<ShareScreenViewModel> w
             onConfirmPrint(size, copies);
           },
           onCancel: () => navigator.pop(),
+          maxPrints: getIt<ProjectManager>().settings.maxPrintsPerPhoto,
         );
       }),
     );

--- a/lib/views/settings_overlay/pages/settings_overlay_view.project.dart
+++ b/lib/views/settings_overlay/pages/settings_overlay_view.project.dart
@@ -77,6 +77,14 @@ Widget _getProjectSettings(SettingsOverlayViewModel viewModel, SettingsOverlayCo
                 value: () => viewModel.projectAvailableLanguagesSetting,
                 onChanged: controller.onProjectAvailableLanguagesChanged,
               ),
+              SettingsNumberEditTile(
+                icon: LucideIcons.printer,
+                title: "Maximum prints per photo",
+                subtitle: "The maximum number of copies a user can choose in the print dialog for a single photo. Set to 1 to lock printing to a single copy.",
+                value: () => viewModel.maxPrintsPerPhotoSetting,
+                onFinishedEditing: controller.onMaxPrintsPerPhotoChanged,
+                min: 1,
+              ),
             ]
           );
         }

--- a/lib/views/settings_overlay/settings_overlay_controller.dart
+++ b/lib/views/settings_overlay/settings_overlay_controller.dart
@@ -214,6 +214,12 @@ class SettingsOverlayController extends ScreenControllerBase<SettingsOverlayView
     }
   }
 
+  void onMaxPrintsPerPhotoChanged(int? maxPrints) {
+    if (maxPrints != null) {
+      viewModel.updateProjectSettings((settings) => settings.copyWith(maxPrintsPerPhoto: maxPrints));
+    }
+  }
+
   void onEnableWakelockChanged(bool? enableWakelock) {
     if (enableWakelock != null) {
       viewModel.updateSettings((settings) => settings.copyWith(enableWakelock: enableWakelock));

--- a/lib/views/settings_overlay/settings_overlay_view_model.dart
+++ b/lib/views/settings_overlay/settings_overlay_view_model.dart
@@ -221,6 +221,7 @@ abstract class SettingsOverlayViewModelBase extends ScreenViewModelBase with Sto
   Color get primaryColorSetting => getIt<ProjectManager>().settings.primaryColor;
   Language get projectLanguageSetting => getIt<ProjectManager>().settings.language;
   List<Language> get projectAvailableLanguagesSetting => getIt<ProjectManager>().settings.availableLanguages;
+  int get maxPrintsPerPhotoSetting => getIt<ProjectManager>().settings.maxPrintsPerPhoto;
 
   // System settings current values
   int get captureDelaySecondsSetting => getIt<SettingsManager>().settings.captureDelaySeconds;


### PR DESCRIPTION
## What

Adds a `maxPrintsPerPhoto` project setting (default: `5`) that bounds the copies slider in the print dialog. The share screen and photo-detail (reprint) screen pass it to `PrintDialog` as `maxPrints`.

Special case: when set to **1**, the slider is hidden (there is no choice to make) and printing goes straight to a single copy. This also avoids a `Slider` assertion, since `divisions` would be `0`.

## Why

The copies slider is currently hardcoded to a max of 5. Operators may want to cap the number of copies (e.g. media/budget limits) or lock it to exactly 1.

## Notes

- Default `5` → **no behaviour change** for existing projects.
- Project-scoped, saved in the project directory.
- New control lives under *Settings → Project → UI settings for project*.
- UI strings are hardcoded English, consistent with the rest of that settings page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)